### PR TITLE
(md:91718) plugins/theme install order changed

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -95,8 +95,8 @@ def wordpress_install():
     run('rm -rf {public_dir}wp-content/themes &&  '
         'ln -s {wpworkflow_dir}themes {public_dir}wp-content'.format(**env))
 
-    activate_theme()
     install_plugins()
+    activate_theme()
 
 
 @task


### PR DESCRIPTION
# Tareas relacionadas
[Algunos temas de Wordpress requieren que al menos un plugin esté instalado y activo para funcionar](http://manoderecha.net/md/index.php/task/91718)

# Descripción del problema o característica:
Algunos temas de Wordpress requieren que al menos un plugin esté instalado y activo para funcionar

# Descripción de la solución:
Se invirtió el orden de ejecución de las tareas, colocando primero la instalación de los plugins y después los temas.

# Pruebas
se ejecuto el siguiente comando

```bash
$ fab environment:vagrant reset_all wordpress_install
```

Todo se ejecuto correctamente