### PR TITLE
110011: Add confirm task

### DIFF
--- a/documentation/commands.php
+++ b/documentation/commands.php
@@ -196,18 +196,22 @@ $ fab environment:vagrant <strong>activate_theme</strong>
                    <div class="col-lg-12 anchor" id="install_plugins" name="install_plugins">
                         <h2>install_plugins</h2>
                         <p>
-                            Installs plugins and initialize according to the <code>settings.json</code> file.
+                            Installs plugins and initialize according to the <code>settings.json</code> file. Also this function does can install a specific plugin when pass plugin name as argument.
                         </p>
                         <pre>
 $ fab environment:env_name[,debug] <strong>install_plugins</strong>
                         </pre>
 
                         <h4>Arguments</h4>
-                        <p>None</p>
+                        <p><code>@param String name</code> This param refers to specific plugin's name that we require install, this param is default null, if this param is null the command does install all plugins from <code>settings.json</code>.</p>
                         
                         <h4>Examples</h4>
                         <pre>
 $ fab environment:vagrant <strong>install_plugins</strong>
+                        </pre>
+                        <p>If we require install only <code>all-in-one-seo-pack</code> plugin, we type:</p>
+                        <pre>
+$ fab environment:vagrant <strong>install_plugins</strong>:<strong>"all-in-one-seo-pack"</strong>  // If <code>settings.json</code> does not have "all-in-one-seo-pack" this command show an error
                         </pre>
                    </div>
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -156,68 +156,135 @@ def activate_theme():
 
 
 @task
-def install_plugins():
+def install_plugins( name='' ):
     """
-    Installs plugins and initialize according to the settings.json file.
+    Installs plugins and initialize according to the settings.json file. :param name: This is an argument for install one specific plugin, if this is null install all plugins
     """
     require('public_dir', 'wpworkflow_dir')
 
     check_plugins()
-    print "Installing plugins..."
-    for custom_plugin in env.get("custom_plugins", []):
-        print "Installing : " + blue(custom_plugin['name'], bold=True) + "..."
+
+    # Install all plugins
+    if( not name ):
+        print "Installing plugins..."
+        for custom_plugin in env.get("custom_plugins", []):
+            install_custom_plugin( custom_plugin )
+
+        # Installs 3rd party plugins
         with cd(env.public_dir):
-            run("""
-                if ! wp plugin is-installed {0};
-                then
-                    ln -s {1}plugins/{0} {2}wp-content/plugins/;
-                fi
-                """.format(
-                custom_plugin['name'],
-                env.wpworkflow_dir,
-                env.public_dir
-                ))
+            for plugin in env.get("plugins", []):
+                install_plugin( plugin )
 
-            activate = "activate"
-            if not custom_plugin['active']:
-                activate = "deactivate"
+    # Install one plugin
+    else:
+        flag, plugin_type, plugin_data = check_if_plugin_exist( name )
+        if flag:
+            if plugin_type == 1: # Custom plugin install
+                install_custom_plugin( plugin_data )
+            if plugin_type == 2: # Plugin install
+                install_plugin( plugin_data )
+        else:
+            print "The plugin: " + blue( name, bold=True) + "does not find in setting.json ..."
 
-            run("""
-                wp plugin {0} {1}
-                """.format(
-                activate,
-                custom_plugin['name']
-                ))
-    # Installs 3rd party plugins
+
+
+def check_if_plugin_exist( name ):
+    print "Check if " + name + " exists in settings.json"
+    """
+    This function chek if a plugin exist within settings.json file
+    This function returns:
+        bolean True if plugin exists
+        integer 0 for null | 1 for custom_plugin | 2 for plugin
+        dic setings.json plugin data
+    """
+    flag = False
+    plugin_type = 0
+    plugin_data = ""
+
+    custom_plugins = env.get("custom_plugins", [])
+    plugins = env.get("plugins")
+
+    for custom_plugin in custom_plugins:
+        if name == custom_plugin['name']:
+            flag = True
+            plugin_type = 1
+            plugin_data = custom_plugin
+
+
+    for custom_plugin in plugins:
+        if name == custom_plugin['name']:
+            flag = True
+            plugin_type = 2
+            plugin_data = custom_plugin
+
+    return ( flag, plugin_type, plugin_data )
+
+def install_custom_plugin( custom_plugin ):
+    """
+    This function install a custom plugin from settings.json file
+    :param custom_plugin: A dictionary with custom_plugin data
+    """
+    print "Installing : " + blue( custom_plugin["name"], bold=True) + "..."
+
+    require('public_dir', 'wpworkflow_dir')
     with cd(env.public_dir):
