### PR TITLE
(md:95558) Adds parameter and wraps the password string

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -96,7 +96,7 @@ def create_config(debug=False):
 
     run("""
         wp core config --dbname={dbname} --dbuser={dbuser} \
-        --dbpass={dbpassword} --path={public_dir} {extra_php}
+        --dbpass={dbpassword} --path={public_dir} --dbhost={dbhost} {extra_php}
         """.format(**env))
 
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -264,7 +264,7 @@ def import_data(file_name="data.sql"):
 
         # changes the user
         run("""
-            wp user update {admin_user} --user_pass={admin_password}\
+            wp user update {admin_user} --user_pass=\"{admin_password}\"\
             --user_email={admin_email}
             """.format(**env))
 


### PR DESCRIPTION
# Tareas relacionadas
[Parámetro dbhost y escape de contraseña entre comillas](http://manoderecha.net/md/index.php/task/95558)
# Descripción del problema
Intentando realizar un deploy a staging de un sitio se encontró necesario realizar estos cambios.
# Descripción de la solución
+ Agrega el parámetro dbhost en la función de creación de la configuración, cuando el servidor de base de datos es diferente.
+ La contraseña es puesta dentro de comillas para evitar que un caracter extraño cause estragos.
