### PR TITLE
112006: Fix error login after change prefix

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -335,6 +335,19 @@ def change_prefix(old_prefix="wp_"):
     # Rename prefix
     env.old_prefix = old_prefix
     run("""
+        mysql -u{dbuser} -p{dbpassword} {dbname} --host={dbhost} --execute=\"
+            UPDATE {old_prefix}options SET option_name='{dbprefix}user_roles' WHERE option_name='{old_prefix}user_roles';
+            UPDATE {old_prefix}usermeta SET meta_key='{dbprefix}autosave_draft_ids' WHERE meta_key='{old_prefix}autosave_draft_ids';
+            UPDATE {old_prefix}usermeta SET meta_key='{dbprefix}capabilities' WHERE meta_key='{old_prefix}capabilities';
+            UPDATE {old_prefix}usermeta SET meta_key='{dbprefix}metaboxorder_post' WHERE meta_key='{old_prefix}metaboxorder_post';
+            UPDATE {old_prefix}usermeta SET meta_key='{dbprefix}user_level' WHERE meta_key='{old_prefix}user_level';
+            UPDATE {old_prefix}usermeta SET meta_key='{dbprefix}usersettings' WHERE meta_key='{old_prefix}usersettings';
+            UPDATE {old_prefix}usermeta SET meta_key='{dbprefix}usersettingstime' WHERE meta_key='{old_prefix}usersettingstime';
+            UPDATE {old_prefix}usermeta SET meta_key='{dbprefix}user-settings' WHERE meta_key='{old_prefix}user-settings';
+            UPDATE {old_prefix}usermeta SET meta_key='{dbprefix}user-settings-time' WHERE meta_key='{old_prefix}user-settings-time';
+            UPDATE {old_prefix}usermeta SET meta_key='{dbprefix}dashboard_quick_press_last_post_id' WHERE meta_key='{old_prefix}dashboard_quick_press_last_post_id';\"
+        """.format(**env))
+    run("""
         mysql -u{dbuser} -p{dbpassword} {dbname} --host={dbhost} --execute="SELECT \
         Concat('ALTER TABLE ', TABLE_NAME, ' RENAME TO ', TABLE_NAME, ';') \
         FROM information_schema.tables WHERE table_schema = 'wordpress_workflow'" \


### PR DESCRIPTION
### Task related 
[Al hacer el bootstrap, cambiar el prefijo de la base de datos de Wordpress](http://manoderecha.net/md/index.php/task/112006)

# Problem 
After change prefix there is an error to start secion.

# Solution 
Some records in the database that reference the updated prefix

Query to update records:
```sql
UPDATE {old_prefix}options SET option_name='{new_prefix}user_roles' WHERE option_name='{old_prefix}user_roles';
UPDATE {old_prefix}usermeta SET meta_key='{new_prefix}autosave_draft_ids' WHERE meta_key='{old_prefix}autosave_draft_ids';
UPDATE {old_prefix}usermeta SET meta_key='{new_prefix}capabilities' WHERE meta_key='{old_prefix}capabilities';
UPDATE {old_prefix}usermeta SET meta_key='{new_prefix}metaboxorder_post' WHERE meta_key='{old_prefix}metaboxorder_post';
UPDATE {old_prefix}usermeta SET meta_key='{new_prefix}user_level' WHERE meta_key='{old_prefix}user_level';
UPDATE {old_prefix}usermeta SET meta_key='{new_prefix}usersettings' WHERE meta_key='{old_prefix}usersettings';
UPDATE {old_prefix}usermeta SET meta_key='{new_prefix}usersettingstime' WHERE meta_key='{old_prefix}usersettingstime';
UPDATE {old_prefix}usermeta SET meta_key='{new_prefix}user-settings' WHERE meta_key='{old_prefix}user-settings';
UPDATE {old_prefix}usermeta SET meta_key='{new_prefix}user-settings-time' WHERE meta_key='{old_prefix}user-settings-time';
UPDATE {old_prefix}usermeta SET meta_key='{new_prefix}dashboard_quick_press_last_post_id' WHERE meta_key='{old_prefix}dashboard_quick_press_last_post_id';
```

# Test
Tests in local environment.