### PR TITLE
133284:Make it optional to set permissions when synchronizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+# Version 0.3.3 (2017-08-04)
+    * Make it optional to set permissions when synchronizing
+    
 # Version 0.3.2 (2016-08-17)
     * Add prefix table wordpress
     * Fix permissions uploads folder

--- a/documentation/commands.php
+++ b/documentation/commands.php
@@ -337,15 +337,21 @@ $ fab environment:vagrant <strong>reset_all</strong>
                                 Sync modified files and establish necessary permissions in selected environment.
                             </p>
                             <pre>
-$ fab environment:env_name[,debug] <strong>sync_files</strong>
+$ fab environment:env_name[,debug] <strong>sync_files<span class="args">[:set_permisions]</span></strong>
                             </pre>
 
                             <h4>Arguments</h4>
-                            <p>None</p>
+                            <ol>
+                                <li><strong><span class="args">set_permisions</span></strong> <i>(boolean)</i> defines if set default permission of wordpress to synchronized files.
+                                    <i>("False" by default)</i>.</li>
+                            </ol>
                             
                             <h4>Examples</h4>
                             <pre>
 $ fab environment:vagrant <strong>sync_files</strong>
+                            </pre>
+                            <pre>
+$ fab environment:vagrant <strong>sync_files:True</strong>
                             </pre>
                        </div>
                        <div class="col-lg-12 anchor" id="wordpress_upgrade" name="wordpress_upgrade">

--- a/fabfile.py
+++ b/fabfile.py
@@ -460,7 +460,7 @@ def reset_all():
 
 
 @task
-def sync_files():
+def sync_files(set_permisions=False):
     """
     Sync modified files and establish necessary permissions in selected environment.
     """
@@ -474,11 +474,12 @@ def sync_files():
         default_opts='-chrtvzP'
     )
 
-    print white("Estableciendo permisos...", bold=True)
-    run('chmod -R o-rwx {0}'.format(env.wpworkflow_dir))
-    run('chmod -R o-rwx {0}'.format(env.public_dir))
-    run('chgrp -R {0} {1}'.format(env.group, env.wpworkflow_dir))
-    run('chgrp -R {0} {1}'.format(env.group, env.public_dir))
+    if boolean(set_permisions):
+        print white("Estableciendo permisos...", bold=True)
+        run('chmod -R o-rwx {0}'.format(env.wpworkflow_dir))
+        run('chmod -R o-rwx {0}'.format(env.public_dir))
+        run('chgrp -R {0} {1}'.format(env.group, env.wpworkflow_dir))
+        run('chgrp -R {0} {1}'.format(env.group, env.public_dir))
 
     print green(u'Successfully sync.')
 


### PR DESCRIPTION
### Task related 
[Falla al cambiar permisos en sync_files](http://manoderecha.net/md/index.php/task/133284)

# Problem 
For security reasons it is no longer necessary to set default permissions when synchronizing the files.

# Solution 
A flag was added to the sync_files command which is used to decide whether or not to set the permissions.

Documentation updated

Now:
![selection_001](https://user-images.githubusercontent.com/6948218/28989346-56fa4d9c-793a-11e7-85dc-031feeb973ed.png)


# Test
Tests in local environment.