### PR TITLE
100302: Adds verifyng env for change_domain

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -29,10 +29,12 @@ def environment(env_name, debug=False):
             env_name,
             schemas_dir + "environment_schema.json"
         )
+        env.is_vagrant = False
         if env_name == "vagrant":
             result = ulocal('vagrant ssh-config | grep IdentityFile',
                             capture=True)
             env.key_filename = result.split()[1].replace('"', '')
+            env.is_vagrant = True
 
     except ValueError:
         print red("environments.json has wrong format.", bold=True)
@@ -225,12 +227,13 @@ def change_domain():
     require('url')
 
     print ("Making actions to change project's url to: "
-        + blue(env.url, bold=True) + "...")
+           + blue(env.url, bold=True) + "...")
 
     with cd(env.public_dir):
-        print "Reloading vagrant virtual machine..."
-        local("vagrant halt")
-        local("vagrant up")
+        if env.is_vagrant:
+            print "Reloading vagrant virtual machine..."
+            local("vagrant halt")
+            local("vagrant up")
 
         print "Changing project url configuration..."
         run("""


### PR DESCRIPTION
# Tareas relacionadas

+ [arreglar change_domain para aplicarse en otros ambientes además de vagrant](http://manoderecha.net/md/index.php/task/100302)

# Descripción del problema

El comando `change_domain` falla cuando se ejecuta en un environment diferente a vagrant

# Descripción de la solución

Se agrega la variable de entorno `is_vagrant` en el comando `environment`

# Plan de pruebas

Comprobar que el dominio es modificado tanto en local como en un entorno distinto con el comando

```bash
fab environment:env change_domain
```