### PR TITLE
(md:91563) Wordpress-workflow allows to change project url for local env

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,9 @@
 
 Vagrant.configure("2") do |config|
 
+  environments_json_path = "environments.json"
+  vagrant_config = (JSON.parse(File.read(environments_json_path)))['vagrant']
+
   config.vm.box = "precise32"
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
 
@@ -16,7 +19,7 @@ Vagrant.configure("2") do |config|
 
   # Hosts
   config.vm.hostname = "www.wordpress-workflow.local"
-  config.hostsupdater.aliases = ["wordpress-workflow.local", "wordpress.local"]
+  config.hostsupdater.aliases = ["wordpress-workflow.local", vagrant_config['url']]
 
   # Shared folders.
   config.vm.synced_folder "src", "/home/vagrant/wordpress-workflow"

--- a/documentation/commands.php
+++ b/documentation/commands.php
@@ -199,7 +199,27 @@ $ fab environment:env_name[,debug] <strong>install_plugins</strong>
 $ fab environment:vagrant <strong>install_plugins</strong>
                         </pre>
                    </div>
-                
+
+                    <div class="col-lg-12" id="change_domain" name="change_domain">
+                        <h2>change_domain</h2>
+                        <p>
+                            Changes the project's domain according to the url configuration from
+                            <code>environment.json</code>, this command must only be used with
+                            <code>vagrant</code> environment.
+                        </p>
+                        <pre>
+$ fab environment:env_name[,debug] <strong>change_domain</strong>
+                        </pre>
+
+                        <h4>Arguments</h4>
+                        <p>None</p>
+
+                        <h4>Examples</h4>
+                        <pre>
+$ fab environment:vagrant <strong>change_domain</strong>
+                        </pre>
+                    </div>
+
                     <div class="col-lg-12" id="import_data" name="import_data">
                             <h2>import_data</h2>
                             <p>

--- a/documentation/index.php
+++ b/documentation/index.php
@@ -300,6 +300,10 @@ $ fab environment:devel ...
                                 <td>Installs plugins and initialize according to the settings.json file.</td>
                             </tr>
                             <tr>
+                                <td><a href="commands.php#change_domain">change_domain</a> </td>
+                                <td>Changes the project's domain according to the url configuration from environment.json</td>
+                            </tr>
+                            <tr>
                                 <td><a href="commands.php#import_data">import_data</a> </td>
                                 <td>Imports the database from given file name. database/data.sql by default.</td>
                             </tr>

--- a/documentation/menu.php
+++ b/documentation/menu.php
@@ -138,6 +138,11 @@
                     </a>
                 </li>
                 <li class="list-group-item">
+                    <a href="commands.php#change_domain">
+                        change_domain
+                    </a>
+                </li>
+                <li class="list-group-item">
                     <a href="commands.php#import_data">
                         import_data
                     </a>

--- a/fabfile.py
+++ b/fabfile.py
@@ -2,7 +2,7 @@
 import sys
 import json
 import os
-from fabric.api import cd, env, run, task, require, sudo
+from fabric.api import cd, env, run, task, require, sudo, local
 from fabric.colors import green, red, white, yellow, blue
 from fabric.contrib.console import confirm
 from fabric.contrib.files import exists
@@ -217,6 +217,29 @@ def install_plugins():
 
 
 @task
+def change_domain():
+    """
+    Changes the project's domain according to the url configuration from
+    environment.json
+    """
+    require('url')
+
+    print ("Making actions to change project's url to: "
+        + blue(env.url, bold=True) + "...")
+
+    with cd(env.public_dir):
+        print "Reloading vagrant virtual machine..."
+        local("vagrant halt")
+        local("vagrant up")
+
+        print "Changing project url configuration..."
+        run("""
+            wp option update home http://{url} &&\
+            wp option update siteurl http://{url}
+            """.format(**env))
+
+
+@task
 def import_data(file_name="data.sql"):
     """
     Imports the database to given file name. database/data.sql by default.
@@ -231,12 +254,15 @@ def import_data(file_name="data.sql"):
         mysql -u {dbuser} -p{dbpassword} {dbname} --host={dbhost} <\
         {wpworkflow_dir}database/{file_name} """.format(**env))
 
