### PR TITLE
110012 Set group www-data to vagrant shared files

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,10 @@ Vagrant.configure("2") do |config|
   config.hostsupdater.aliases = ["wordpress-workflow.local", vagrant_config['url']]
 
   # Shared folders.
-  config.vm.synced_folder "src", "/home/vagrant/wordpress-workflow"
+  config.vm.synced_folder "src", "/home/vagrant/wordpress-workflow",
+    owner: "vagrant",
+    group: "www-data",
+    mount_options: ["dmode=775,fmode=764"]
   config.vm.synced_folder "wordpress-workflow/documentation", "/home/vagrant/workflow-documentation"
 
   # Provider


### PR DESCRIPTION
# Related task
* [Establecer correctamente los permisos de archivos y directorios compartidos con vagrant](http://www.manoderecha.net/md/index.php/task/110012)

# Issue
Files requires permissions 775 to run properly in vagrant.

# Solution
Add group "www-data" files in src folder by vagrant