### PR TITLE
134895:Add task version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+# Version 0.3.5 (2017-08-09)
+    * Add task version to show wordpress workflow version.
+
 # Version 0.3.4 (2017-08-09)
     * Rename site-available wordpress file to wordpress.conf.
     * Fix template enviroment.json, set corret value from user.

--- a/documentation/commands.php
+++ b/documentation/commands.php
@@ -559,6 +559,22 @@ $ fab environment:vagrant <strong>wordpress_workflow_upgrade:<span class="args">
 $ fab environment:vagrant <strong>wordpress_workflow_upgrade:<span class="args">origin,develop</span></strong>
                             </pre>
                        </div>
+                       <div class="col-lg-12 anchor" id="version" name="version">
+                            <h2>version</h2>
+                            <p>
+                                Print Wordpress Workflow version.
+                            </p>
+                            <pre>
+$ fab <strong>version</strong>
+                            </pre>
+
+                            <h4>Arguments</h4>
+                            <p>None</p>
+                            
+                            <h4>Examples</h4>
+                            <pre>
+$ fab <strong>version</strong>
+                            </pre>
 
                     </div>
                 </div>

--- a/documentation/menu.php
+++ b/documentation/menu.php
@@ -221,6 +221,11 @@
                         wordpress_workflow_upgrade
                     </a>
                 </li>
+                <li class="list-group-item">
+                    <a href="commands.php#version">
+                        version
+                    </a>
+                </li>
             </ul>
         </div>
       </div>

--- a/fabfile.py
+++ b/fabfile.py
@@ -14,7 +14,6 @@ from fabutils.env import set_env_from_json_file
 from fabutils.tasks import ursync_project, ulocal, urun
 import customfab
 
-
 @task
 def environment(env_name, debug=False):
     """
@@ -913,3 +912,11 @@ def verify_checksums():
             fi
             done
             """.format(**env))
+
+@task
+def version():
+    """
+    Print Wordpress Workflow version.
+    """
+    print "Wordpress Workflow version 0.3.5"
+


### PR DESCRIPTION
### Task related 
[Crear tarea para desplegar la versión de wordpress workflow instalada.](http://manoderecha.net/md/index.php/task/134895)

# Problem 
Create task to show wordpress workflow version.

# Solution 
Add task version in fabfile.py

Now:
![selection_003](https://user-images.githubusercontent.com/6948218/29144946-8e08885a-7d20-11e7-99b9-7c9660b6c0bd.png)
![selection_004](https://user-images.githubusercontent.com/6948218/29144962-9b71a508-7d20-11e7-8362-74fc9b511147.png)


# Test
Tests in local environment.