### PR TITLE
Adicionando un paso de instalación

### DIFF
--- a/documentation/install.php
+++ b/documentation/install.php
@@ -53,6 +53,7 @@
                         <pre>
 $ mkdir new-project
 $ cd new-project
+$ git init
 $ git submodule add git@github.com:vinco/wordpress-workflow.git
 $ wordpress-workflow/startProject.sh
                         </pre>


### PR DESCRIPTION
Actualizar documentación de instalación

Se debe inicializar un repositorio para poder usar git submodule