### PR TITLE
111999:Add wps-hide-login plugin by default in settings.json

### DIFF
--- a/defaults/settings.json
+++ b/defaults/settings.json
@@ -4,6 +4,11 @@
     "theme": "twentyfourteen",
     "plugins": [
         {
+            "name": "wps-hide-login",
+            "active": true,
+            "version": "stable"
+        },
+        {
             "name": "wordpress-seo",
             "active": true,
             "version": "stable"


### PR DESCRIPTION
### Task related 
[Agregar que eliminemos el login de la ruta /wp-admin o /wp-login](http://manoderecha.net/md/index.php/task/111999)

# Problem 
Hide login url of wordpress.

Plugin: https://wordpress.org/plugins/wps-hide-login/

# Solution 
Add wps-hide-login plugin by default in settings.json

# Test
Tests in local environment.