### PR TITLE
11581: Fix permissions uploads folder

### DIFF
--- a/defaults/environments.json
+++ b/defaults/environments.json
@@ -3,7 +3,7 @@
         "url": "wordpress.local",
 
         "user": "vagrant",
-        "group": "vagrant",
+        "group": "www-data",
         "hosts": ["127.0.0.1:2222"],
         "public_dir": "/home/vagrant/public_www/",
         "wpworkflow_dir": "/home/vagrant/wordpress-workflow/",

--- a/fabfile.py
+++ b/fabfile.py
@@ -71,6 +71,12 @@ def bootstrap():
     # Enables apache module
     run('sudo a2enmod rewrite')
     wordpress_install()
+    # Set permissions by vagrant
+    if env.is_vagrant:
+        run('sudo chmod -R o-rwx {0}'.format(env.wpworkflow_dir))
+        run('sudo chmod -R o-rwx {0}'.format(env.public_dir))
+        run('sudo chgrp -R {0} {1}'.format(env.group, env.wpworkflow_dir))
+        run('sudo chgrp -R {0} {1}'.format(env.group, env.public_dir))
 
 
 @task


### PR DESCRIPTION
### Task related 
[La carpeta uploads no tiene permisos de escritura](http://manoderecha.net/md/index.php/task/115801)

# Problem 
Vagrant environment do not let upload multimedia
 
# Solution 
+ Change group for www-data by uploads folder.
+ Set write permissions for user group www-data by uploads folder

Now:
![seleccion_015](https://cloud.githubusercontent.com/assets/6948218/17184911/4b7fc440-53f4-11e6-86b9-e37b9d683b10.png)

# Test
Tests in local environment.