### PR TITLE
112608:Fix errors from apache to execute provision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+# Version 0.3.4 (2017-08-09)
+    * Rename site-available wordpress file to wordpress.conf.
+    * Fix template enviroment.json, set corret value from user.
+    * Remove provision/templates/httpd.conf
+
 # Version 0.3.3 (2017-08-04)
     * Make it optional to set permissions when synchronizing
     

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ Vagrant.configure("2") do |config|
   vagrant_config = (JSON.parse(File.read(environments_json_path)))['vagrant']
 
   config.vm.box = "ubuntu/xenial32"
+  config.vm.box_version = "20170803.0.0"
 
   #provisioning
   config.vm.provision "shell", path: "wordpress-workflow/provision/preprovision.sh"

--- a/defaults/environments.json
+++ b/defaults/environments.json
@@ -1,7 +1,7 @@
 {
     "vagrant": {
         "url": "wordpress.local",
-        "user": "vagrant",
+        "user": "ubuntu",
         "group": "www-data",
         "hosts": ["127.0.0.1:2222"],
         "public_dir": "/home/ubuntu/public_www/",

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -77,16 +77,14 @@ fi
 # Activates site
 
 # Apache
-cp /home/ubuntu/templates/wordpress.apache /etc/apache2/sites-available/wordpress
-cp /home/ubuntu/templates/httpd.conf /etc/apache2/conf.d/httpd.conf
+cp /home/ubuntu/templates/wordpress.apache /etc/apache2/sites-available/wordpress.conf
 a2enmod actions
-a2dissite default
 a2ensite wordpress
 service apache2 stop
 
 # Nginx
-cp /home/ubuntu/templates/wordpress.nginx /etc/nginx/sites-available/wordpress
 cp /home/ubuntu/templates/www.conf /etc/php/5.6/fpm/pool.d/www.conf
+cp /home/ubuntu/templates/wordpress.nginx /etc/nginx/sites-available/wordpress
 cp /home/ubuntu/templates/nginx.conf /etc/nginx/nginx.conf
 cp /home/ubuntu/templates/nginx.conf /home/ubuntu/nginx.conf
 rm  /etc/nginx/sites-enabled/*

--- a/provision/templates/httpd.conf
+++ b/provision/templates/httpd.conf
@@ -1,4 +1,0 @@
-ScriptAlias /local-bin /usr/bin
-AddHandler application/x-httpd-php5 php
-Action application/x-httpd-php5 /local-bin/php-cgi
-Timeout 3000


### PR DESCRIPTION
### Task related 
[undefined](http://manoderecha.net/md/index.php/)

# Problem 
Fix errors from apache to execute provison file.

# Solution 
+ Rename site-available wordpress file to wordpress.conf.
+ Fix template enviroment.json, set corret value from user.
+ Remove provision/templates/httpd.conf

# Test
Tests in local environment.