### PR TITLE
Correccion de documentacion al activar un tema

### DIFF
--- a/documentation/use_cases.php
+++ b/documentation/use_cases.php
@@ -59,7 +59,7 @@
                             Instalamos el nuevo sitio en desarrollo
                         </p>
                         <pre>
-$ fab environment:fab activate_theme
+$ fab environment:vagrant activate_theme
                         </pre>
                         <p>
                             Una vez comprobado que el tema funciona y realizar


### PR DESCRIPTION
# Tareas relacionadas
Revisión de la documentación
# Descripción del problema
Error en la documentación en el comando para activar un tema.
# Descripción de la solución
Se escribió en la documentación el comando correcto para activar un tema.

Antes:
![1](https://cloud.githubusercontent.com/assets/6948218/7079523/e545bfb0-deea-11e4-84c7-b780ffe84333.png)

Ahora:
![2](https://cloud.githubusercontent.com/assets/6948218/7079525/e974bd7a-deea-11e4-81ff-083f32e066a1.png)

# Pruebas
Se realizo en un entorno local