### PR TITLE
Development

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -96,7 +96,7 @@ def create_config(debug=False):
 
     run("""
         wp core config --dbname={dbname} --dbuser={dbuser} \
-        --dbpass={dbpassword} --path={public_dir} {extra_php}
+        --dbpass={dbpassword} --path={public_dir} --dbhost={dbhost} {extra_php}
         """.format(**env))
 
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -264,7 +264,7 @@ def import_data(file_name="data.sql"):
 
         # changes the user
         run("""
-            wp user update {admin_user} --user_pass={admin_password}\
+            wp user update {admin_user} --user_pass=\"{admin_password}\"\
             --user_email={admin_email}
             """.format(**env))
 


### PR DESCRIPTION
# Tareas relacionadas

+ [Parámetro dbhost y escape de contraseña entre comillas](http://manoderecha.net/md/index.php/task/95558)

# Descripción del problema

Wordpress-workflow no está preparado para base fuera de localhost

# Descripción de la solución

Se agregan los parametros de la base de datos `dbhost`