### PR TITLE
(md:91719) fabric function to set wordpress debug mode

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -7,6 +7,7 @@ from fabric.colors import green, red, white, yellow, blue
 from fabric.contrib.console import confirm
 from fabric.contrib.files import exists
 from fabric import state
+from fabutils import boolean
 
 from fabutils.env import set_env_from_json_file
 from fabutils.tasks import ursync_project, ulocal, urun
@@ -64,6 +65,40 @@ def bootstrap():
     run('sudo a2enmod rewrite')
     wordpress_install()
 
+@task
+def create_config(debug=False):
+    """
+    Crear configuraciones de wordpress
+    """
+
+    require('public_dir', 'dbname', 'dbuser', 'dbpassword')
+    
+    debug_text = ""
+    if boolean(debug):
+        debug_text = """--extra-php <<PHP
+                define( 'WP_DEBUG', true );
+                define( 'WP_DEBUG_LOG', true );
+                """
+
+    env['debug_text'] = debug_text
+
+    print "Cambiando el modo de debug a: {0}".format(debug)
+
+    if exists("{public_dir}wp-config.php".format(**env)):
+        run("rm {public_dir}wp-config.php".format(**env))
+
+    run("""
+        wp core config --dbname={dbname} --dbuser={dbuser} \
+        --dbpass={dbpassword} --path={public_dir} {debug_text}
+        """.format(**env))
+
+@task
+def set_debug_mode(debug=False):
+    """
+    Cambiando el modo debug de wordpress, por defecto False
+    """
+    create_config(debug)
+
 
 @task
 def wordpress_install():
@@ -81,8 +116,7 @@ def wordpress_install():
 
     print "Creando configuraciones de wordpress"
     #creates config
-    run('wp core config --dbname={dbname} --dbuser={dbuser} '
-        '--dbpass={dbpassword} --path={public_dir}'.format(**env))
+    create_config()
 
     print "Instalando wordpress"
     #Installs into db


### PR DESCRIPTION
# Tareas relacionadas
[hacer tarea para poner el wordpress en modo debug](http://manoderecha.net/md/index.php/task/91719)


# Descripción del problema o característica:
No existia una manera de cambiar el modo de debug de wordpress desde wordpress-workflow


# Descripción de la solución:
Se agrega nueva función `set_debug_mode` de fabric para cambiar el modo de debug


# Pruebas
se ejecuto el siguiente comando


```bash
$ fab environment:vagrant reset_all wordpress_install
$ fab environment:vagrant create_config:debug=False
$ fab environment:vagrant set_debug_mode:debug=False
```


Todo se ejecuto correctamente