### PR TITLE
112006: Add prefix table wordpress

### DIFF
--- a/defaults/environments.json
+++ b/defaults/environments.json
@@ -16,6 +16,7 @@
         "dbname": "wordpress_workflow",
         "dbuser": "root",
         "dbpassword": "password",
-        "dbhost": "localhost"
+        "dbhost": "localhost",
+        "dbprefix": "wp_"
     }
 }

--- a/documentation/commands.php
+++ b/documentation/commands.php
@@ -231,6 +231,28 @@ $ fab environment:vagrant <strong>change_domain</strong>
 
                     </div>
 
+                    <div class="col-lg-12 anchor" id="change_prefix" name="change_prefix">
+                        <h2>change_prefix</h2>
+                        <p>
+                            Changes the database table prefix according to the dbprefix
+                            configuration from <code>environment.json</code>.
+                        </p>
+                        <pre>
+$ fab environment:vagrant <strong>change_prefix</strong>
+                        </pre>
+
+                        <h4>Arguments</h4>
+                        <ol>
+                            <li><strong><span class="args">old_prefix</span></strong> <i>(string)</i> current prefix.
+                                <i>("wp_" by default)</i>.</li>
+                        </ol>
+                            <h4>Examples</h4>
+                            <pre>
+$ fab environment:vagrant <strong>change_prefix:wp_</strong>
+                            </pre>
+
+                    </div>
+
                     <div class="col-lg-12 anchor" id="import_data" name="import_data">
                             <h2>import_data</h2>
                             <p>

--- a/documentation/menu.php
+++ b/documentation/menu.php
@@ -142,6 +142,11 @@
                     </a>
                 </li>
                 <li class="list-group-item">
+                    <a href="commands.php#change_prefix">
+                        change_prefix
+                    </a>
+                </li>
+                <li class="list-group-item">
                     <a href="commands.php#import_data">
                         import_data
                     </a>

--- a/json_schemas/environment_schema.json
+++ b/json_schemas/environment_schema.json
@@ -67,6 +67,10 @@
             "description": "wordpress' datbase host",
             "type": "string"
         },
+        "dbprefix": {
+            "description": "wordpress' database table prefix",
+            "type": "string"
+        },
         "command_prefixes": {
             "description": "command prefixes' list",
             "type": "array",
@@ -79,6 +83,6 @@
     "required": [
         "title", "url", "user", "group", "hosts", "public_dir", "wpworkflow_dir",
         "command_prefixes", "admin_user", "admin_password", "admin_email",
-        "dbname", "dbuser", "dbpassword", "dbhost"
+        "dbname", "dbuser", "dbpassword", "dbhost", "dbprefix"
     ]
 }


### PR DESCRIPTION
### Task related 
[Al hacer el bootstrap, cambiar el prefijo de la base de datos de Wordpress](http://manoderecha.net/md/index.php/task/112006)

# Problem 
Change the table prefix WordPress

# Solution 
+ Add suport to set prefix from tables
+ Create task to change the current prefix by new prefix

Now:
![seleccion_021](https://cloud.githubusercontent.com/assets/6948218/17265026/06495210-55b1-11e6-82b2-0cd89099b291.png)

![seleccion_022](https://cloud.githubusercontent.com/assets/6948218/17265110/ba32950c-55b1-11e6-91a0-f21c8d8d7d4e.png)



# Test
chante prefix wp_ by el_barto_
+ Before execute task chante prefix:

![seleccion_016](https://cloud.githubusercontent.com/assets/6948218/17265040/24aaba14-55b1-11e6-9e47-5499df66df0a.png)

+ After

![seleccion_023](https://cloud.githubusercontent.com/assets/6948218/17265489/07f163d8-55b5-11e6-95ae-ba222b314dce.png)
)

Tests in local environment.