### PR TITLE
Actualizar documentación

### DIFF
--- a/documentation/update.php
+++ b/documentation/update.php
@@ -45,11 +45,15 @@
                         <p> 
                             Para obtener las nuevas características del proyecto
                             sólo se debe actualizar el submódulo por lo tanto
-                            con estos dos comandos debería ser suficiente:
+                            con estos comandos será suficiente:
                         </p>
                         <pre>
 $ cd wordpress-workflow
-$ git submodule update --remote
+$ git fetch origin
+$ git pull origin master
+$ cd ..
+$ git add wordpress-workflow
+$ git commit -m "Update Wordpress Workflow to last version"
                         </pre>
                     </div>
                 </div>

--- a/documentation/update.php
+++ b/documentation/update.php
@@ -53,7 +53,7 @@ $ git fetch origin
 $ git pull origin master
 $ cd ..
 $ git add wordpress-workflow
-$ git commit -m "Update Wordpress Workflow to last version"
+$ git commit -m "Update Wordpress Workflow to the last version"
                         </pre>
                     </div>
                 </div>


### PR DESCRIPTION
El comando `$git submodule update --remote`,  funciona correctamente siempre y cuando estés ubicado en el repositorio principal. No dentro del submódulo.

Inconvenientes:
* Al ejecutarlo, se actualizarán todos los repositorios.
* No funciona si tienes archivos modificados sin hacer commit.

Problema:
Cuando tienes más de un sub módulo y no deseas actualizar uno de ellos por alguna razón.