### PR TITLE
Adding git because some machines don't have it, and Fix a typo

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -10,6 +10,7 @@ apt-get update
 PACKAGES="php5 mysql-client mysql-server php5-mysql apache2 tree vim curl"
 PACKAGES="$PACKAGES nginx-full php5-fpm php5-cgi spawn-fcgi php-pear php5-gd"
 PACKAGES="$PACKAGES php-apc php5-curl php5-mcrypt php5-memcached fcgiwrap php5-mcrypt"
+PACKAGES="$PACKAGES git"
 
 APP_TOKEN="/home/vagrant/workflow-documentation/scripts/app_token"
 PUBLIC_DIRECTORY="/home/vagrant/public_www"
@@ -39,7 +40,7 @@ curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.pha
 chmod +x wp-cli.phar
 mv wp-cli.phar /usr/local/bin/wp
 
-Installing composer
+echo "Installing composer"
 curl -sS https://getcomposer.org/installer | php
 chmod +x composer.phar
 mv composer.phar /usr/local/bin/composer


### PR DESCRIPTION
This is not from a Tarea in manoderecha.

I see this in my installations and I have decided to contribute.
- Add git program, some machines do not have it.
- Error "Installing composer" is not a command; instead is info to be displayed.

Cheers!
