### PR TITLE
Create Wordpress Upgrade and Downgrade Fabric Task

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -303,13 +303,45 @@ def wordpress_upgrade():
     require("wordpress_dir")
     require("site_dir")
     require('env')
-    #Upgrades wordpress based on settings.py options
-    run('''
-        wp core update --version={0} --path={1} --locale={2} --force
-        '''.format(
-        SITE_CONFIG['version'],
-        env.wordpress_dir,
-        SITE_CONFIG['locale']
-        ))
-    print green('Upgrade exitoso.')
+    with cd(env.wordpress_dir):
+        current_ver = run(''' wp core version''')
+        request_ver = SITE_CONFIG['version']
+    if request_ver > current_ver:
+        #Upgrades wordpress based on settings.py options
+        run('''
+            wp core update --version={0} --path={1} --locale={2} 
+            '''.format(
+            SITE_CONFIG['version'],
+            env.wordpress_dir,
+            SITE_CONFIG['locale']
+            ))
+        print green('Upgrade exitoso.')
+    else:
+        print red("La version de wordpress en settings.py ("+ request_ver + ") debe ser mayor que la versión actual (" + current_ver + ")")
 
+@task
+def wordpress_downgrade():
+    '''
+    Descarga la nueva version de wordpress escrita en settings y hace el downgrade
+    '''
+    require("wordpress_dir")
+    require("site_dir")
+    require('env')
+    with cd(env.wordpress_dir):
+        current_ver = run(''' wp core version''')
+        request_ver = SITE_CONFIG['version']
+    if request_ver < current_ver:
+        #Upgrades wordpress based on settings.py options
+        run('''
+            wp core update --version={0} --path={1} --locale={2} 
+            '''.format(
+            SITE_CONFIG['version'],
+            env.wordpress_dir,
+            SITE_CONFIG['locale']
+            ))
+        print green('Downgrade exitoso.')
+    else:
+        print red("La version de wordpress en settings.py ("+ request_ver + ") debe ser inferior a la versión actual (" + current_ver + ")")
+
+
+        

--- a/fabfile.py
+++ b/fabfile.py
@@ -333,7 +333,7 @@ def wordpress_downgrade():
     if request_ver < current_ver:
         #Upgrades wordpress based on settings.py options
         run('''
-            wp core update --version={0} --path={1} --locale={2} 
+            wp core update --version={0} --path={1} --locale={2} --force
             '''.format(
             SITE_CONFIG['version'],
             env.wordpress_dir,
@@ -344,4 +344,3 @@ def wordpress_downgrade():
         print red("La version de wordpress en settings.py ("+ request_ver + ") debe ser inferior a la versión actual (" + current_ver + ")")
 
 
-        

--- a/fabfile.py
+++ b/fabfile.py
@@ -313,29 +313,3 @@ def wordpress_upgrade():
         ))
     print green('Upgrade exitoso.')
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/fabfile.py
+++ b/fabfile.py
@@ -293,3 +293,49 @@ def deploy():
         delete=False
     )
     print green('Deploy exitoso.')
+
+
+@task
+def wordpress_upgrade():
+    '''
+    Descarga la nueva version de wordpress escrita en settings y hace el upgrade
+    '''
+    require("wordpress_dir")
+    require("site_dir")
+    require('env')
+    #Upgrades wordpress based on settings.py options
+    run('''
+        wp core update --version={0} --path={1} --locale={2} --force
+        '''.format(
+        SITE_CONFIG['version'],
+        env.wordpress_dir,
+        SITE_CONFIG['locale']
+        ))
+    print green('Upgrade exitoso.')
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/fabfile.py
+++ b/fabfile.py
@@ -315,7 +315,7 @@ def wordpress_upgrade():
             env.wordpress_dir,
             SITE_CONFIG['locale']
             ))
-        print green('Upgrade exitoso.')
+        print green('Upgrade a versión '+ request_ver + ' exitoso.')
     else:
         print red("La version de wordpress en settings.py ("+ request_ver + ") debe ser mayor que la versión actual (" + current_ver + ")")
 
@@ -339,7 +339,7 @@ def wordpress_downgrade():
             env.wordpress_dir,
             SITE_CONFIG['locale']
             ))
-        print green('Downgrade exitoso.')
+        print green('Downgrade a versión '+ request_ver + ' exitoso.')
     else:
         print red("La version de wordpress en settings.py ("+ request_ver + ") debe ser inferior a la versión actual (" + current_ver + ")")
 


### PR DESCRIPTION
<h2>Tareas Relacionadas</h2>
<a href="http://www.manoderecha.net/md/index.php/task/89385" target="_blank">89385 : <strong>WP-Workflow</strong> - Agregar tarea a fabric de actualización de wordpress a nueva versión en settings.py</a>

<h2>Problemas</h2>
Se necesita una tarea en fabric para actualizar WordPress desde la linea de comandos. 

<h2>Soluciones</h2>
Se utilizó la función de wp core update en http://wp-cli.org/commands/core/update/ para ejecutar el upgrade usando los variables de settings.py para la configuración. 

<h2>Pruebas</h2>
Se realizó una prueba en local, cambiando de WordPress 3.9.1 a 4.1
![captura de pantalla 2015-02-05 a las 17 05 46](https://cloud.githubusercontent.com/assets/7527146/6071352/9d7a1a3a-ad5a-11e4-917d-6a8861197b26.png)