-        for plugin in env.get("plugins", []):
-            print "Installing : " + blue(plugin['name'], bold=True) + "..."
-            version = ""
-            activate = "activate"
+        run("""
+            if ! wp plugin is-installed {0};
+            then
+                ln -s {1}plugins/{0} {2}wp-content/plugins/;
+            fi
+            """.format(
+            custom_plugin["name"],
+            env.wpworkflow_dir,
+            env.public_dir
+            ))
 
-            if plugin['version'] != 'stable':
-                version = ' --version=' + plugin['version']
+        activate = "activate"
+        if not custom_plugin['active']:
+            activate = "deactivate"
 
-            run("""
-                if ! wp plugin is-installed {0};
-                then
-                    wp plugin install {0} {1};
-                fi
-                """.format(
-                plugin['name'],
-                version
-                ))
+        run("""
+            wp plugin {0} {1}
+            """.format(
+            activate,
+            custom_plugin['name']
+            ))
 
-            if not plugin['active']:
-                activate = "deactivate"
 
-            run("""
-                wp plugin {0} {1}
-                """.format(
-                activate,
-                plugin['name']
-                ))
+def install_plugin( plugin ):
+    """
+    This function install a plugin from settings.json file
+    :param custom_plugin: A dictionary with plugin data
+    """
+    print "Installing : " + blue(plugin['name'], bold=True) + "..."
 
+    require('public_dir', 'wpworkflow_dir')
+    version = ""
+    activate = "activate"
+
+    if plugin['version'] != 'stable':
+        version = ' --version=' + plugin['version']
+
+    with cd(env.public_dir):
+        run("""
+            if ! wp plugin is-installed {0};
+            then
+                wp plugin install {0} {1};
+            fi
+            """.format(
+            plugin['name'],
+            version
+            ))
+
+        if not plugin['active']:
+            activate = "deactivate"
+
+        run("""
+            wp plugin {0} {1}
+            """.format(
+            activate,
+            plugin['name']
+            ))
 
 @task
 def change_domain():

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -9,7 +9,7 @@ apt-get update
 
 PACKAGES="php5 mysql-client mysql-server php5-mysql apache2 tree vim curl"
 PACKAGES="$PACKAGES nginx-full php5-fpm php5-cgi spawn-fcgi php-pear php5-gd"
-PACKAGES="$PACKAGES php-apc php5-curl php5-mcrypt php5-memcached fcgiwrap"
+PACKAGES="$PACKAGES php-apc php5-curl php5-mcrypt php5-memcached fcgiwrap php5-mcrypt"
 
 APP_TOKEN="/home/vagrant/workflow-documentation/scripts/app_token"
 PUBLIC_DIRECTORY="/home/vagrant/public_www"
@@ -73,3 +73,4 @@ rm  /etc/nginx/sites-enabled/*
 ln -s /etc/nginx/sites-available/wordpress /etc/nginx/sites-enabled/
 service php5-fpm restart
 service nginx restart
+export WP_ENV=production


### PR DESCRIPTION
# Related task
[Agregar confirmación al eliminar una base de datos cuando no se ejecuta el comando en ambiente vagrant](http://www.manoderecha.net/md/index.php/task/110011)

# Issue
Ask for confirmation when deleting a database

# Solution
Add confirmation task by environments not equals to vagrant.

The tasks that were added confirmation are: bootstrap, wordpress_install, import_data, resetdb, reset_all, wordpress_upgrade and wordpress_downgrade.

Now:
![seleccion_042](https://cloud.githubusercontent.com/assets/6948218/15304324/51e0701e-1b82-11e6-8a9e-c1be2dc41a79.png)

![seleccion_043](https://cloud.githubusercontent.com/assets/6948218/15304349/7594d2de-1b82-11e6-8422-52f7adac409b.png)