-    with cd(env.public_dir):  # Changes the domain
+    with cd(env.public_dir):
+
+        # Changes the domain
         run("""
             wp option update home http://{url} &&\
             wp option update siteurl http://{url}
             """.format(**env))
-        #changes the user
+
+        # changes the user
         run("""
             wp user update {admin_user} --user_pass={admin_password}\
             --user_email={admin_email}

--- a/provision/templates/wordpress.apache
+++ b/provision/templates/wordpress.apache
@@ -1,7 +1,6 @@
 <VirtualHost *:80>
     ServerAdmin webmaster@localhost
 
-    ServerName wordpress.local
     DocumentRoot /home/vagrant/public_www
     <Directory />
         Options FollowSymLinks

--- a/provision/templates/wordpress.nginx
+++ b/provision/templates/wordpress.nginx
@@ -1,5 +1,5 @@
 server {
-    listen      80;
+    listen      80 default_server;
 
     root /home/vagrant/public_www;
     index index.php index.html index.htm;
@@ -7,16 +7,12 @@ server {
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log warn;
 
-    server_name wordpress.local;
-    server_name www.wordpress.local;
-
     location / {
         try_files $uri $uri/ /index.php?$args;
     }
 
     location ~ /(\.|wp-config.php|readme.html|license.txt|licencia.txt) {
         return 404;
-
     }
 
     location ~ \.php$ {
@@ -25,15 +21,13 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include fastcgi_params;
-
     }
 
     location ~ /\. {
         deny all;
-
     }
-
 }
+
 server {
     root /home/vagrant/workflow-documentation;
     index index.php index.html index.htm;
@@ -47,6 +41,5 @@ server {
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include fastcgi_params;
-
     }
 }


### PR DESCRIPTION
# Tareas relacionadas
[Posibilidad de cambiar la URL a una más acorde al proyecto que se esté desarrollando](http://manoderecha.net/md/index.php/task/91563)


# Descripción del problema o característica:
Posibilidad de cambiar la URL a una más acorde al proyecto que se esté desarrollando


# Descripción de la solución:
* Se creó una tarea de Fabric que permita al usuario de wordpress-workflow personalizar la URL para que sea mas descriptiva con el proyecto
* Se incluyó dicha tarea a la documentación de wordpress-workflow

Adicionalmente se hicieron cambios en las plantillas de configuración para apache2 y nginx, para considerar cualquier dominio personalizado que el usuario pueda utilizar, por lo que el primer servername sera usado para procesar el proyecto. La justificación de estos cambios se muestran a continuación:

NGINX
"nginx first decides which server should process the request. Let’s start with a simple configuration where all three virtual servers listen on port *:80

In this configuration nginx tests only the request’s header field “Host” to determine which server the request should be routed to. If its value does not match any server name, or the request does not contain this header field at all, then nginx will route the request to the default server for this port. In the configuration above, the default server is the first one — which is nginx’s standard default behaviour. It can also be set explicitly which server should be default, with the default_server parameter".

http://nginx.org/en/docs/http/request_processing.html

APACHE2
"The asterisks match all addresses, so the main server serves no requests. Due to the fact that www.example.com is first in the configuration file, it has the highest priority and can be seen as the default or primary server. That means that if a request is received that does not match one of the specified ServerName directives, it will be served by this first VirtualHost".

http://httpd.apache.org/docs/2.2/vhosts/examples.html
# Pruebas
Previamente se necesita cambiar la propiedad URL de vagrant en el documento environments.json

Se probó accediendo a el dominio de documentación y el del proyecto después de haber ejecutando el siguiente comando:

```bash
$ fab environment:vagrant change_domain
```
Todo se muestra correctamente