### PR TITLE
110244 install one plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-#Version 0.2.5 (2015-04-28)
+# Version 0.3.0 (2015-06-13)
+    * Add code verification
+    * Fixes password quotation
+
+# Version 0.2.5 (2015-04-28)
     * Improves documentation
     * Adds change_domain command
 

--- a/documentation/commands.php
+++ b/documentation/commands.php
@@ -196,18 +196,22 @@ $ fab environment:vagrant <strong>activate_theme</strong>
                    <div class="col-lg-12 anchor" id="install_plugins" name="install_plugins">
                         <h2>install_plugins</h2>
                         <p>
-                            Installs plugins and initialize according to the <code>settings.json</code> file.
+                            Installs plugins and initialize according to the <code>settings.json</code> file. Also this function does can install a specific plugin when pass plugin name as argument.
                         </p>
                         <pre>
 $ fab environment:env_name[,debug] <strong>install_plugins</strong>
                         </pre>
 
                         <h4>Arguments</h4>
-                        <p>None</p>
+                        <p><code>@param String name</code> This param refers to specific plugin's name that we require install, this param is default null, if this param is null the command does install all plugins from <code>settings.json</code>.</p>
                         
                         <h4>Examples</h4>
                         <pre>
 $ fab environment:vagrant <strong>install_plugins</strong>
+                        </pre>
+                        <p>If we require install only <code>all-in-one-seo-pack</code> plugin, we type:</p>
+                        <pre>
+$ fab environment:vagrant <strong>install_plugins</strong>:<strong>"all-in-one-seo-pack"</strong>  // If <code>settings.json</code> does not have "all-in-one-seo-pack" this command show an error
                         </pre>
                    </div>
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -157,7 +157,9 @@ def activate_theme():
 @task
 def install_plugins( name='' ):
     """
-    Installs plugins and initialize according to the settings.json file. :param name: This is an argument for install one specific plugin, if this is null install all plugins
+    Installs plugins and initialize according to the settings.json file.
+    :param name: This is an argument for install one specific plugin
+    if this is null install all plugins
     """
     require('public_dir', 'wpworkflow_dir')
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -216,7 +216,43 @@ def install_plugins():
                 activate,
                 plugin['name']
                 ))
+@task
+def install_plugin( name, **kwargs ):
+    """
+    Install a specific plugin with a specific version, install_plugin:[name],version=[version | stable by default],status=[True | False by default]
+    """
+    env.version = kwargs.get('version') if kwargs.get('version') else 'stable'
+    env.name = name
+    env.status = kwargs.get('status') if kwargs.get('status') else False
 
+    print "Installing : " + blue(name, bold=True) + " version " + red(env.version, bold=True) +" activate? = "+ green(env.status, bold=True) + " ..."
+
+    with cd(env.public_dir):
+
+        activate = "activate"
+
+        if env.version != 'stable':
+            env.version = ' --version=' + env.version
+
+        run("""
+            if ! wp plugin is-installed {0};
+            then
+            wp plugin install {0} {1};
+            fi
+            """.format(
+                env.name,
+                env.version
+            ))
+
+        if not env.status:
+            activate = "deactivate"
+
+        run("""
+            wp plugin {0} {1}
+            """.format(
+                activate,
+                env.name
+            ))
 
 @task
 def change_domain():


### PR DESCRIPTION
# Related task
* [Poder instalar un solo plugin](http://manoderecha.net/md/index.php/task/110244)

# Issue description
We need that WW just can install a especific plugin

# Solution description

We modified fabric task `install_plugins` which does install all wordpress plugins (custom and thirth party). Until now this function does not receive arguments but in this change this function receive an argument which is the plugin name that requires install.
By the way, we create three functions which description is the next.
* `check_if_plugin_exist`: This function checks that the argument name be a plugin within setting.json
  :param name: This argument is the name of plugin that requires check
* `install_custom_plugin`: This function install a custom_plugin that is in the settings.json file
  :param custom_plugin: This is a dictionary with the custom_plugin data from setting.json
* `install_plugin`: This function install a plugin that is in the settings.json file
  :param plugin: This is a dictionary with the plugin data from setting.json

#### Install All Plugins
`fab environment:[environment] install_plugins`

![seleccion_128](https://cloud.githubusercontent.com/assets/9924457/14897284/08f9bf2a-0d47-11e6-9301-2a34744ac52c.png)


#### Install specific plugin
`fab environment:[environment] install_plugins:"all-in-one-seo-pack"`

![seleccion_129](https://cloud.githubusercontent.com/assets/9924457/14897292/0fb8d454-0d47-11e6-8919-6576fa5381d2.png)



