### PR TITLE
113402: Fix error locale to upgrade and downgrade wordpress

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -448,10 +448,11 @@ def wordpress_upgrade():
 
     if request_ver > current_ver:
         run("""
-            wp core update --version={version} --path={public_dir}
-            --locale={locale} """.format(**env))
+            wp core update --version={version} --path={public_dir} --locale={locale}
+            """.format(**env))
 
-        print green('Upgrade to versión ' + request_ver + ' sucessfull.')
+
+        print green('Upgrade to version ' + request_ver + ' sucessfull.')
 
     else:
         print red("""
@@ -474,10 +475,10 @@ def wordpress_downgrade():
 
     if request_ver < current_ver:
         run("""
-            wp core update --version={version} --path={public_dir}
-            --locale={locale} --force """.format(**env))
+            wp core update --version={version} --path={public_dir} --locale={locale} --force
+            """.format(**env))
 
-        print green('Downgrade to versión ' + request_ver + ' success.')
+        print green('Downgrade to version ' + request_ver + ' success.')
     else:
         print red("""
                   The wordpress version in settings.json {0}


### PR DESCRIPTION
# Related tasks
[Arreglar error al actualizar o desactualizar wordpress](http://www.manoderecha.net/md/index.php/task/113402)

# Issue description
There is an error when you upgrade or downgrade wordpress. You want to run a command at the bash --locale

# Solution description
All WordPress update command was left in a single line

# Test
Tests in local environment.