### PR TITLE
139668/fixs shared templates files in osx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+# Version 0.3.7 (2017-12-17)
+    * Add task configure_circle_ci to wordpress workflow.
 # Version 0.3.6 (2017-08-14)
     * Add task import_backup to wordpress workflow.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
 
   #provisioning
   config.vm.provision "shell", path: "wordpress-workflow/provision/preprovision.sh"
-  config.vm.provision "file", source:"wordpress-workflow/provision/templates/", destination: "/home/ubuntu/templates/"
+  config.vm.provision "file", source:"wordpress-workflow/provision/templates/", destination: "/home/ubuntu/."
   config.vm.provision "shell", path: "wordpress-workflow/provision/provision.sh"
 
   # Private IP

--- a/ci/Dangerfile
+++ b/ci/Dangerfile
@@ -1,0 +1,186 @@
+require 'ox'
+
+TESTING_REPORT = "#{ENV['CIRCLE_TEST_REPORTS']}/phpcs/junit.xml"
+TESTING_REPORT_ARTIFACT = {:message => "html coverage report", :path => "#{ENV['CIRCLE_TEST_REPORTS']}/phpcs/junit.xml"}
+
+PHPCS_SUMMARY_REPORT = "#{ENV['CIRCLE_ARTIFACTS']}/phpcs/summary.txt"
+PHPCS_SUMMARY_REPORT_ARTIFACT = {:message => "PHPCS summary report", :path => "#{ENV['CIRCLE_ARTIFACTS']}/phpcs/summary.txt"}
+
+PHPCS_XML_REPORT = "#{ENV['CIRCLE_ARTIFACTS']}/phpcs/xml.xml"
+PHPCS_XML_REPORT_ARTIFACT = {:message => "PHPCS XML report", :path => "artifacts/phpcs/summary.txt"}
+
+PHPCS_FULL_REPORT = "#{ENV['CIRCLE_TEST_REPORTS']}/full.txt"
+PHPCS_FULL_REPORT_ARTIFACT = {:message => "PHPCS full report", :path => "#{ENV['CIRCLE_TEST_REPORTS']}/full.txt"}
+
+artifacts = []
+phpcs_summary_data = ""
+
+if File.zero?(PHPCS_XML_REPORT)
+    message('Everithing OK with the Static Code Analysis')
+    artifacts << PHPCS_XML_REPORT_ARTIFACT
+    artifacts << PHPCS_FULL_REPORT_ARTIFACT
+    artifacts << PHPCS_SUMMARY_REPORT_ARTIFACT
+else
+    xml_string = File.read(PHPCS_XML_REPORT)
+    @doc = Ox.parse(xml_string)
+    summary = @doc.nodes.first
+    summary_md = ""
+
+    if summary.nodes[0] != "\n"
+
+        summary_md << "## Static Code Analysis \n\n"
+        summary_md << "### Summary \n\n"
+
+        attributes = ["File", "Errors", "Warnings"]
+        summary_md << attributes.join(' | ') + "|\n"
+        summary_md << attributes.map { |_| '---' }.join(' | ') + "|\n"
+
+        summary.nodes.each do |files|
+            filename = files['name']
+            errors = files['errors']
+            warnings = files['warnings']
+            summary_md << "#{filename}|"
+            summary_md << "#{errors}|"
+            summary_md << "#{warnings}|"
+            summary_md << "\n"
+        end
+    end
+
+    markdown summary_md
+end
+
+if File.file?(TESTING_REPORT)
+    xml_string = File.read(TESTING_REPORT)
+    @doc = Ox.parse(xml_string)
+    summary = @doc.nodes.first.locate("testsuite").first
+    packages = summary.nodes
+    tests_md = ""
+
+    if summary.nodes[0] != "\n"
+        tests = summary['tests']
+        assertions = summary['assertions']
+        failures = summary['failures']
+        errors = summary['errors']
+        time = summary['time']
+
+        tests_md << "## Unit testing \n\n"
+        attributes = ["Tests", "Assertions", "Errors", "Failures", "Time"]
+        tests_md << attributes.join(' | ') + "|\n"
+        tests_md << attributes.map { |_| '---' }.join(' | ') + "|\n"
+        tests_md << "#{tests} | #{assertions} | #{errors} | #{failures} | #{time} |\n\n"
+
+        summary.nodes.each do |package|
+            if package['errors'].to_i > 0
+                attributes = ["Type", "Class","Line", "Rule"]
+
+                filename = package['file']
+                tests_md << "\n#### #{filename}\n\n"
+                package.nodes.each do |testcase|
+                    if testcase.nodes.size > 0
+                        testcase.nodes.each do |errors|
+                            if !errors.nodes.nil?
+                                tests_md << attributes.join(' | ') + "|\n"
+                                tests_md << attributes.map { |_| '---' }.join(' | ') + "|\n"
+                                fail_type = errors.value
+                                error_info = errors['type']
+                                error_line= testcase['line']
+                                class_name= package['name']
+                                method_name= testcase['name']
+                                error_desc = errors.nodes[0]
+                                tests_md << "#{fail_type}|"
+                                tests_md << "#{class_name}:#{method_name}|"
+                                tests_md << "#{error_line}|"
+                                tests_md << "#{error_info}|\n"
+                                tests_md << "\n<blockquote>\n#{error_desc}</blockquote>\n\n"
+                            end
+                        end
+                    end
+                end
+                tests_md << "\n"
+            end
+        end
+
+        markdown tests_md
+        artifacts << TESTING_REPORT_ARTIFACT
+    end
+else
+    warn "You are not running tests."
+end
+
+if !artifacts.empty?
+    username = ENV['CIRCLE_PROJECT_USERNAME']
+    project_name = ENV['CIRCLE_PROJECT_REPONAME']
+    build_number = ENV['CIRCLE_BUILD_NUM']
+    node_index = ENV['CIRCLE_NODE_INDEX']
+    should_display_message = username && project_name && build_number && node_index
+
+    if should_display_message
+
+        # build the path to where the circle CI artifacts will be uploaded to
+        circle_ci_artifact_path  = 'https://circleci.com/api/v1/project/'
+        circle_ci_artifact_path += username
+        circle_ci_artifact_path += '/'
+        circle_ci_artifact_path += project_name
+        circle_ci_artifact_path += '/'
+        circle_ci_artifact_path += build_number
+        circle_ci_artifact_path += '/artifacts/'
+        circle_ci_artifact_path += node_index
+        circle_ci_artifact_path += '/$CIRCLE_ARTIFACTS/'
+
+        artifacts.each do |artifact|
+            # create a markdown link that uses the message text and the artifact path
+            message_string = '[' + artifact[:message] + ']'
+            message_string += '(' + circle_ci_artifact_path + artifact[:path] + ')'
+            message(message_string)
+        end
+    end
+end
+
+# Ensure a clean commits history
+if git.commits.any? { |c| c.message =~ /^Merge branch/ }
+    warn "Please consider to do a rebase to get rid of the merge commits in this PR"
+end
+
+# Warm https://github.com/Moya/Aeryn/blob/master/Dangerfile
+has_test_changes = !git.modified_files.grep("/tests/").empty?
+message("You didn't write new tests. Are you refactoring?") unless has_test_changes
+
+
+# Warn summary on pull request
+if github.pr_body.length < 100
+    warn "Please provide a summary in the Pull Request description"
+else
+    prefixes = [
+        /^# Related tasks$/i,
+        /^# Main description$/i,
+        /^# Solution description$/i
+    ]
+    reg = Regexp.union(prefixes)
+    pr_content = github.pr_body
+    if !pr_content.match(reg)
+        warn "Please use de defined format for the Pull Request Description"
+        markdown "### PR Example"
+
+        markdown <<-MARKDOWN
+        Here's an example of the PR description:
+        ```
+        # Related tasks
+        + [Task title](Task link)
+        # Main description
+        “Description”
+        # Solution description
+        “Description”
+        # Evidence
+        “Description or image about changes”
+        # Tests
+        “Related information about unit testing”
+        # Additional information
+        “Description”
+        ```
+        MARKDOWN
+    end
+end
+
+
+# From https://github.com/loadsmart/dangerfile/blob/master/Dangerfile
+message("Good job on cleaning the code") if git.deletions > git.insertions

--- a/ci/Gemfile
+++ b/ci/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gem 'danger'
+gem "danger-junit"
+gem "ox"

--- a/ci/circle.yml
+++ b/ci/circle.yml
@@ -1,0 +1,38 @@
+machine:
+  php:
+    version: 5.6.22
+  python:
+    version: 2.7.11
+dependencies:
+  cache_directories:
+    - "wpcs/vendor/"
+  pre:
+    - pip install vo-fabutils
+  override:
+    - git submodule update --init --recursive
+    - cd wordpress-workflow/ci/wpcs/ && composer install
+    - bundle install
+test:
+  pre:
+    - mkdir -p $CIRCLE_ARTIFACTS/phpcs/ $CIRCLE_TEST_REPORTS/phpcs/
+  post:
+    - wordpress-workflow/ci/wpcs/vendor/bin/phpcs -d memory_limit=1024M -s --report=full --extensions=php --report-file=$CIRCLE_ARTIFACTS/phpcs/full.txt --standard=Wordpress-Core --extensions=php ./src/themes
+    - wordpress-workflow/ci/wpcs/vendor/bin/phpcs -d memory_limit=1024M -s --report=summary --extensions=php --report-file=$CIRCLE_ARTIFACTS/phpcs/summary.txt --standard=Wordpress-Core --extensions=php ./src/themes
+    - wordpress-workflow/ci/wpcs/vendor/bin/phpcs -d memory_limit=1024M -s --report=xml --extensions=php --report-file=$CIRCLE_ARTIFACTS/phpcs/xml.xml --standard=Wordpress-Core --extensions=php ./src/themes
+    - wordpress-workflow/ci/wpcs/vendor/bin/phpcs -d memory_limit=1024M -s --report=junit --extensions=php --report-file=$CIRCLE_TEST_REPORTS/phpcs/junit.xml --standard=Wordpress-Core --extensions=php ./src/themes
+    - bundle exec danger
+deployment:
+  staging:
+    branch: staging
+    owner: vinco
+    commands:
+      - fab environment:staging,true sync_files
+      - fab environment:staging,true export_data:circleci_backup.sql
+      - fab environment:staging,true install_plugins
+  production:
+    branch: production
+    owner: vinco
+    commands:
+      - fab environment:production,true sync_files
+      - fab environment:production,true export_data:circleci_backup.sql
+      - fab environment:production,true install_plugins

--- a/ci/wpcs/.gitattributes
+++ b/ci/wpcs/.gitattributes
@@ -1,0 +1,25 @@
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop for WPCS using Composer, use `--prefer-source`.
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/.github export-ignore
+/bin export-ignore
+/Test export-ignore
+/WordPress/Tests export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+*.md text
+*.php text
+*.inc text

--- a/ci/wpcs/.gitignore
+++ b/ci/wpcs/.gitignore
@@ -1,0 +1,6 @@
+.buildpath
+.project
+.settings/
+vendor
+composer.lock
+phpunit.xml

--- a/ci/wpcs/CHANGELOG.md
+++ b/ci/wpcs/CHANGELOG.md
@@ -1,0 +1,541 @@
+# Change Log for WordPress Coding Standards
+
+All notable changes to this project will be documented in this file.
+
+This projects adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com/).
+
+## [Unreleased]
+
+_Nothing yet._
+
+## [0.14.0] - 2017-11-01
+
+### Added
+- `WordPress.Arrays.MultipleStatementAlignment` sniff to the `WordPress-Core` ruleset which will align the array assignment operator for multi-item, multi-line associative arrays.
+    This new sniff offers four custom properties to customize its behaviour: [`ignoreNewlines`](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-allow-for-new-lines), [`exact`](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-allow-non-exact-alignment), [`maxColumn`](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-maximum-column) and [`alignMultilineItems`](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#array-alignment-dealing-with-multi-line-items).
+- `WordPress.DB.PreparedSQLPlaceholders` sniff to the `WordPress-Core` ruleset which will analyse the placeholders passed to `$wpdb->prepare()` for their validity, check whether queries using `IN ()` and `LIKE` statements are created correctly and will check whether a correct number of replacements are passed.
+    This sniff should help detect queries which are impacted by the security fixes to `$wpdb->prepare()` which shipped with WP 4.8.2 and 4.8.3.
+    The sniff also adds a new ["PreparedSQLPlaceholders replacement count" whitelist comment](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors#preparedsql-placeholders-vs-replacements) for pertinent replacement count vs placeholder mismatches. Please consider carefully whether something could be a bug when you are tempted to use the whitelist comment and if so, [report it](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/new).
+- `WordPress.PHP.DiscourageGoto` sniff to the `WordPress-Core` ruleset.
+- `WordPress.PHP.RestrictedFunctions` sniff to the `WordPress-Core` ruleset which initially forbids the use of `create_function()`.
+    This was previous only discouraged under certain circumstances.
+- `WordPress.WhiteSpace.ArbitraryParenthesesSpacing` sniff to the `WordPress-Core` ruleset which checks the spacing on the inside of arbitrary parentheses.
+- `WordPress.WhiteSpace.PrecisionAlignment` sniff to the `WordPress-Core` ruleset which will throw a warning when precision alignment is detected in PHP, JS and CSS files.
+- `WordPress.WhiteSpace.SemicolonSpacing` sniff to the `WordPress-Core` ruleset which will throw a (fixable) error when whitespace is found before a semi-colon, except for when the semi-colon denotes an empty `for()` condition.
+- `WordPress.CodeAnalysis.AssignmentInCondition` sniff to the `WordPress-Extra` ruleset.
+- `WordPress.WP.DiscouragedConstants` sniff to the `WordPress-Extra` and `WordPress-VIP` rulesets to detect usage of deprecated WordPress constants, such as `STYLESHEETPATH` and `HEADER_IMAGE`.
+- Ability to pass the `minimum_supported_version` to use for the `DeprecatedFunctions`, `DeprecatedClasses` and `DeprecatedParameters` sniff in one go. You can pass a `minimum_supported_wp_version` runtime variable for this [from the command line or pass it using a `config` directive in a custom ruleset](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#setting-minimum-supported-wp-version-for-all-sniffs-in-one-go-wpcs-0140).
+- `Generic.Formatting.MultipleStatementAlignment` - customized to have a `maxPadding` of `40` -, `Generic.Functions.FunctionCallArgumentSpacing` and `Squiz.WhiteSpace.ObjectOperatorSpacing` to the `WordPress-Core` ruleset.
+- `Squiz.Scope.MethodScope`, `Squiz.Scope.MemberVarScope`, `Squiz.WhiteSpace.ScopeKeywordSpacing`, `PSR2.Methods.MethodDeclaration`, `Generic.Files.OneClassPerFile`, `Generic.Files.OneInterfacePerFile`, `Generic.Files.OneTraitPerFile`, `PEAR.Files.IncludingFile`, `Squiz.WhiteSpace.LanguageConstructSpacing`, `PSR2.Namespaces.NamespaceDeclaration` to the `WordPress-Extra` ruleset.
+- The `is_class_constant()`, `is_class_property` and `valid_direct_scope()` utility methods to the `WordPress\Sniff` class.
+
+### Changed
+- When passing an array property via a custom ruleset to PHP_CodeSniffer, spaces around the key/value are taken as intentional and parsed as part of the array key/value. In practice, this leads to confusion and WPCS does not expect any values which could be preceded/followed by a space, so for the WordPress Coding Standard native array properties, like `customAutoEscapedFunction`, `text_domain`, `prefixes`, WPCS will now trim whitespace from the keys/values received before use.
+- The WPCS native whitelist comments used to only work when they were put on the _end of the line_ of the code they applied to. As of now, they will also be recognized when they are be put at the _end of the statement_ they apply to.
+- The `WordPress.Arrays.ArrayDeclarationSpacing` sniff used to enforce all associative arrays to be multi-line. The handbook has been updated to only require this for multi-item associative arrays and the sniff has been updated accordingly.
+    [The original behaviour can still be enforced](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#arrays-forcing-single-item-associative-arrays-to-be-multi-line) by setting the new `allow_single_item_single_line_associative_arrays` property to `false` in a custom ruleset.
+- The `WordPress.NamingConventions.PrefixAllGlobals` sniff will now allow for a limited list of WP core hooks which are intended to be called by plugins and themes.
+- The `WordPress.PHP.DiscouragedFunctions` sniff used to include `create_function`. This check has been moved to the new `WordPress.PHP.RestrictedFunctions` sniff.
+- The `WordPress.PHP.StrictInArray` sniff now has a separate error code `FoundNonStrictFalse` for when the `$strict` parameter has been set to `false`. This allows for excluding the warnings for that particular situation, which will normally be intentional, via a custom ruleset.
+- The `WordPress.VIP.CronInterval` sniff now allows for customizing the minimum allowed cron interval by [setting a property in a custom ruleset](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#vip-croninterval-minimum-interval).
+- The `WordPress.VIP.RestrictedFunctions` sniff used to prohibit the use of certain WP native functions, recommending the use of `wpcom_vip_get_term_link()`, `wpcom_vip_get_term_by()` and `wpcom_vip_get_category_by_slug()` instead, as the WP native functions were not being cached. As the results of the relevant WP native functions are cached as of WP 4.8, the advice has now been reversed i.e. use the WP native functions instead of `wpcom...` functions.
+- The `WordPress.VIP.PostsPerPage` sniff now allows for customizing the `post_per_page` limit for which the sniff will trigger by [setting a property in a custom ruleset](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#vip-postsperpage-post-limit).
+- The `WordPress.WP.I18n` sniff will now allow and actively encourage omitting the text-domain in I18n function calls if the text-domain passed via the `text_domain` property is `default`, i.e. the domain used by Core.
+    When `default` is one of several text-domains passed via the `text_domain` property, the error thrown when the domain is missing has been downgraded to a `warning`.
+- The `WordPress.XSS.EscapeOutput` sniff now has a separate error code `OutputNotEscapedShortEcho` and the error message texts have been updated.
+- Moved `Squiz.PHP.Eval` from the `WordPress-Extra` and `WordPress-VIP` to the `WordPress-Core` ruleset.
+- Removed two sniffs from the `WordPress-VIP` ruleset which were already included via the `WordPress-Core` ruleset.
+- The unit test suite is now compatible with PHPCS 3.1.0+ and PHPUnit 6.x.
+- Some tidying up of the unit test case files.
+- All sniffs are now also being tested against PHP 7.2 for consistent sniff results.
+- An attempt is made to detect potential fixer conflicts early via a special build test.
+- Various minor documentation fixes.
+- Improved the Atom setup instructions in the Readme.
+- Updated the unit testing information in Contributing.
+- Updated the [custom ruleset example](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/phpcs.xml.dist.sample) for the changes contained in this release and to make it more explicit what is recommended versus example code.
+- The minimum recommended version for the suggested `DealerDirect/phpcodesniffer-composer-installer` Composer plugin has gone up to `0.4.3`. This patch version fixes support for PHP 5.3.
+
+### Fixed
+- The `WordPress.Arrays.ArrayIndentation` sniff did not correctly handle array items with multi-line strings as a value.
+- The `WordPress.Arrays.ArrayIndentation` sniff did not correctly handle array items directly after an array item with a trailing comment.
+- The `WordPress.Classes.ClassInstantiation` sniff will now correctly handle detection when using `new $array['key']` or `new $array[0]`.
+- The `WordPress.NamingConventions.PrefixAllGlobals` sniff did not allow for arbitrary word separators in hook names.
+- The `WordPress.NamingConventions.PrefixAllGlobals` sniff did not correctly recognize namespaced constants as prefixed.
+- The `WordPress.PHP.StrictInArray` sniff would erronously trigger if the `true` for `$strict` was passed in uppercase.
+- The `WordPress.PHP.YodaConditions` sniff could get confused over complex ternaries containing assignments. This has been remedied.
+- The `WordPress.WP.PreparedSQL` sniff would erronously throw errors about comments found within a DB function call.
+- The `WordPress.WP.PreparedSQL` sniff would erronously throw errors about `(int)`, `(float)` and `(bool)` casts and would also flag the subsequent variable which had been safe casted.
+- The `WordPress.XSS.EscapeOutput` sniff would erronously trigger when using a fully qualified function call - including the global namespace `\` indicator - to one of the escaping functions.
+- The lists of WP global variables and WP mixed case variables have been synchronized, which fixes some false positives.
+
+
+## [0.13.1] - 2017-08-07
+
+### Fixed
+- Fatal error when using PHPCS 3.x with the `installed_paths` config variable set via the ruleset.
+
+## [0.13.0] - 2017-08-03
+
+### Added
+- Support for PHP_CodeSniffer 3.0.2+. The minimum required PHPCS version (2.9.0) stays the same.
+- Support for the PHPCS 3 `--ignore-annotations` command line option. If you pass this option, both PHPCS native `@ignore ...` annotations as well as the WPCS specific [whitelist flags](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors) will be ignored.
+
+### Changed
+- The minimum required PHP version is now 5.3 when used in combination with PHPCS 2.x and PHP 5.4 when used in combination with PHPCS 3.x.
+- The way the unit tests can be run is now slightly different for PHPCS 2.x versus 3.x. For more details, please refer to the updated information in the [Contributing Guidelines](CONTRIBUTING.md).
+- Release archives will no longer contain the unit tests and other typical development files. You can still get these by using Composer with `--prefer-source` or by checking out a git clone of the repository.
+- Various textual improvements to the Readme.
+- Various textual improvements to the Contributing Guidelines.
+- Minor internal changes.
+
+### Removed
+- The `WordPress.Arrays.ArrayDeclaration` sniff has been deprecated. The last remaining checks this sniff contained have been moved to the `WordPress.Arrays.ArrayDeclarationSpacing` sniff.
+- Work-arounds which were in place to support PHP 5.2.
+
+### Fixed
+- A minor bug where the auto-fixer could accidentally remove a comment near an array opener.
+
+
+## [0.12.0] - 2017-07-21
+
+### Added
+- A default file encoding setting to the `WordPress-Core` ruleset. All files sniffed will now be regarded as `utf-8` by default.
+- `WordPress.Arrays.ArrayIndentation` sniff to the `WordPress-Core` ruleset to verify - and auto-fix - the indentation of array items and the array closer for multi-line arrays. This replaces the (partial) indentation fixing contained within the `WordPress.Array.ArrayDeclarationSpacing` sniff.
+- `WordPress.Arrays.CommaAfterArrayItem` sniff to the `WordPress-Core` ruleset to enforce that each array item is followed by a comma - except for the last item in a single-line array - and checks the spacing around the comma. This replaces (and improves) the checks which were previously included in the `WordPress.Arrays.ArrayDeclaration` sniff which were causing incorrect fixes and fixer conflicts.
+- `WordPress.Functions.FunctionCallSignatureNoParams` sniff to the `WordPress-Core` ruleset to verify that function calls without parameters do not have any whitespace between the parentheses.
+- `WordPress.WhiteSpace.DisallowInlineTabs` to the `WordPress-Core` ruleset to verify - and auto-fix - that spaces are used for mid-line alignment.
+- `WordPress.WP.CapitalPDangit` sniff to the `WordPress-Core` ruleset to - where relevant - verify that `WordPress` is spelled correctly. For misspellings in text strings and comment text, the sniff can auto-fix violations.
+- `Squiz.Classes.SelfMemberReference` whitespace related checks to the `WordPress-Core` ruleset and the additional check for using `self` rather than a FQN to the `WordPress-Extra` ruleset.
+- `Squiz.PHP.EmbeddedPhp` sniff to the `WordPress-Core` ruleset to check PHP code embedded within HTML blocks.
+- `PSR2.ControlStructures.SwitchDeclaration` to the `WordPress-Core` ruleset to check for the correct layout of `switch` control structures.
+- `WordPress.Classes.ClassInstantion` sniff to the `WordPress-Extra` ruleset to detect - and auto-fix - missing parentheses on object instantiation and superfluous whitespace in PHP and JS files. The sniff will also detect `new` being assigned by reference.
+- `WordPress.CodeAnalysis.EmptyStatement` sniff to the `WordPress-Extra` ruleset to detect - and auto-fix - superfluous semi-colons and empty PHP open-close tag combinations.
+- `WordPress.NamingConventions.PrefixAllGlobals` sniff to the `WordPress-Extra` ruleset to verify that all functions, classes, interfaces, traits, variables, constants and hook names which are declared/defined in the global namespace are prefixed with one of the prefixes provided via a custom property or via the command line.
+    To activate this sniff, [one or more allowed prefixes should be provided to the sniff](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace). This can be done using a custom ruleset or via the command line.
+    PHP superglobals and WP global variables are exempt from variable name prefixing. Deprecated hook names will also be disregarded when non-prefixed. Back-fills for known native PHP functionality is also accounted for.
+    For verified exceptions, [unprefixed code can be whitelisted](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors#non-prefixed-functionclassvariableconstant-in-the-global-namespace).
+    Code in unit test files is automatically exempt from this sniff.
+- `WordPress.WP.DeprecatedClasses` sniff to the `WordPress-Extra` ruleset to detect usage of deprecated WordPress classes.
+- `WordPress.WP.DeprecatedParameters` sniff to the `WordPress-Extra` ruleset to detect deprecated parameters being passed to WordPress functions with a value other than the expected default.
+- The `sanitize_textarea_field()` function to the `sanitizingFunctions` list used by the `WordPress.CSRF.NonceVerification`, `WordPress.VIP.ValidatedSanitizedInput` and `WordPress.XSS.EscapeOutput` sniffs.
+- The `find_array_open_closer()` utility method to the `WordPress_Sniff` class.
+- Information about setting `installed_paths` using a custom ruleset to the Readme.
+- Additional support links to the `composer.json` file.
+- Support for Composer PHPCS plugins which sort out the `installed_paths` setting.
+- Linting and code-style check of the XML ruleset files provided by WPCS.
+
+### Changed
+- The minimum required PHP_CodeSniffer version to 2.9.0 (was 2.8.1). **Take note**: PHPCS 3.x is not (yet) supported. The next release is expected to fix that.
+- Improved support for detecting issues in code using heredoc and/or nowdoc syntax.
+- Improved sniff efficiency, precision and performance for a number of sniffs.
+- Updated a few sniffs to take advantage of new features and fixes which are included in PHP_CodeSniffer 2.9.0.
+- `WordPress.Files.Filename`: The "file name mirrors the class name prefixed with 'class'" check for PHP files containing a class will no longer be applied to typical unit test classes, i.e. for classes which extend `WP_UnitTestCase`, `PHPUnit_Framework_TestCase` and `PHPUnit\Framework\TestCase`. Additional test case base classes can be passed to the sniff using the new [`custom_test_class_whitelist` property](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes).
+- The `WordPress.Files.FileName` sniff allows now for more theme-specific template hierarchy based file name exceptions.
+- The whitelist flag for the `WordPress.VIP.SlowQuery` sniff was `tax_query` which was unintuitive. This has now been changed to `slow query` to be in line with other whitelist flags.
+- The `WordPress.WhiteSpace.OperatorSpacing` sniff will now ignore operator spacing within `declare()` statements.
+- The `WordPress.WhiteSpace.OperatorSpacing` sniff now extends the upstream `Squiz.WhiteSpace.OperatorSpacing` sniff for improved results and will now also examine the spacing around ternary operators and logical (`&&`, `||`) operators.
+- The `WordPress.WP.DeprecatedFunctions` sniff will now detect functions deprecated in WP 4.7 and 4.8. Additionally, a number of other deprecated functions which were previously not being detected have been added to the sniff and for a number of functions the "alternative" for the deprecated function has been added/improved.
+- The `WordPress.XSS.EscapeOutput` sniff will now also detect unescaped output when the short open echo tags `<?=` are used.
+- Updated the list of WP globals which is used by both the `WordPress.Variables.GlobalVariables` and the `WordPress.NamingConventions.PrefixAllGlobals` sniffs.
+- Updated the information on using a custom ruleset and associated naming conventions in the Readme.
+- Updated the [custom ruleset example](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/phpcs.xml.dist.sample) to provide a better starting point and renamed the file to follow current PHPCS best practices.
+- Various inline documentation improvements.
+- Updated the link to the PHPStorm documentation in the Readme.
+- Various textual improvements to the Readme.
+- Minor improvements to the build script.
+
+### Removed
+- `Squiz.Commenting.LongConditionClosingComment` sniff from the `WordPress-Core` ruleset. This rule has been removed from the WP Coding Standards handbook.
+- The exclusion of the `Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace` error from the `WordPress-Core` ruleset.
+- The exclusion of the `PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket` and `PEAR.Functions.FunctionCallSignature.CloseBracketLine` error from the `WordPress-Core` ruleset when used in combination with the fixer, i.e. `phpcbf`. The exclusions remain in place for `phpcs` runs.
+- `wp_get_post_terms()`, `wp_get_post_categories()`, `wp_get_post_tags()` and `wp_get_object_terms()` from the `WordPress.VIP.RestrictedFunctions` sniff as these functions are now cached natively since WP 4.7.
+
+### Fixed
+- The `WordPress.Array.ArrayDeclarationSpacing` could be overeager when fixing associative arrays to be multi-line. Non-associative single-line arrays which contained a nested associative array would also be auto-fixed by the sniff, while only the nested associated array should be fixed.
+- The `WordPress.Files.FileName` sniff did not play nice with IDEs passing a filename to PHPCS via `--stdin-path=`.
+- The `WordPress.Files.FileName` sniff was being triggered on code passed via `stdin` where there is no file name to examine.
+- The `WordPress.PHP.YodaConditions` sniff would give a false positive for the result of a condition being assigned to a variable.
+- The `WordPress.VIP.RestrictedVariables` sniff was potentially underreporting issues when the variables being restricted were a combination of variables, object properties and array members.
+- The auto-fixer in the `WordPress.WhiteSpace.ControlStructureSpacing` sniff which deals with "blank line after control structure" issues could cause comments at the end of control structures to be removed.
+- The `WordPress.WP.DeprecatedFunctions` sniff was reporting the wrong WP version for the deprecation of a number of functions.
+- The `WordPress.WP.EnqueuedResources` sniff would potentially underreport issues in certain circumstances.
+- The `WordPress.XSS.EscapeOutput` sniff will no now longer report issues when it encounters a `__DIR__`, `(unset)` cast or a floating point number, and will correctly disregard more arithmetic operators when deciding whether to report an issue or not.
+- The [whitelisting of errors using flags](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors) was sometimes a bit too eager and could accidentally whitelist code which was not intended to be whitelisted.
+- Various (potential) `Undefined variable`, `Undefined index` and `Undefined offset` notices.
+- Grammer in one of the `WordPress.WP.I18n` error messages.
+
+
+## [0.11.0] - 2017-03-20
+
+### Important notes for end-users:
+
+If you use the WordPress Coding Standards with a custom ruleset, please be aware that some of the checks have been moved between sniffs and that the naming of a number of error codes has changed.
+If you exclude some sniffs or error codes, you may have to update your custom ruleset to be compatible with WPCS 0.11.0.
+
+Additionally, to make it easier for you to customize your ruleset, two new wiki pages have been published with information on the properties you can adjust from your ruleset:
+* [WPCS customizable sniff properties](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties)
+* [PHPCS customizable sniff properties](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties)
+
+For more detailed information about the changed sniff names and error codes, please refer to PR [#633](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/633) and PR [#814](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/814).
+
+### Important notes for sniff developers:
+
+If you maintain or develop sniffs based upon the WordPress Coding Standards, most notably, if you use methods and properties from the `WordPress_Sniff` class, extend one of the abstract sniff classes WPCS provides or extend other sniffs from WPCS to use their properties, please be aware that this release contains significant changes which will, more likely than not, affect your sniffs.
+
+Please read this changelog carefully to understand how this will affect you.
+For more detailed information on the most significant changes, please refer to PR [#795](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/795), PR [#833](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/833) and PR [#841](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/841).
+You are also encouraged to check the file history of any WPCS classes you extend.
+
+### Added
+- `WordPress.WP.DeprecatedFunctions` sniff to the `WordPress-Extra` ruleset to check for usage of deprecated WP version and show errors/warnings depending on a `minimum_supported_version` which [can be passed to the sniff from a custom ruleset](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters). The default value for the `minimum_supported_version` property is three versions before the current WP version.
+- `WordPress.WP.I18n`: ability to check for missing _translators comments_ when a I18n function call contains translatable text strings containing placeholders. This check will also verify that the _translators comment_ is correctly placed in the code and uses the correct comment type for optimal compatibility with the various tools available to create `.pot` files.
+- `WordPress.WP.I18n`: ability to pass the `text_domain` to check for [from the command line](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#setting-text_domain-from-the-command-line-wpcs-0110).
+- `WordPress.Arrays.ArrayDeclarationSpacing`: check + fixer for single line associative arrays. The [handbook](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation) states that these should always be multi-line.
+- `WordPress.Files.FileName`: verification that files containing a class reflect this in the file name as per the core guidelines. This particular check can be disabled in a custom ruleset by setting the new [`strict_class_file_names` property](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#disregard-class-file-name-rules).
+- `WordPress.Files.FileName`: verification that files in `/wp-includes/` containing template tags - annotated with `@subpackage Template` in the file header - use the `-template` suffix.
+- `WordPress.Files.FileName`: [`is_theme` property](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#themes-allow-filename-exceptions) which can be set in a custom ruleset. This property can be used to indicate that the project being checked is a theme and will allow for a predefined theme hierarchy based set of exceptions to the file name rules.
+- `WordPress.VIP.AdminBarRemoval`: check for hiding the admin bar using CSS.
+- `WordPress.VIP.AdminBarRemoval`: customizable [`remove_only` property](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#admin-bar-visibility-manipulations) to toggle whether to error of all manipulation of the visibility of the admin bar or to execute more thorough checking for removal only.
+- `WordPress.WhiteSpace.ControlStructureSpacing`: support for checking the whitespace in `try`/`catch` constructs.
+- `WordPress.WhiteSpace.ControlStructureSpacing`: check that the space after the open parenthesis and before the closing parenthesis of control structures and functions is *exactly* one space. Includes auto-fixer.
+- `WordPress.WhiteSpace.CastStructureSpacing`: ability to automatically fix errors thrown by the sniff.
+- `WordPress.VIP.SessionFunctionsUsage`: detection of the `session_abort()`, `session_create_id()`, `session_gc()` and `session_reset()` functions.
+- `WordPress.CSRF.NonceVerification`: ability to pass [custom sanitization functions](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-input-sanitization-functions) to the sniff.
+- The `get_the_ID()` function to the `autoEscapedFunctions` list used by the `WordPress.XSS.EscapeOutput` sniff.
+- The `wp_strip_all_tags()`, `sanitize_hex_color_no_hash()` and `sanitize_hex_color()` functions to the `sanitizingFunctions` list used by the `WordPress.CSRF.NonceVerification`, `WordPress.VIP.ValidatedSanitizedInput` and `WordPress.XSS.EscapeOutput` sniffs.
+- The `floatval()` function to the `escapingFunctions`, `sanitizingFunctions`, `unslashingSanitizingFunctions`, `SQLEscapingFunctions` lists used by the `WordPress.CSRF.NonceVerification`, `WordPress.VIP.ValidatedSanitizedInput`, `WordPress.XSS.EscapeOutput` and `WordPress.WP.PreparedSQL` sniffs.
+- The table name based `clean_*_cache()` functions to the `cacheDeleteFunctions` list used by the `WordPress.VIP.DirectDatabaseQuery` sniff.
+- Abstract `AbstractFunctionParameter` parent class to allow for examining parameters passed in function calls.
+- A number of utility functions to the `WordPress_Sniff` class: `strip_quotes()`, `addMessage()`, `addFixableMessage()`, `string_to_errorcode()`, `does_function_call_have_parameters()`, `get_function_call_parameter_count()`, `get_function_call_parameters()`, `get_function_call_parameter()`, `has_html_open_tag()`.
+- `Squiz.Commenting.LongConditionClosingComment`, `Squiz.WhiteSpace.CastSpacing`, `Generic.Formatting.DisallowMultipleStatements` to the `WordPress-Core` ruleset.
+- `Squiz.PHP.NonExecutableCode`, `Squiz.Operators.IncrementDecrementUsage`, `Squiz.Operators.ValidLogicalOperators`, `Squiz.Functions.FunctionDuplicateArgument`, `Generic.PHP.BacktickOperator`, `Squiz.PHP.DisallowSizeFunctionsInLoops` to the `WordPress-Extra` ruleset.
+- Numerous additional unit tests covering the correct handling of properties overruled via a custom ruleset by various sniffs.
+- Instructions on how to use WPCS with Visual Studio to the Readme.
+- Section on how to use WPCS with CI Tools to the Readme, initially covering integration with Travis CI.
+- Section on considerations when writing sniffs for WPCS to `Contributing.md`.
+
+### Changed
+- The minimum required PHP version to 5.2 (was 5.1).
+- The minimum required PHP_CodeSniffer version to 2.8.1 (was 2.6).
+- Improved support for detecting issues in code using closures (anonymous functions), short array syntax and anonymous classes.
+- Improved sniff efficiency and performance for a number of sniffs.
+- The discouraged/restricted functions sniffs have been reorganized and made more modular.
+    * The new `WordPress.PHP.DevelopmentFunctions` sniff now contains the checks related to PHP functions typically used during development which are discouraged in production code.
+    * The new `WordPress.PHP.DiscouragedPHPFunctions` sniff now contains checks related to various PHP functions, use of which is discouraged for various reasons.
+    * The new `WordPress.WP.AlternativeFunctions` sniff contains the checks related to PHP functions for which WP offers an alternative which should be used instead.
+    * The new `WordPress.WP.DiscouragedFunctions` sniff contains checks related to various WP functions, use of which is discouraged for various reasons.
+    * A number of checks contained in the `WordPress.VIP.RestrictedFunctions` sniff have been moved to other sniffs.
+    * The `WordPress.PHP.DiscouragedFunctions` sniff has been deprecated and is no longer used. The checks which were previously contained herein have been moved to other sniffs.
+    * The reorganized sniffs also detect a number of additional functions which were previously ignored by these sniffs. For more detail, please refer to the [summary of the PR](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/633#issuecomment-269693016) and to [PR #759](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/759).
+- The error codes for these sniffs as well as for `WordPress.DB.RestrictedClasses`, `WordPress.DB.RestrictedFunctions`, `WordPress.Functions.DontExtract`, `WordPress.PHP.POSIXFunctions` and a number of the `VIP` sniffs have changed. They were previously based on function group names and will now be based on function group name in combination with the identified function name. Complete function groups can still be silenced by using the [`exclude` property](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#excluding-a-group-of-checks) in a custom ruleset.
+- `WordPress.NamingConventions.ValidVariableName`: The `customVariablesWhitelist` property which could be passed from the ruleset has been renamed to [`customPropertiesWhitelist`](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#mixed-case-property-name-exceptions) as it is only usable to whitelist class properties.
+- `WordPress.WP.I18n`: now allows for an array of text domain names to be passed to the `text_domain` property from a custom ruleset.
+- `WordPress.WhiteSpace.CastStructureSpacing`: the error level for the checks in this sniff has been raised from `warning` to `error`.
+- `WordPress.Variables.GlobalVariables`: will no longer throw errors if the global variable override is done from within a test method. Whether something is considered a "test method" is based on whether the method is in a class which extends a predefined set of known unit test classes. This list can be enhanced by setting the [`custom_test_class_whitelist` property](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#custom-unit-test-classes) in your ruleset.
+- The `WordPress.Arrays.ArrayDeclaration` sniff has been split into two sniffs: `WordPress.Arrays.ArrayDeclaration` and `WordPress.Arrays.ArrayDeclarationSpacing` for better compatibility with PHPCS upstream.
+- The `WordPress.Arrays.ArrayDeclaration` sniff has been synced with the PHPCS upstream version to get the benefit of some bug fixes and improvements which had been made upstream since the sniff was originally copied over.
+- The `WordPress.VIP.FileSystemWritesDisallow`, `WordPress.VIP.TimezoneChange` and `WordPress.VIP.SessionFunctionsUsage` sniffs now extend the `WordPress_AbstractFunctionRestrictionsSniff`.
+- Property handling of custom properties set via a custom ruleset where the property is expected to be set in array format (`type="array"`) has been made more lenient and will now also handle properties passed as a comma delimited lists correctly. This affects all customizable properties which expect array format.
+- Moved `Squiz.PHP.DisallowMultipleAssignments` from the `WordPress-Extra` to the `WordPress-Core` ruleset.
+- Replaced the `WordPress.Classes.ValidClassName`, `WordPress.PHP.DisallowAlternativePHPTags` and the `WordPress.Classes.ClassOpeningStatement` sniffs with the existing `PEAR.NamingConventions.ValidClassName` and the new upstream `Generic.PHP.DisallowAlternativePHPTags` and `Generic.Classes.OpeningBraceSameLine` sniffs in the `WordPress-Core` ruleset.
+- Use the upstream `Squiz.PHP.Eval` sniff for detecting the use of `eval()` instead of a WPCS native implementation.
+- Made the `Generic.WhiteSpace.ScopeIndent` sniff in the `WordPress-Core` ruleset more lenient to allow for different indentation in inline HTML, heredoc and nowdoc structures.
+- Made the `Generic.Strings.UnnecessaryStringConcat` sniff in the `WordPress-Extra` ruleset more lenient to allow for multi-line string concatenation.
+- All sniffs are now also being tested against PHP 7.1 for consistent sniff results.
+- The requirements for running the sniffs have been made more explicit in the readme.
+- Updated composer installation instructions in the readme.
+- Updated information about the rulesets in the readme and moved the information up to make it easier to find.
+- Improved the information about running the unit tests in `Contributing.md`.
+- Improved the inline documentation of the rulesets.
+- Various other code quality and code consistency improvements under the hood, including refactoring of some of the abstract sniff classes, closer coupling of the child classes to the `WordPress_Sniff` parent class and changes to the visibility and staticness of properties for a large number of sniffs.
+
+### Removed
+- Warnings thrown by individual sniffs about parse errors they encounter. This is left up to the `Generic.PHP.Syntax` sniff which is included in the `WordPress-Extra` ruleset.
+- The `post_class()` function from the `autoEscapedFunctions` list used by the `WordPress.XSS.EscapeOutput` sniff.
+- The `Generic.Files.LowercasedFilename` sniff from the `WordPress-Core` ruleset in favour of the improved `WordPress.Files.FileName` sniff to prevent duplicate messages being thrown.
+- Some temporary work-arounds for changes which were pulled and merged into PHPCS upstream.
+
+### Fixed
+- `WordPress.Variables.GlobalVariables`: **_All known bugs have been fixed. If you'd previously disabled the sniff in your custom ruleset because of these bugs, it should be fine to re-enable it now._**
+    * Assignments to global variables using other assignment operators than the `=` operator were not detected.
+    * If a `global ...;` statement was detected, the whole file would be checked for the variables which were made global, not just the code after the global statement.
+    * If a `global ...;` statement was detected, the whole file would be checked for the variables which were made global, including code contained within a function/closure/class scope where there is no access to the global variable.
+    * If a `global ...;` statement was detected within a function call or closure, the whole file would be checked for the variables which were made global, not just the code within the function or closure.
+    * If a `global ...;` statement was detected and an assignment was made to a static class variable using the same name as one of the variables made global, an error would incorrectly be thrown.
+    * An override of a protected global via `$GLOBALS` in combination with simple string concatenation obfuscation was not being detected.
+- `WordPress.WP.I18n`: all reported bugs have been fixed.
+    * A superfluous `UnorderedPlaceholders` error was being thrown when `%%` (a literal % sign) was encountered in a string.
+    * The sniff would sometimes erroneously trigger errors when a literal `%` was found in a translatable string without placeholders.
+    * Not all type of placeholders were being recognized.
+    * No warning was being thrown when encountering a mix of ordered and unordered placeholders.
+    * The fixer for unordered placeholders was erroneously replacing all placeholders as if they were the first one.
+    * The fixer for unordered placeholders could cause faulty replacements in double quoted strings.
+    * Compatibility with PHP nightly / PHP 7.2.
+- `WordPress.WhiteSpace.ControlStructureSpacing`: synced in fixes from the upstream version.
+    * The fixer would bork on control structures which contained only a single empty line.
+    * The sniff did not check the spacing used for `do {} while ()` control structures.
+    * Conditional function declarations could cause an infinite loop when using the fixer.
+- `WordPress.VIP.PluginMenuSlug`: the sniff would potentially incorrectly process method calls and namespaced functions with the same function name as the targeted WordPress native functions.
+- `WordPress.VIP.CronInterval`: the native WP time constants were not recognized leading to false positives.
+- `WordPress.VIP.CronInterval`: the finding of the referenced function declaration has been made more accurate.
+- `WordPress.PHP.YodaConditions`: minor clarification of the error message.
+- `WordPress.NamingConventions.ValidVariableName`: now allows for a predefined list of known mixed case global variables coming from WordPress itself reducing false positives.
+- The `unslashingSanitizingFunctions` list was not consistently taken into account when verifying whether a variable was sanitized for the `WordPress.VIP.ValidatedSanitizedInput` and `WordPress.CSRF.NonceVerification` sniffs.
+- The passing of properties via the ruleset was buggy for a number of sniffs - most notably those sniffs using custom properties in array format - and could lead to unintended bleed-through between sniffs.
+- Various (potential) `Undefined variable`, `Undefined index` and `Undefined offset` notices.
+- An issue with placeholder replacement not taking place in some error messages.
+- A (potential) issue which could play up when sniffs examined text strings which contained quotes.
+
+
+## [0.10.0] - 2016-08-29
+
+### Added
+- `WordPress.WP.I18n` sniff to the `WordPress-Core` ruleset to flag dynamic translatable strings and textdomains.
+- `WordPress.PHP.DisallowAlternativePHPTags` sniff to the `WordPress-Core` ruleset to flag - and fix - ASP and `<script>` PHP open tags.
+- `WordPress.Classes.ClassOpeningStatement` sniff to the `WordPress-Core` ruleset to flag - and fix - class opening brace placement.
+- `WordPress.NamingConventions.ValidHookName` sniff to the `WordPress-Core` ruleset to flag filter and action hooks which don't comply with the guideline of lowercase letters and underscores. For maintaining backward-compatibility of hook names an `additionalWordDelimiters` property can be added via a custom ruleset.
+- `WordPress.Functions.DontExtract` sniff to the `WordPress-Core` ruleset to flag usage of the `extract()` function.
+- `WordPress.PHP.POSIXFunctions` sniff to the `WordPress-Core` ruleset to flag usage of regex functions from the POSIX PHP extension which was deprecated since PHP 5.3 and removed in PHP 7.
+- `WordPress.DB.RestrictedFunctions` and `WordPress.DB.RestrictedClasses` sniffs to the `WordPress-Core` ruleset to flag usage of direct database calls using PHP functions and classes rather than the WP functions for the same.
+- Abstract `AbstractClassRestrictions` parent class to allow for easier sniffing for usage of specific classes.
+- `Squiz.Strings.ConcatenationSpacing`, `PSR2.ControlStructures.ElseIfDeclaration`, `PSR2.Files.ClosingTag`, `Generic.NamingConventions.UpperCaseConstantName` to the `WordPress-Core` ruleset.
+- Ability to add arbitrary variables to the whitelist via a custom ruleset property for the `WordPress.NamingConventions.ValidVariableName` sniff.
+- Ability to use a whitelist comment for tax queries for the `WordPress.VIP.SlowDBQuery` sniff.
+- Instructions on how to use WPCS with Atom and SublimeLinter to the Readme.
+- Reference to the [wiki](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki) to the Readme.
+- Recommendation to also use the [PHPCompatibility](https://github.com/wimg/PHPCompatibility) ruleset to the Readme.
+
+### Changed
+- The minimum required PHP_CodeSniffer version to 2.6.0.
+- Moved the `WordPress.WP.PreparedSQL` sniff from `WordPress-Extra` to `WordPress-Core`.
+- `WordPress.PHP.StrictInArray` will now also flag non-strict usage of `array_keys()` and `array_search()`.
+- Added `_deprecated_constructor()` and `_deprecated_hook()` to the list of printing functions.
+- Added numerous additional functions to sniff for to the `WordPress.VIP.RestrictedFunctions` sniff as per the VIP guidelines.
+- Upped the `posts_per_page` limit from 50 to 100 in `WordPress.VIP.PostsPerPage` sniff as per the VIP guidelines.
+- Added `cat_ID` to the whitelisted exceptions for the `WordPress.NamingConventions.ValidVariableName` sniff.
+- Added `__debugInfo` to the magic method whitelist for class methods starting with double underscore in the `WordPress.NamingConventions.ValidFunctionName` sniff.
+- An error will now also be thrown for non-magic _functions_ using a double underscore prefix - `WordPress.NamingConventions.ValidFunctionName` sniff.
+- The `WordPress.Arrays.ArrayAssignmentRestrictions`, `WordPress.Functions.FunctionRestrictions`, `WordPress.Variables.VariableRestrictions` sniffs weren't in actual fact sniffs, but parent classes for child sniffs. These have now all been turned into proper abstract parent classes and moved to the main `WordPress` directory.
+- The array provided to `AbstractFunctionRestrictions` can now take a `whitelist` key to whitelist select functions when blocking a group of functions by function prefix.
+- Updated installation instructions in the readme.
+- The `WordPress-Core` ruleset is now ordered according to the handbook
+- The WPCS code base itself now complies with the WordPress-Core, -Extra and -Docs coding standards.
+- Various other code quality and code consistency improvements under the hood.
+
+### Removed
+- `Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose` from the `WordPress-Core` standard (was causing duplicate messages for the same issue).
+- `Squiz.Commenting.FunctionComment.ScalarTypeHintMissing`, `Squiz.Commenting.InlineComment.NotCapital` from the `WordPress-Docs` standard.
+- Removed the sniffing for `get_pages()` from the `WordPress.VIP.RestrictedFunctions` sniff as per the VIP guidelines.
+- Removed the sniffing for `extract()` from the `WordPress.VIP.RestrictedFunctions` sniff as it's now covered in a separate sniff.
+- Removed the sniffing for the POSIX functions from the `WordPress.PHP.DiscouragedFunctions` sniff as it's now covered in a separate sniff.
+
+### Fixed
+- Error message precision for the `WordPress.NamingConventions.ValidVariableName` sniff.
+- Bug in the `WordPress.WhiteSpace.ControlStructureSpacing.BlankLineAfterEnd` sniff which was incorrectly being triggered on last method of class.
+- Function name sniffs based on the `AbstractFunctionRestrictions` parent class will now do a case-insensitive function name comparison.
+- Function name sniffs in the `WordPress.PHP.DiscouragedFunctions` sniff will now do a case-insensitive function name comparison.
+- Whitelist comments directly followed by a PHP closing tag were not being recognized.
+- Some PHP Magic constants were not recognized by the `WordPress.XSS.EscapeOutput` sniff.
+- An error message suggesting camel caps rather than the intended snake case format in the `WordPress.NamingConventions.ValidFunctionName` sniff.
+- `WordPress.WhiteSpace.ControlStructureSpacing` should no longer throw error notices during live code review.
+- Errors will be no longer be thrown for methods not complying with the naming conventions when the class extends a parent class or implements an interface - `WordPress.NamingConventions.ValidFunctionName` sniff.
+
+
+## [0.9.0] - 2016-02-01
+
+### Added
+- `count()` to the list of auto-escaped functions.
+- `Squiz.PHP.CommentedOutCode` sniff to `WordPress-VIP` ruleset.
+- Support for PHP 5.2.
+- `attachment_url_to_postid()` and `parse_url()` to the restricted functions for `WordPress-VIP`.
+- `WordPress.VIP.OrderByRand` sniff.
+- `WordPress.PHP.StrictInArray` sniff for `WordPress-VIP` and `WordPress-Extra`.
+- `get_tag_link()`, `get_category_link()`, `get_cat_ID()`, `url_to_post_id()`, `attachment_url_to_postid()`
+`get_posts()`, `wp_get_recent_posts()`, `get_pages()`, `get_children()`, `wp_get_post_terms()`
+`wp_get_post_categories()`, `wp_get_post_tags()`, `wp_get_object_terms()`, `term_exists()`,
+`count_user_posts()`, `wp_old_slug_redirect()`, `get_adjacent_post()`, `get_previous_post()`,
+`get_next_post()` to uncached functions in `WordPress.VIP.RestrictedFunctions` sniff.
+- `wp_handle_upload()` and `array_key_exists()` to the list of sanitizing functions.
+- Checking for object properties in `WordPress.PHP.YodaConditions` sniff.
+- `WordPress.NamingConventions.ValidVariableName` sniff.
+- Flagging of function calls incorporated into database queries in `WordPress.WP.PreparedSQL`.
+- Recognition of escaping and auto-escaped functions in `WordPress.WP.PreparedSQL`.
+- `true`, `false`, and `null` to the tokens ignored in `WordPress.XSS.EscapeOutput`.
+
+### Fixed
+- Incorrect ternary detection in `WordPress.XSS.EscapeOutput` sniff.
+- False positives when detecting variables interpolated into strings in the
+`WordPress.WP.PreparedSQL` and `WordPress.VIP.ValidatedSanitizedInput` sniffs.
+- False positives in `WordPress.PHP.YodaConditions` when the variable is being casted.
+- `$wpdb` properties being flagged in `WordPress.WP.PreparedSQL` sniff.
+- False positive in `WordPress.PHP.YodaConditions` when the a string is on the left side of the
+comparison.
+
+## [0.8.0] - 2015-10-02
+
+### Added
+- `implode()` and `join()` to the list of formatting functions in the `WordPress.XSS.EscapeOutput`
+sniff. This is useful when you need to have HTML in the `$glue` parameter.
+- Support in the `WordPress.XSS.EscapeOutput` sniff for escaping an array of values
+using `array_map()`. (Otherwise the support for `implode()` isn't of much use :)
+- Docs for running WPCS in Sublime Text.
+- `nl2br()` to the list of formatting functions.
+- `wp_dropdown_pages()` to the list of printing functions.
+- Error codes to all error/warning messages.
+- `WordPress.WP.PreparedSQL` sniff for flagging unprepared SQL queries.
+
+### Removed
+- Sniffing for the number of spaces before a closure's opening parenthesis from the
+default configuration of the `WordPress.WhiteSpace.ControlStructureSpacing` sniff. It
+can be re-enabled per-project as desired.
+
+### Fixed
+- The `WordPress.XSS.EscapeOutput` sniff giving error messages with the closing
+parenthesis in them instead of the offending function's name.
+
+## [0.7.1] - 2015-08-31
+
+### Changed
+- The default number of spaces before a closure's opening parenthesis from 1 to 0.
+
+## [0.7.0] - 2015-08-30
+
+### Added
+- Automatic error fixing to the `WordPress.Arrays.ArrayKeySpacingRestrictions` sniff.
+- Functions and closures to the control structures checked by the `WordPress.WhiteSpace.ControlStructureSpacing`
+sniff.
+- Sniffing and fixing for extra spacing in the `WordPress.WhiteSpace.ControlStructureSpacing`
+sniff. (Previously it only checked for insufficient spacing.)
+- `.twig` files to the default ignored files.
+- `esc_url_raw()` and `hash_equals()` to the list of sanitizing functions.
+- `intval()` and `boolval()` to list of unslashing functions.
+- `do_shortcode()` to the list of auto-escaped functions.
+
+### Removed
+- `WordPress.Functions.FunctionDeclarationArgumentSpacing` in favor of the upstream
+sniff `Squiz.Functions.FunctionDeclarationArgumentSpacing`.
+
+### Fixed
+- Reference to incorrect issue in the inline docs of the `WordPress.VIP.SessionVariableUsage`
+sniff.
+- `WordPress.XSS.EscapeOutput` sniff incorrectly handling ternary conditions in
+`echo` statements without parentheses in some cases.
+
+## [0.6.0] - 2015-06-30
+
+### Added
+- Support for `wp_cache_add()` and `wp_cache_delete()`, as well as custom cache 
+functions,in the `WordPress.VIP.DirectDatabaseQuery` sniff.
+
+### Removed
+- `WordPress.Functions.FunctionRestrictions` and `WordPress.Variables.VariableRestrictions` 
+from the `WordPress-VIP` standard, since they are just parents for other sniffs.
+
+## [0.5.0] - 2015-06-01
+
+### Added
+- `WordPress.CSRF.NonceVerification` sniff to flag form processing without nonce verification.
+- `in_array()` and `is_array()` to the list of sanitizing functions.
+- Support for automatic error fixing to the `WordPress.Arrays.ArrayDeclaration` sniff.
+- `WordPress.PHP.StrictComparisions` to the `WordPress-VIP` and `WordPress-Extra` rulesets.
+- `WordPress-Docs` ruleset to sniff for proper commenting.
+- `Generic.PHP.LowerCaseKeyword`, `Generic.Files.EndFileNewline`, `Generic.Files.LowercasedFilename`, 
+`Generic.Formatting.SpaceAfterCast`, and `Generic.Functions.OpeningFunctionBraceKernighanRitchie` to the `WordPress-Core` ruleset.
+- `Generic.PHP.DeprecatedFunctions`, `Generic.PHP.ForbiddenFunctions`, `Generic.Functions.CallTimePassByReference`, 
+`Generic.Formatting.DisallowMultipleStatements`, `Generic.CodeAnalysis.EmptyStatement`, 
+`Generic.CodeAnalysis.ForLoopShouldBeWhileLoop`, `Generic.CodeAnalysis.ForLoopWithTestFunctionCall`, 
+`Generic.CodeAnalysis.JumbledIncrementer`, `Generic.CodeAnalysis.UnconditionalIfStatement`, 
+`Generic.CodeAnalysis.UnnecessaryFinalModifier`, `Generic.CodeAnalysis.UselessOverridingMethod`, 
+`Generic.Classes.DuplicateClassName`, and `Generic.Strings.UnnecessaryStringConcat` to the `WordPress-Extra` ruleset.
+- Error for missing use of `wp_unslash()` on superglobal data to the `WordPress.VIP.ValidatedSanitizedInput` sniff. 
+
+### Changed
+- The `WordPress.VIP.ValidatedSanitizedInput` sniff to require sanitization of input even when it is being directly escaped and output.
+- The minimum required PHP_CodeSniffer version to 2.2.0.
+- The `WordPress.VIP.ValidatedSanitizedInput` and `WordPress.XSS.EscapeOutput` sniffs: 
+the list of escaping functions was split from the list of sanitizing functions. The `customSanitizingFunctions` 
+property has been moved to the `ValidatedSanitizedInput` sniff, and the `customEscapingFunctions`
+property should now be used instead for the `EscapeOutput` sniff.
+- The `WordPress.Arrays.ArrayDeclaration` sniff to give errors for `NoSpaceAfterOpenParenthesis`, `SpaceAfterArrayOpener`, and `SpaceAfterArrayCloser`, instead of warnings.
+- The `WordPress.NamingConventions.ValidFunctionName` sniff to allow camelCase method names in classes that implement interfaces.
+
+### Fixed
+- The `WordPress.VIP.ValidatedSanitizedInput` sniff not reporting missing validation when reporting missing sanitization.
+- The `WordPress.VIP.ValidatedSanitizedInput` sniff flagging superglobals as needing sanitization when they were only being used in a comparison using `if` or `switch`, etc.
+
+## [0.4.0] - 2015-05-01
+
+### Added
+- Change log file.
+- Handling for string-interpolated input variables in the `WordPress.VIP.ValidatedSanitizedInput` sniff.
+- Errors for using uncached functions when cached equivalents exist.
+- `space_before_colon` setting for the `WordPress.WhiteSpace.ControlStructureSpacing` sniff, for control structures using alternative syntax. Possible values: `'required'`, `'optional'`, `'forbidden'`.
+- Support for `sanitization` whitelisting comments for the `WordPress.VIP.ValidatedSanitizedInput` sniff.
+- Granular error/warning names for all errors and warnings.
+- Handling for ternary conditions in the `WordPress.XSS.EscapeOutput` sniff.
+- `die`, `exit`, `printf`, `vprintf`, `wp_die`, `_deprecated_argument`, `_deprecated_function`, `_deprecated_file`, `_doing_it_wrong`, `trigger_error`, and `user_error` to the list of printing functions in the `WordPress.XSS.EscapeOutput` sniff.
+- `customPrintingFunctions` setting for the `WordPress.XSS.EscapeOutput` sniff.
+- `rawurlencode()` and `wp_parse_id_list()` to the list of "sanitizing" functions in the `WordPress.XSS.EscapeOutput` sniff.
+- `json_encode()` to the list of discouraged functions in the `WordPress.PHP.DiscouragedFunctions` sniff, in favor of `wp_json_encode()`.
+- `vip_powered_wpcom()` to the list of auto-escaped functions in the `WordPress.XSS.EscapeOutput` sniff.
+- `debug_print_backtrace()` and `var_export()` to the list of discouraged functions in the `WordPress.PHP.DiscouragedFunctions` sniff.
+- Smart handling for formatting functions (`sprintf()` and `wp_sprintf()`) in the `WordPress.XSS.EscapeOutput` sniff.
+- `WordPress.PHP.StrictComparisons` sniff.
+- Correct handling of `array_map()` in the `WordPress.VIP.ValidatedSanitizedInput` sniff.
+- `$_COOKIE` and `$_FILE` to the list of superglobals flagged by the `WordPress.VIP.ValidatedSanitizedInput` and `WordPress.VIP.SuperGlobalInputUsage` sniffs.
+- `$_SERVER` to the list of superglobals flagged by the `WordPress.VIP.SuperGlobalInputUsage` sniff.
+- `Squiz.ControlStructures.ControlSignature` sniff to the rulesets.
+
+### Changed
+- `WordPress.Arrays.ArrayKeySpacingRestrictions` sniff to give errors for `NoSpacesAroundArrayKeys` and `SpacesAroundArrayKeys` instead of just warnings.
+- `WordPress.NamingConventions.ValidFunctionName` sniff to allow for camel caps method names in child classes.
+- `WordPress.XSS.EscapeOutput` sniff to allow for integers (e.g. `echo 5` and `print( -1 )`).
+
+### Removed
+- Errors for mixed key/keyless array elements in the `WordPress.Arrays.ArrayDeclaration` sniff.
+- BOM from `WordPress.WhiteSpace.OperatorSpacing` sniff file.
+- `$content_width` from the list of non-overwritable globals in the `WordPress.Variables.GlobalVariables` sniff.
+- `WordPress.Arrays.ArrayAssignmentRestrictions` sniff from the `WordPress-VIP` ruleset.
+
+### Fixed
+- Incorrect errors for `else` statements using alternative syntax.
+- `WordPress.VIP.ValidatedSanitizedInput` sniff not always treating casting as sanitization.
+- `WordPress.XSS.EscapeOutput` sniff flagging comments as needing to be escaped.
+- `WordPress.XSS.EscapeOutput` sniff not sniffing comma-delimited `echo` arguments after encountering the first escaping function in the statement.
+- `WordPress.PHP.YodaConditions` sniff not flagging comparisons to constants or function calls.
+- `WordPress.Arrays.ArrayDeclaration` sniff not ignoring doc comments.
+- Link to phpStorm instructions in `README.md`.
+- Poor performance of the `WordPress.Arrays.ArrayAssignmentRestrictions` sniff.
+- Poor performance of the `WordPress.Files.FileName` sniff.
+
+## [0.3.0] - 2014-12-11
+
+See the comparison for full list.
+
+### Changed
+- Use semantic version tags for releases.
+
+## [2013-10-06]
+
+See the comparison for full list.
+
+## 2013-06-11
+
+Initial tagged release.
+
+[Unreleased]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/master...HEAD
+[0.14.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.13.1...0.14.0
+[0.13.1]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.13.0...0.13.1
+[0.13.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.12.0...0.13.0
+[0.12.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.11.0...0.12.0
+[0.11.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.10.0...0.11.0
+[0.10.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.9.0...0.10.0
+[0.9.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.8.0...0.9.0
+[0.8.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.7.1...0.8.0
+[0.7.1]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.7.0...0.7.1
+[0.7.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.6.0...0.7.0
+[0.6.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.5.0...0.6.0
+[0.5.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.4.0...0.5.0
+[0.4.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/0.3.0...0.4.0
+[0.3.0]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/2013-10-06...0.3.0
+[2013-10-06]: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/compare/2013-06-11...2013-10-06

--- a/ci/wpcs/LICENSE
+++ b/ci/wpcs/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2009 John Godley and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ci/wpcs/README.md
+++ b/ci/wpcs/README.md
@@ -1,0 +1,282 @@
+[![Build Status](https://travis-ci.org/WordPress-Coding-Standards/WordPress-Coding-Standards.png?branch=master)](https://travis-ci.org/WordPress-Coding-Standards/WordPress-Coding-Standards)
+[![Total Downloads](https://poser.pugx.org/wp-coding-standards/wpcs/downloads)](https://packagist.org/packages/wp-coding-standards/wpcs)
+
+# WordPress Coding Standards for PHP_CodeSniffer
+
+* [Introduction](#introduction)
+* [Project history](#project-history)
+* [Installation](#installation)
+    + [Requirements](#requirements)
+    + [Composer](#composer)
+    + [Standalone](#standalone)
+* [Rulesets](#rulesets)
+    + [Standards subsets](#standards-subsets)
+    + [Using a custom ruleset](#using-a-custom-ruleset)
+    + [Customizing sniff behaviour](#customizing-sniff-behaviour)
+    + [Recommended additional rulesets](#recommended-additional-rulesets)
+* [How to use](#how-to-use)
+    + [Command line](#command-line)
+    + [PhpStorm](#phpstorm)
+    + [Sublime Text](#sublime-text)
+    + [Atom](#atom)
+    + [Visual Studio](#visual-studio)
+* [Running your code through WPCS automatically using CI tools](#running-your-code-through-wpcs-automatically-using-ci-tools)
+    + [Travis CI](#travis-ci)
+* [Fixing errors or whitelisting them](#fixing-errors-or-whitelisting-them)
+* [Contributing](#contributing)
+* [License](#license)
+
+## Introduction
+
+This project is a collection of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) rules (sniffs) to validate code developed for WordPress. It ensures code quality and adherence to coding conventions, especially the official [WordPress Coding Standards](http://make.wordpress.org/core/handbook/coding-standards/).
+
+## Project history
+
+ - In April 2009 original project from [Urban Giraffe](http://urbangiraffe.com/articles/wordpress-codesniffer-standard/) was published.
+ - In May 2011 the project was forked on GitHub by [Chris Adams](http://chrisadams.me.uk/).
+ - In April 2012 [XWP](https://xwp.co/) started to dedicate resources to develop and lead the creation of the sniffs and rulesets for `WordPress-Core`, `WordPress-VIP` (WordPress.com VIP), and `WordPress-Extra`.
+ - In 2015, [J.D. Grimes](https://github.com/JDGrimes) began significant contributions, along with maintenance from [Gary Jones](https://github.com/GaryJones).
+ - In 2016, [Juliette Reinders Folmer](https://github.com/jrfnl) began contributing heavily, adding more commits in a year than anyone else in 5 years previous since the project's inception.
+
+## Installation
+
+### Requirements
+
+The WordPress Coding Standards require PHP 5.3 or higher and [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) version **2.9.0** or higher.
+As of version 0.13.0, the WordPress Coding Standards are compatible with PHPCS 3.0.2+. In that case, the minimum PHP requirement is PHP 5.4.
+
+### Composer
+
+Standards can be installed with the [Composer](https://getcomposer.org/) dependency manager:
+
+    composer create-project wp-coding-standards/wpcs --no-dev
+
+Running this command will:
+
+1. Install WordPress standards into `wpcs` directory.
+2. Install PHP_CodeSniffer.
+3. Register WordPress standards in PHP_CodeSniffer configuration.
+4. Make `phpcs` command available from `wpcs/vendor/bin`.
+
+For the convenience of using `phpcs` as a global command, you may want to add the path to the `wpcs/vendor/scripts` (PHPCS 2.x) and/or `wpcs/vendor/bin` (PHPCS 3.x) directories to a `PATH` environment variable for your operating system.
+
+#### Installing WPCS as a dependency
+
+When installing the WordPress Coding Standards as a dependency in a larger project, the above mentioned step 3 will not be executed automatically.
+
+There are two actively maintained Composer plugins which can handle the registration of standards with PHP_CodeSniffer for you:
+* [composer-phpcodesniffer-standards-plugin](https://github.com/higidi/composer-phpcodesniffer-standards-plugin)
+* [phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.4.3"
+
+It is strongly suggested to `require` one of these plugins in your project to handle the registration of external standards with PHPCS for you.
+
+### Standalone
+
+1. Install PHP_CodeSniffer by following its [installation instructions](https://github.com/squizlabs/PHP_CodeSniffer#installation) (via Composer, Phar file, PEAR, or Git checkout).
+
+   Do ensure that PHP_CodeSniffer's version matches our [requirements](#requirements), if, for example, you're using [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV).
+
+2. Clone the WordPress standards repository:
+
+        git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wpcs
+
+3. Add its path to the PHP_CodeSniffer configuration:
+
+        phpcs --config-set installed_paths /path/to/wpcs
+
+   **Pro-tip:** Alternatively, you can tell PHP_CodeSniffer the path to the WordPress standards by adding the following snippet to your custom ruleset:
+   ```xml
+   <config name="installed_paths" value="/path/to/wpcs" />
+   ```
+
+To summarize:
+
+```bash
+cd ~/projects
+git clone https://github.com/squizlabs/PHP_CodeSniffer.git phpcs
+git clone -b master https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wpcs
+cd phpcs
+#PHPCS 2.x
+./scripts/phpcs --config-set installed_paths ../wpcs
+#PHPCS 3.x
+./bin/phpcs --config-set installed_paths ../wpcs
+```
+
+And then add the `~/projects/phpcs/scripts` (PHPCS 2.x) or `~/projects/phpcs/bin` (PHPCS 3.x) directory to your `PATH` environment variable via your `.bashrc`.
+
+You should then see `WordPress-Core` et al listed when you run `phpcs -i`.
+
+##  Rulesets
+
+### Standards subsets
+
+The project encompasses a super-set of the sniffs that the WordPress community may need. If you use the `WordPress` standard you will get all the checks. Some of them might be unnecessary for your environment, for example, those specific to WordPress VIP coding requirements.
+
+You can use the following as standard names when invoking `phpcs` to select sniffs, fitting your needs:
+
+* `WordPress` - complete set with all of the sniffs in the project
+  - `WordPress-Core` - main ruleset for [WordPress core coding standards](http://make.wordpress.org/core/handbook/coding-standards/)
+  - `WordPress-Docs` - additional ruleset for [WordPress inline documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/)
+  - `WordPress-Extra` - extended ruleset for recommended best practices, not sufficiently covered in the WordPress core coding standards
+    - includes `WordPress-Core`
+  - `WordPress-VIP` - extended ruleset for [WordPress VIP coding requirements](http://vip.wordpress.com/documentation/code-review-what-we-look-for/)
+    - includes `WordPress-Core`
+
+### Using a custom ruleset
+
+If you need to further customize the selection of sniffs for your project - you can create a custom ruleset file. When you name this file either `phpcs.xml` or `phpcs.xml.dist`, PHP_CodeSniffer will automatically locate it as long as it is placed in the directory from which you run the CodeSniffer or in a directory above it. If you follow these naming conventions you don't have to supply a `--standard` arg. For more info, read about [using a default configuration file](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#using-a-default-configuration-file). See also provided [`phpcs.xml.dist.sample`](phpcs.xml.dist.sample) file and [fully annotated example](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml) in the PHP_CodeSniffer documentation.
+
+### Customizing sniff behaviour
+
+The WordPress Coding Standard contains a number of sniffs which are configurable. This means that you can turn parts of the sniff on or off, or change the behaviour by setting a property for the sniff in your custom `phpcs.xml` file.
+
+You can find a complete list of all the properties you can change in the [wiki](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties).
+
+### Recommended additional rulesets
+
+The [PHPCompatibility](https://github.com/wimg/PHPCompatibility) ruleset comes highly recommended.
+The [PHPCompatibility](https://github.com/wimg/PHPCompatibility) sniffs are designed to analyse your code for cross-PHP version compatibility.
+Install it as a separate ruleset and either run it separately against your code or add it to your custom ruleset.
+
+Whichever way you run it, do make sure you set the `testVersion` to run the sniffs against. The `testVersion` determines for which PHP versions you will receive compatibility information. The recommended setting for this at this moment is  `5.2-7.1` to support the same PHP versions as WordPress Core supports.
+
+For more information about setting the `testVersion`, see:
+* [PHPCompatibility: Using the compatibility sniffs](https://github.com/wimg/PHPCompatibility#using-the-compatibility-sniffs)
+* [PHPCompatibility: Using a custom ruleset](https://github.com/wimg/PHPCompatibility#using-a-custom-ruleset)
+
+## How to use
+
+### Command line
+
+Run the `phpcs` command line tool on a given file or directory, for example:
+
+    phpcs --standard=WordPress wp-load.php
+
+Will result in following output:
+
+	--------------------------------------------------------------------------------
+	FOUND 10 ERRORS AND 5 WARNINGS AFFECTING 8 LINES
+	--------------------------------------------------------------------------------
+	 24 | WARNING | [ ] error_reporting() can lead to full path disclosure.
+	 24 | WARNING | [ ] error_reporting() found. Changing configuration at runtime
+	    |         |     is rarely necessary.
+	 34 | ERROR   | [x] Expected 1 spaces before closing bracket; 0 found
+	 39 | WARNING | [ ] Silencing errors is discouraged
+	 39 | WARNING | [ ] Silencing errors is discouraged
+	 46 | ERROR   | [ ] Inline comments must end in full-stops, exclamation marks,
+	    |         |     or question marks
+	 46 | ERROR   | [x] There must be no blank line following an inline comment
+	 63 | WARNING | [ ] Detected access of super global var $_SERVER, probably
+	    |         |     needs manual inspection.
+	 63 | ERROR   | [ ] Detected usage of a non-validated input variable: $_SERVER
+	 63 | ERROR   | [ ] Missing wp_unslash() before sanitization.
+	 63 | ERROR   | [ ] Detected usage of a non-sanitized input variable: $_SERVER
+	 74 | ERROR   | [ ] Inline comments must end in full-stops, exclamation marks,
+	    |         |     or question marks
+	 90 | ERROR   | [x] String "Create a Configuration File" does not require
+	    |         |     double quotes; use single quotes instead
+	 92 | ERROR   | [ ] Expected next thing to be an escaping function (see Codex
+	    |         |     for 'Data Validation'), not '$die'
+	 92 | ERROR   | [ ] Expected next thing to be an escaping function (see Codex
+	    |         |     for 'Data Validation'), not '__'
+	--------------------------------------------------------------------------------
+	PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
+	--------------------------------------------------------------------------------
+
+### PhpStorm
+
+Please see "[PHP Code Sniffer with WordPress Coding Standards Integration](https://confluence.jetbrains.com/display/PhpStorm/WordPress+Development+using+PhpStorm#WordPressDevelopmentusingPhpStorm-PHPCodeSnifferwithWordPressCodingStandardsIntegrationinPhpStorm)" in the PhpStorm documentation.
+
+### Sublime Text
+
+##### sublime-phpcs package
+Install the [sublime-phpcs package](https://github.com/benmatselby/sublime-phpcs), then use the "Switch coding standard" command in the Command Palette to switch between coding standards.
+
+##### SublimeLinter-phpcs
+sublime-phpcs is insanely powerful, but if you'd prefer automatic linting, [SublimeLinter-phpcs](https://github.com/SublimeLinter/SublimeLinter-phpcs/) can do that.
+
+- Install PHP Sniffer and WordPress Coding Standards per above.
+- Use [Package Control](https://packagecontrol.io/) to search for and install [SublimeLinter](http://www.sublimelinter.com) then [SublimeLinter-phpcs](https://github.com/SublimeLinter/SublimeLinter-phpcs/).
+- From the command palette, select `Preferences: SublimeLinter Settings - User` and change `user.linters.phpcs.standard` to the phpcs standard of your choice (e.g. `WordPress`, `WordPress-VIP`, etc.).
+
+![SublimeLinter-phpcs user settings](https://cloud.githubusercontent.com/assets/224636/12946250/068776ba-cfc1-11e5-816b-109e4e32d21b.png)
+
+- You may need to restart Sublime for these settings to take effect. Error messages appear in the bottom of the editor.
+
+![SublimeLinter-phpcs linting](https://cloud.githubusercontent.com/assets/224636/12946326/75986c3a-cfc1-11e5-8537-1243554bbab6.png)
+
+![SublimeLinter-phpcs error](https://cloud.githubusercontent.com/assets/224636/12946335/8bee5a30-cfc1-11e5-8b5f-b10e8e4a4909.png)
+
+### Atom
+
+- Install PHP Sniffer and WordPress Coding Standards per above.
+- Install [linter-phpcs](https://atom.io/packages/linter-phpcs) via Atom's package manager.
+- Run `which phpcs` to get your `phpcs` executable path.
+- Open the linter-phpcs package settings; enter your `phpcs` executable path and one of the coding standards specified above (e.g. `WordPress`, `WordPress-VIP`, etc.).
+- Below these settings find the Tab Width setting and change it to `4`.
+
+![Atom Linter WordPress Coding Standards configuration](https://cloud.githubusercontent.com/assets/224636/12740504/ce4e97b8-c941-11e5-8d83-c77a2470d58e.png)
+
+![Atom Linter in action using WordPress Coding Standards](https://cloud.githubusercontent.com/assets/224636/12740542/131c5894-c942-11e5-9e31-5e020c993224.png)
+
+- Note that certain items within PHPCS config file can cause linting to fail, see [linter-phpcs #95](https://github.com/AtomLinter/linter-phpcs/issues/95#issuecomment-316133107) for more details.
+
+### Visual Studio
+
+Please see "[Setting up PHP CodeSniffer in Visual Studio Code](https://tommcfarlin.com/php-codesniffer-in-visual-studio-code/)", a tutorial by Tom McFarlin.
+
+
+## Running your code through WPCS automatically using CI tools
+
+### [Travis CI](https://travis-ci.org/)
+
+To integrate PHPCS with WPCS with Travis CI, you'll need to install both `before_install` and add the run command to the `script`.
+If your project uses Composer, the typical instructions might be different.
+
+If you use a matrix setup in Travis to test your code against different PHP and/or WordPress versions, you don't need to run PHPCS on each variant of the matrix as the results will be same.
+You can set an environment variable in the Travis matrix to only run the sniffs against one setup in the matrix.
+
+#### Travis CI example
+```yaml
+language: php
+
+matrix:
+  include:
+    # Arbitrary PHP version to run the sniffs against.
+    - php: '7.0'
+      env: SNIFF=1
+
+before_install:
+  - if [[ "$SNIFF" == "1" ]]; then export PHPCS_DIR=/tmp/phpcs; fi
+  - if [[ "$SNIFF" == "1" ]]; then export SNIFFS_DIR=/tmp/sniffs; fi
+  # Install PHP_CodeSniffer.
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
+  # Install WordPress Coding Standards.
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+  # Set install path for WordPress Coding Standards.
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $SNIFFS_DIR; fi
+  # After CodeSniffer install you should refresh your path.
+  - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
+
+script:
+  # Run against WordPress Coding Standards.
+  # If you use a custom ruleset, change `--standard=WordPress` to point to your ruleset file,
+  # for example: `--standard=wpcs.xml`.
+  # You can use any of the normal PHPCS command line arguments in the command:
+  # https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs -p . --standard=WordPress; fi
+```
+
+
+## Fixing errors or whitelisting them
+
+You can find information on how to deal with some of the more frequent issues in the [wiki](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki).
+
+
+## Contributing
+
+See [CONTRIBUTING](.github/CONTRIBUTING.md), including information about [unit testing](.github/CONTRIBUTING.md#unit-testing) the standard.
+
+## License
+
+See [LICENSE](LICENSE) (MIT).

--- a/ci/wpcs/WordPress-Core/ruleset.xml
+++ b/ci/wpcs/WordPress-Core/ruleset.xml
@@ -1,0 +1,468 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Core">
+	<description>Non-controversial generally-agreed upon WordPress Coding Standards</description>
+
+	<autoload>./../WordPress/PHPCSAliases.php</autoload>
+
+	<!-- Treat all files as UTF-8. -->
+	<config name="encoding" value="utf-8"/>
+
+	<!-- Default tab width for indentation fixes and such. -->
+	<arg name="tab-width" value="4"/>
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Single and Double Quotes.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#single-and-double-quotes
+	#############################################################################
+	-->
+	<!-- Covers rule: Use single and double quotes when appropriate.
+		 If you're not evaluating anything in the string, use single quotes. -->
+	<rule ref="Squiz.Strings.DoubleQuoteUsage"/>
+	<rule ref="Squiz.Strings.DoubleQuoteUsage.ContainsVar">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Rule: Text that goes into attributes should be run through esc_attr().
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/527 -->
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Indentation.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#indentation
+	#############################################################################
+	-->
+	<!-- Covers rule: Your indentation should always reflect logical structure. -->
+	<rule ref="Generic.WhiteSpace.ScopeIndent">
+		<properties>
+			<property name="exact" value="false"/>
+			<property name="indent" value="4"/>
+			<property name="tabIndent" value="true"/>
+			<property name="ignoreIndentationTokens" type="array" value="T_HEREDOC,T_NOWDOC,T_INLINE_HTML"/>
+		</properties>
+	</rule>
+	<rule ref="WordPress.Arrays.ArrayIndentation"/>
+
+	<!-- Covers rule: Use real tabs and not spaces. -->
+	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+	<rule ref="WordPress.WhiteSpace.PrecisionAlignment"/>
+
+	<!-- Generic array layout check. -->
+	<!-- Covers rule: For associative arrays, values should start on a new line.
+		 Also covers various single-line array whitespace issues. -->
+	<rule ref="WordPress.Arrays.ArrayDeclarationSpacing"/>
+
+	<!-- Covers rule: Note the comma after the last array item: this is recommended. -->
+	<rule ref="WordPress.Arrays.CommaAfterArrayItem"/>
+
+	<!-- Covers rule: For switch structures case should indent one tab from the
+	     switch statement and break one tab from the case statement. -->
+	<rule ref="PSR2.ControlStructures.SwitchDeclaration">
+		<!-- Prevent duplicate messages for the same issue. Covered by other sniffs. -->
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.NotLower"/>
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine"/>
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLine"/>
+	</rule>
+
+	<!-- Covers rule: ... while spaces can be used mid-line for alignment. -->
+	<rule ref="WordPress.WhiteSpace.DisallowInlineTabs"/>
+
+	<!-- Implied through the examples: align the assignment operator in a block of assignments. -->
+	<rule ref="Generic.Formatting.MultipleStatementAlignment">
+		<properties>
+			<property name="maxPadding" value="40"/>
+		</properties>
+	</rule>
+
+	<!-- Implied through the examples: align the double arrows. -->
+	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<properties>
+			<property name="maxColumn" value="60"/>
+		</properties>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Brace Style.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#brace-style
+	#############################################################################
+	-->
+	<!-- Covers rule: Braces shall be used for all blocks. -->
+	<rule ref="Squiz.ControlStructures.ControlSignature"/>
+
+	<!-- Covers rule: Braces should always be used, even when they are not required. -->
+	<rule ref="Generic.ControlStructures.InlineControlStructure"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Use elseif, not else if.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#use-elseif-not-else-if
+	#############################################################################
+	-->
+	<rule ref="PSR2.ControlStructures.ElseIfDeclaration"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Regular Expressions.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#regular-expressions
+	#############################################################################
+	-->
+	<!-- Covers rule: Perl compatible regular expressions should be used in preference
+		 to their POSIX counterparts. -->
+	<rule ref="WordPress.PHP.POSIXFunctions"/>
+
+	<!-- Rule: Never use the /e switch, use preg_replace_callback instead.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/632 -->
+
+	<!-- Rule: It's most convenient to use single-quoted strings for regular expressions.
+		 Already covered by Squiz.Strings.DoubleQuoteUsage -->
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Opening and Closing PHP Tags.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#opening-and-closing-php-tags
+	#############################################################################
+	-->
+	<!-- Covers rule: When embedding multi-line PHP snippets within a HTML block, the
+	     PHP open and close tags must be on a line by themselves. -->
+	<rule ref="Squiz.PHP.EmbeddedPhp">
+		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingBefore"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp.Indent"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp.OpenTagIndent"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingAfter"/>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - No Shorthand PHP Tags.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#no-shorthand-php-tags
+	#############################################################################
+	-->
+	<!-- Covers rule: Never use shorthand PHP start tags. Always use full PHP tags. -->
+	<rule ref="Generic.PHP.DisallowShortOpenTag"/>
+	<rule ref="Generic.PHP.DisallowAlternativePHPTags"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Remove Trailing Spaces.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#remove-trailing-spaces
+	#############################################################################
+	-->
+	<!-- Covers rule: Remove trailing whitespace at the end of each line of code. -->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+
+	<!-- Covers rule: Omitting the closing PHP tag at the end of a file is preferred. -->
+	<rule ref="PSR2.Files.ClosingTag"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Space Usage.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#space-usage
+	#############################################################################
+	-->
+	<!-- Covers rule: Always put spaces after commas, and on both sides of logical,
+		 comparison, string and assignment operators. -->
+	<rule ref="WordPress.WhiteSpace.OperatorSpacing"/>
+	<rule ref="Squiz.Strings.ConcatenationSpacing">
+		<properties>
+			<property name="spacing" value="1"/>
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
+	</rule>
+
+	<!-- Covers rule: Put spaces on both sides of the opening and closing parenthesis of
+		 if, elseif, foreach, for, and switch blocks. -->
+	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing"/>
+
+	<!-- Covers rule: Define a function like so: function my_function( $param1 = 'foo', $param2 = 'bar' ) { -->
+	<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie">
+		<properties>
+			<property name="checkClosures" value="true"/>
+		</properties>
+	</rule>
+	<rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+		<properties>
+			<property name="equalsSpacing" value="1"/>
+			<property name="requiredSpacesAfterOpen" value="1"/>
+			<property name="requiredSpacesBeforeClose" value="1"/>
+		</properties>
+		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose"/>
+	</rule>
+
+	<!-- Covers rule: Call a function, like so: my_function( $param1, func_param( $param2 ) ); -->
+	<rule ref="PEAR.Functions.FunctionCallSignature">
+		<properties>
+			<property name="requiredSpacesAfterOpen" value="1"/>
+			<property name="requiredSpacesBeforeClose" value="1"/>
+		</properties>
+	</rule>
+	<rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
+		<severity phpcs-only="true">0</severity>
+	</rule>
+	<rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
+		<severity phpcs-only="true">0</severity>
+	</rule>
+	<!-- Related to issue #970 / https://github.com/squizlabs/PHP_CodeSniffer/issues/1512 -->
+	<rule ref="WordPress.Functions.FunctionCallSignatureNoParams"/>
+
+	<rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+
+	<!-- Rule: Perform logical comparisons, like so: if ( ! $foo ) { -->
+
+	<!-- Covers rule: When type casting, do it like so: $foo = (boolean) $bar; -->
+	<rule ref="Generic.Formatting.SpaceAfterCast"/>
+	<rule ref="Squiz.WhiteSpace.CastSpacing"/>
+	<rule ref="WordPress.WhiteSpace.CastStructureSpacing"/>
+
+	<!-- Covers rule: ... array items, only include a space around the index if it is a variable. -->
+	<rule ref="WordPress.Arrays.ArrayKeySpacingRestrictions"/>
+
+	<!-- Rule: In a switch block, there must be no space before the colon for a case statement. -->
+	<!-- Covered by the PSR2.ControlStructures.SwitchDeclaration sniff. -->
+
+	<!-- Rule: Similarly, there should be no space before the colon on return type declarations. -->
+
+	<!-- Covers rule: Unless otherwise specified, parentheses should have spaces inside of them. -->
+	<!-- Duplicate of upstream. Should defer to upstream version once minimum PHPCS requirement has gone up.
+		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1701 -->
+	<rule ref="WordPress.WhiteSpace.ArbitraryParenthesesSpacing">
+		<properties>
+			<property name="spacingInside" value="1"/>
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Formatting SQL statements.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#formatting-sql-statements
+	#############################################################################
+	-->
+	<!-- Rule: Always capitalize the SQL parts of the statement like UPDATE or WHERE.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/639 -->
+
+	<!-- Rule: Functions that update the database should expect their parameters to lack
+		 SQL slash escaping when passed.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/640 -->
+
+	<!-- Rule: in $wpdb->prepare - only %s and %d are used as placeholders. Note that they are not "quoted"! -->
+	<rule ref="WordPress.DB.PreparedSQLPlaceholders"/>
+
+	<!-- Covers rule: Escaping should be done as close to the time of the query as possible,
+		 preferably by using $wpdb->prepare() -->
+	<rule ref="WordPress.WP.PreparedSQL"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Database Queries.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#database-queries
+	#############################################################################
+	-->
+	<!-- Covers rule: Avoid touching the database directly. -->
+	<rule ref="WordPress.DB.RestrictedFunctions"/>
+	<rule ref="WordPress.DB.RestrictedClasses"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Naming Conventions.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#naming-conventions
+	#############################################################################
+	-->
+	<!-- Covers rule: Use lowercase letters in variable, action, and function names.
+		 Separate words via underscores. -->
+	<rule ref="WordPress.NamingConventions.ValidFunctionName"/>
+	<rule ref="WordPress.NamingConventions.ValidHookName"/>
+	<rule ref="WordPress.NamingConventions.ValidVariableName"/>
+
+	<!-- Covers rule: Class names should use capitalized words separated by underscores. -->
+	<rule ref="PEAR.NamingConventions.ValidClassName"/>
+
+	<!-- Covers rule: Constants should be in all upper-case with underscores separating words. -->
+	<rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
+
+	<!-- Covers rule: Files should be named descriptively using lowercase letters.
+		 Hyphens should separate words. -->
+	<!-- Covers rule: Class file names should be based on the class name with "class-"
+		 prepended and the underscores in the class name replaced with hyphens.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/642 -->
+	<!-- Covers rule: Files containing template tags in wp-includes should have "-template"
+		 appended to the end of the name.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/642 -->
+	<rule ref="WordPress.Files.FileName"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Self-Explanatory Flag Values for Function Arguments.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#self-explanatory-flag-values-for-function-arguments
+	#############################################################################
+	-->
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Interpolation for Naming Dynamic Hooks.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#interpolation-for-naming-dynamic-hooks
+
+	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/751
+	#############################################################################
+	-->
+	<!-- Rule: Dynamic hooks should be named using interpolation rather than concatenation. -->
+
+	<!-- Rule: Variables used in hook tags should be wrapped in curly braces { and },
+		 with the complete outer tag name wrapped in double quotes. -->
+
+	<!-- Rule: Where possible, dynamic values in tag names should also be as succinct
+		 and to the point as possible. -->
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Ternary Operator.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#ternary-operator
+	#############################################################################
+	-->
+	<!-- Rule: Always have Ternaries test if the statement is true, not false.
+		 An exception would be using ! empty(), as testing for false here is generally more intuitive.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/643 -->
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Yoda Conditions.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#yoda-conditions
+	#############################################################################
+	-->
+	<!-- Covers rule: When doing logical comparisons, always put the variable on the right side,
+		 constants or literals on the left. -->
+	<rule ref="WordPress.PHP.YodaConditions"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Clever Code.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#clever-code
+	#############################################################################
+	-->
+	<!-- Rule: In general, readability is more important than cleverness or brevity.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/607 -->
+	<rule ref="Squiz.PHP.DisallowMultipleAssignments"/>
+	<rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+
+	<!-- Rule: In a switch statement... If a case contains a block, then falls through
+	     to the next block, this must be explicitly commented. -->
+	<!-- Covered by the PSR2.ControlStructures.SwitchDeclaration sniff. -->
+
+	<!-- Rule: The goto statement must never be used. -->
+	<!-- Duplicate of upstream. Should defer to upstream version once minimum PHPCS requirement has gone up.
+		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1664 -->
+	<rule ref="WordPress.PHP.DiscourageGoto"/>
+	<rule ref="WordPress.PHP.DiscourageGoto.Found">
+		<type>error</type>
+		<message>The "goto" language construct should not be used.</message>
+	</rule>
+
+	<!-- Rule: The eval() construct is very dangerous, and is impossible to secure. ... these must not be used. -->
+	<rule ref="Squiz.PHP.Eval"/>
+	<rule ref="Squiz.PHP.Eval.Discouraged">
+		<type>error</type>
+		<message>eval() is a security risk so not allowed.</message>
+	</rule>
+
+	<!-- Rule: create_function() function, which internally performs an eval(),
+	     is deprecated in PHP 7.2. Both of these must not be used. -->
+	<rule ref="WordPress.PHP.RestrictedPHPFunctions"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - (No) Error Control Operator @.
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#error-control-operator
+	#############################################################################
+	-->
+	<rule ref="Generic.PHP.NoSilencedErrors"/>
+
+
+	<!--
+	#############################################################################
+	Handbook: PHP - Don't extract().
+	Ref: https://make.wordpress.org/core/handbook/coding-standards/php/#dont-extract
+	#############################################################################
+	-->
+	<rule ref="WordPress.Functions.DontExtract"/>
+
+
+	<!--
+	#############################################################################
+	Not in the handbook: Generic sniffs.
+	#############################################################################
+	-->
+	<!-- Important to prevent issues with content being sent before headers. -->
+	<rule ref="Generic.Files.ByteOrderMark"/>
+
+	<!-- All line endings should be \n. -->
+	<rule ref="Generic.Files.LineEndings">
+		<properties>
+			<property name="eolChar" value="\n"/>
+		</properties>
+	</rule>
+
+	<!-- All files should end with a new line. -->
+	<rule ref="Generic.Files.EndFileNewline"/>
+
+	<!-- No whitespace should come before semicolons. -->
+	<!-- Extends upstream sniff. Should defer to upstream version once minimum PHPCS requirement
+		 has gone up to version containing bugfix.
+		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1691 -->
+	<rule ref="WordPress.WhiteSpace.SemicolonSpacing"/>
+
+	<!-- Lowercase PHP constants, like true, false and null. -->
+	<!-- http://make.wordpress.org/core/handbook/coding-standards/php/#naming-conventions -->
+	<rule ref="Generic.PHP.LowerCaseConstant"/>
+
+	<!-- Lowercase PHP keywords, like class, function and case. -->
+	<rule ref="Generic.PHP.LowerCaseKeyword"/>
+
+	<!-- Class opening braces should be on the same line as the statement. -->
+	<rule ref="Generic.Classes.OpeningBraceSameLine"/>
+
+	<!-- Object operators should not have whitespace around them unless they are multi-line. -->
+	<rule ref="Squiz.WhiteSpace.ObjectOperatorSpacing">
+		<properties>
+			<property name="ignoreNewlines" value="true"/>
+		</properties>
+	</rule>
+
+	<!-- References to self in a class should be lower-case and not have extraneous spaces,
+		 per implicit conventions in the core codebase; the NotUsed code refers to using the
+		 fully-qualified class name instead of self, for which there are instances in core. -->
+	<rule ref="Squiz.Classes.SelfMemberReference"/>
+	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed">
+		<severity>0</severity>
+	</rule>
+
+	<!--
+	#############################################################################
+	Not in the coding standard handbook: WP specific sniffs.
+	Ref: https://make.wordpress.org/core/handbook/best-practices/internationalization/ (limited info)
+	Ref: https://developer.wordpress.org/plugins/internationalization/ (more extensive)
+	#############################################################################
+	-->
+	<!-- Check for correct usage of the WP i18n functions. -->
+	<rule ref="WordPress.WP.I18n"/>
+
+	<!-- Check for correct spelling of WordPress. -->
+	<rule ref="WordPress.WP.CapitalPDangit"/>
+
+</ruleset>

--- a/ci/wpcs/WordPress-Docs/ruleset.xml
+++ b/ci/wpcs/WordPress-Docs/ruleset.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Docs">
+	<description>WordPress Coding Standards for Inline Documentation and Comments</description>
+
+	<!--
+		Handbook: PHP Documentation Standards
+		Ref: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
+	-->
+
+	<rule ref="Squiz.Commenting">
+		<!-- Excluded to allow /* translators: ... */ comments -->
+		<exclude name="Squiz.Commenting.BlockComment.SingleLine"/>
+		<!-- Sniff seems to require indenting with spaces -->
+		<exclude name="Squiz.Commenting.BlockComment.FirstLineIndent"/>
+		<!-- Sniff seems to require indenting with spaces -->
+		<exclude name="Squiz.Commenting.BlockComment.LineIndent"/>
+		<!-- Sniff seems to require indenting with spaces -->
+		<exclude name="Squiz.Commenting.BlockComment.LastLineIndent"/>
+		<!-- WP requires /** for require() et al. See https://github.com/squizlabs/PHP_CodeSniffer/pull/581 -->
+		<exclude name="Squiz.Commenting.BlockComment.WrongStart"/>
+		<!-- WP handbook doesn't clarify one way or another, so ignore -->
+		<exclude name="Squiz.Commenting.BlockComment.NoEmptyLineAfter"/>
+
+		<!-- WP prefers indicating @since, @package, @subpackage etc in class comments -->
+		<exclude name="Squiz.Commenting.ClassComment.TagNotAllowed"/>
+
+		<!-- WP doesn't require //end ... for classes and functions -->
+		<exclude name="Squiz.Commenting.ClosingDeclarationComment.Missing"/>
+
+		<!-- Excluded to allow param documentation for arrays  -->
+		<exclude name="Squiz.Commenting.DocCommentAlignment.SpaceAfterStar"/>
+
+		<!-- WP doesn't require a @author value for Squiz -->
+		<exclude name="Squiz.Commenting.FileComment.IncorrectAuthor"/>
+		<!-- WP doesn't require a @copyright value for Squiz -->
+		<exclude name="Squiz.Commenting.FileComment.IncorrectCopyright"/>
+		<!-- WP doesn't require @author tags -->
+		<exclude name="Squiz.Commenting.FileComment.MissingAuthorTag"/>
+		<!-- WP doesn't require @subpackage tags -->
+		<exclude name="Squiz.Commenting.FileComment.MissingSubpackageTag"/>
+		<!-- WP doesn't require @copyright tags -->
+		<exclude name="Squiz.Commenting.FileComment.MissingCopyrightTag"/>
+		<!-- WP has a different prefered order of tags -->
+		<exclude name="Squiz.Commenting.FileComment.PackageTagOrder"/>
+		<!-- WP has a different prefered order of tags -->
+		<exclude name="Squiz.Commenting.FileComment.SubpackageTagOrder"/>
+		<!-- WP has a different prefered order of tags -->
+		<exclude name="Squiz.Commenting.FileComment.AuthorTagOrder"/>
+		<!-- WP has a different prefered order of tags -->
+		<exclude name="Squiz.Commenting.FileComment.CopyrightTagOrder"/>
+
+		<!-- WP prefers int and bool instead of integer and boolean -->
+		<exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName"/>
+		<!-- WP prefers int and bool instead of integer and boolean -->
+		<exclude name="Squiz.Commenting.FunctionComment.InvalidReturn"/>
+		<!-- WP prefers indicating a @return null for early returns -->
+		<exclude name="Squiz.Commenting.FunctionComment.InvalidReturnNotVoid"/>
+		<!-- WP states not all functions require @return -->
+		<exclude name="Squiz.Commenting.FunctionComment.MissingReturn"/>
+		<!-- Excluded to allow param documentation for arrays  -->
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentNotCapital"/>
+		<!-- Excluded to allow param documentation for arrays  -->
+		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamName"/>
+		<!-- WP doesn't require type hints -->
+		<exclude name="Squiz.Commenting.FunctionComment.TypeHintMissing"/>
+
+		<!-- Exclude to allow duplicate hooks to be documented -->
+		<exclude name="Squiz.Commenting.InlineComment.DocBlock"/>
+		<!-- Excluded to allow /* translators: ... */ comments -->
+		<exclude name="Squiz.Commenting.InlineComment.NotCapital"/>
+
+		<!-- Not in Inline Docs standard, and a code smell -->
+		<exclude name="Squiz.Commenting.LongConditionClosingComment"/>
+
+		<!-- Not in Inline Docs standard, and needed to bypass WPCS checks -->
+		<exclude name="Squiz.Commenting.PostStatementComment"/>
+
+		<!-- WP prefers int and bool instead of integer and boolean -->
+		<exclude name="Squiz.Commenting.VariableComment.IncorrectVarType"/>
+		<!-- WP demands a @since tag for class variables -->
+		<exclude name="Squiz.Commenting.VariableComment.TagNotAllowed"/>
+		<!-- WP prefers @since first -->
+		<exclude name="Squiz.Commenting.VariableComment.VarOrder"/>
+
+		<!-- It is too early for PHP7 features to be required -->
+		<exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing"/>
+	</rule>
+
+	<!-- Make this sniff less likely to trigger on end comments. -->
+	<rule ref="Squiz.PHP.CommentedOutCode">
+		<properties>
+			<property name="maxPercentage" value="45"/>
+		</properties>
+	</rule>
+
+	<rule ref="Generic.Commenting">
+		<!-- WP has different alignment of tag values -->
+		<exclude name="Generic.Commenting.DocComment.TagValueIndent"/>
+		<!-- WP has a different prefered order of tags -->
+		<exclude name="Generic.Commenting.DocComment.ParamNotFirst"/>
+		<!-- Excluded to allow param documentation for arrays  -->
+		<exclude name="Generic.Commenting.DocComment.ParamGroup"/>
+		<!-- WP prefers no empty line between @param tags and @return -->
+		<exclude name="Generic.Commenting.DocComment.NonParamGroup"/>
+		<!-- Excluded to allow param documentation for arrays  -->
+		<exclude name="Generic.Commenting.DocComment.TagsNotGrouped"/>
+		<!-- Exclude to allow duplicate hooks to be documented -->
+		<exclude name="Generic.Commenting.DocComment.ContentAfterOpen"/>
+		<!-- Exclude to allow duplicate hooks to be documented -->
+		<exclude name="Generic.Commenting.DocComment.SpacingBeforeShort"/>
+		<!-- Exclude to allow duplicate hooks to be documented -->
+		<exclude name="Generic.Commenting.DocComment.ContentBeforeClose"/>
+
+		<!-- WP allows @todo's in comments -->
+		<exclude name="Generic.Commenting.Todo.CommentFound"/>
+		<!-- WP allows @todo's in comments -->
+		<exclude name="Generic.Commenting.Todo.TaskFound"/>
+	</rule>
+</ruleset>

--- a/ci/wpcs/WordPress-Extra/ruleset.xml
+++ b/ci/wpcs/WordPress-Extra/ruleset.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Extra">
+	<description>Best practices beyond core WordPress Coding Standards</description>
+
+	<autoload>./../WordPress/PHPCSAliases.php</autoload>
+
+	<!-- Generic PHP best practices.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382 -->
+	<rule ref="Generic.PHP.DeprecatedFunctions"/>
+	<rule ref="Generic.PHP.ForbiddenFunctions"/>
+	<rule ref="Generic.Functions.CallTimePassByReference"/>
+	<rule ref="Generic.CodeAnalysis.EmptyStatement"/>
+	<rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
+	<rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
+	<rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
+	<rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
+	<rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
+	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
+	<rule ref="Generic.Classes.DuplicateClassName"/>
+	<rule ref="Generic.Strings.UnnecessaryStringConcat">
+		<properties>
+			<property name="allowMultiline" value="true"/>
+		</properties>
+	</rule>
+	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
+
+	<!-- Duplicate of upstream. Can be removed once minimum PHPCS requirement has gone up.
+		 https://github.com/squizlabs/PHP_CodeSniffer/pull/1594 -->
+	<rule ref="WordPress.CodeAnalysis.AssignmentInCondition"/>
+
+	<!-- More generic PHP best practices.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/607 -->
+	<rule ref="Squiz.PHP.NonExecutableCode"/>
+	<rule ref="Squiz.Operators.IncrementDecrementUsage"/>
+	<rule ref="Squiz.Operators.ValidLogicalOperators"/>
+	<rule ref="Squiz.Functions.FunctionDuplicateArgument"/>
+
+	<!-- And even more generic PHP best practices.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/809 -->
+	<rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
+
+	<!-- And yet more best practices.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1143 -->
+	<rule ref="PEAR.Files.IncludingFile">
+		<exclude name="PEAR.Files.IncludingFile.UseInclude"/>
+		<exclude name="PEAR.Files.IncludingFile.UseIncludeOnce"/>
+	</rule>
+	<rule ref="PEAR.Files.IncludingFile.BracketsNotRequired">
+		<type>warning</type>
+	</rule>
+	<rule ref="PEAR.Files.IncludingFile.UseRequire">
+		<type>warning</type>
+	</rule>
+	<rule ref="PEAR.Files.IncludingFile.UseRequireOnce">
+		<type>warning</type>
+	</rule>
+
+	<!-- Check correct spacing of language constructs. This also ensures that the
+	     above rule for not using brackets with require is fixed correctly.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1153 -->
+	<rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+
+	<!-- Hook callbacks may not use all params -->
+	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/382#discussion_r29981655 -->
+	<!--<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>-->
+
+	<!-- Encourage having only one class/interface/trait per file. -->
+	<!-- Once the minimum WPCS PHPCS requirement has gone up to PHPCS 3.1.0, these three sniffs can be
+	     replaced by the more comprehensive Generic.Files.OneObjectStructurePerFile sniff. -->
+	<rule ref="Generic.Files.OneClassPerFile"/>
+	<rule ref="Generic.Files.OneClassPerFile.MultipleFound">
+		<type>warning</type>
+		<message>Best practice suggestion: Declare only one class in a file.</message>
+	</rule>
+	<rule ref="Generic.Files.OneInterfacePerFile"/>
+	<rule ref="Generic.Files.OneInterfacePerFile.MultipleFound">
+		<type>warning</type>
+		<message>Best practice suggestion: Declare only one interface in a file.</message>
+	</rule>
+	<rule ref="Generic.Files.OneTraitPerFile"/>
+	<rule ref="Generic.Files.OneTraitPerFile.MultipleFound">
+		<type>warning</type>
+		<message>Best practice suggestion: Declare only one trait in a file.</message>
+	</rule>
+
+	<rule ref="WordPress-Core"/>
+
+	<!-- Verify modifier keywords for declared methods and properties in classes.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1101 -->
+	<rule ref="Squiz.Scope.MethodScope"/>
+	<rule ref="Squiz.Scope.MemberVarScope"/>
+	<rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
+	<rule ref="PSR2.Methods.MethodDeclaration"/>
+	<rule ref="PSR2.Methods.MethodDeclaration.Underscore">
+		<type>warning</type>
+	</rule>
+
+	<!-- Warn against using fully-qualified class names instead of the self keyword. -->
+	<rule ref="Squiz.Classes.SelfMemberReference.NotUsed">
+		<!-- Restore default severity of 5 which WordPress-Core sets to 0. -->
+		<severity>5</severity>
+	</rule>
+
+	<rule ref="WordPress.XSS.EscapeOutput"/>
+
+	<!-- Verify that a nonce check is done before using values in superglobals.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/73 -->
+	<rule ref="WordPress.CSRF.NonceVerification"/>
+
+	<rule ref="WordPress.PHP.DevelopmentFunctions"/>
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions"/>
+	<rule ref="WordPress.WP.DeprecatedFunctions"/>
+	<rule ref="WordPress.WP.DeprecatedClasses"/>
+	<rule ref="WordPress.WP.DeprecatedParameters"/>
+	<rule ref="WordPress.WP.AlternativeFunctions"/>
+	<rule ref="WordPress.WP.DiscouragedConstants"/>
+	<rule ref="WordPress.WP.DiscouragedFunctions"/>
+
+	<!-- Scripts & style should be enqueued.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/35 -->
+	<rule ref="WordPress.WP.EnqueuedResources"/>
+
+	<!-- Warn against overriding WP global variables.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/26 -->
+	<rule ref="WordPress.Variables.GlobalVariables"/>
+
+	<!-- Encourage the use of strict ( === and !== ) comparisons.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/242 -->
+	<rule ref="WordPress.PHP.StrictComparisons"/>
+
+	<!-- Check that in_array() and array_search() use strict comparisons.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/399
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/503 -->
+	<rule ref="WordPress.PHP.StrictInArray"/>
+
+	<!-- Discourage use of the backtick operator (execution of shell commands).
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/646 -->
+	<rule ref="Generic.PHP.BacktickOperator"/>
+
+	<!-- Check for PHP Parse errors.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/522 -->
+	<rule ref="Generic.PHP.Syntax"/>
+
+	<!-- Make the translators comment check which is included in core stricter. -->
+	<rule ref="WordPress.WP.I18n.MissingTranslatorsComment">
+		<type>error</type>
+	</rule>
+	<rule ref="WordPress.WP.I18n.TranslatorsCommentWrongStyle">
+		<type>error</type>
+	</rule>
+
+	<!-- Verify that everything in the global namespace is prefixed. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals"/>
+
+	<!-- Check that object instantiations always have braces & are not assigned by reference.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/919 -->
+	<rule ref="WordPress.Classes.ClassInstantiation"/>
+
+
+	<!--
+	#############################################################################
+	Code style sniffs for more recent PHP features and syntaxes.
+	#############################################################################
+	-->
+
+	<!-- Check for single blank line after namespace declaration. -->
+	<rule ref="PSR2.Namespaces.NamespaceDeclaration"/>
+
+</ruleset>

--- a/ci/wpcs/WordPress-VIP/ruleset.xml
+++ b/ci/wpcs/WordPress-VIP/ruleset.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress VIP">
+	<description>WordPress VIP Coding Standards</description>
+
+	<autoload>./../WordPress/PHPCSAliases.php</autoload>
+
+	<rule ref="WordPress-Core"/>
+
+	<!-- Covers:
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#removing-the-admin-bar
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#cron-schedules-less-than-15-minutes-or-expensive-events
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#direct-database-queries
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#filesystem-writes
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#order-by-rand
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-__file__-for-page-registration
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#uncached-functions
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#flush_rewrite_rules
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#session_start-and-other-session-related-functions
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#functions-that-use-joins-taxonomy-relation-queries-cat-tax-queries-subselects-or-api-calls
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#querying-on-meta_value
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#manipulating-the-timezone-server-side
+		 https://vip.wordpress.com/documentation/code-review-what-we-look-for/#validation-sanitization-and-escaping
+	-->
+	<rule ref="WordPress.VIP"/>
+
+	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#validation-sanitization-and-escaping -->
+	<!-- https://vip.wordpress.com/documentation/best-practices/security/validating-sanitizing-escaping/ -->
+	<rule ref="WordPress.XSS.EscapeOutput"/>
+	<rule ref="WordPress.CSRF.NonceVerification"/>
+
+	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-instead-of -->
+	<rule ref="WordPress.PHP.StrictComparisons"/>
+
+	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output -->
+	<rule ref="Squiz.PHP.CommentedOutCode">
+		<properties>
+			<property name="maxPercentage" value="45"/>
+		</properties>
+	</rule>
+
+	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#eval-and-create_function -->
+	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#serializing-data -->
+	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#encoding-values-used-when-creating-a-url-or-passed-to-add_query_arg -->
+	<!-- https://github.com/Automattic/vip-scanner/blob/master/vip-scanner/checks/ForbiddenPHPFunctionsCheck.php -->
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+		<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/633#issuecomment-266634811 -->
+		<properties>
+			<property name="exclude" value="obfuscation"/>
+		</properties>
+	</rule>
+	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#settings-alteration -->
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration">
+		<type>error</type>
+	</rule>
+
+	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#commented-out-code-debug-code-or-output -->
+	<rule ref="WordPress.PHP.DevelopmentFunctions"/>
+	<rule ref="WordPress.PHP.DevelopmentFunctions.error_log">
+		<type>error</type>
+	</rule>
+	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#settings-alteration -->
+	<rule ref="WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure">
+		<type>error</type>
+	</rule>
+
+	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-in_array-without-strict-parameter -->
+	<rule ref="WordPress.PHP.StrictInArray"/>
+
+	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_parse_url-instead-of-parse_url -->
+	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_json_encode-over-json_encode -->
+	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#filesystem-writes -->
+	<!-- https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#remote-calls -->
+	<rule ref="WordPress.WP.AlternativeFunctions"/>
+	<!-- VIP recommends other functions -->
+	<rule ref="WordPress.WP.AlternativeFunctions.curl">
+		<message>Using cURL functions is highly discouraged within VIP context. Check (Fetching Remote Data) on VIP Documentation.</message>
+	</rule>
+	<rule ref="WordPress.WP.AlternativeFunctions.file_get_contents">
+		<message>%s() is highly discouraged, please use vip_safe_wp_remote_get() instead.</message>
+	</rule>
+
+	<!-- https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-theme-constants -->
+	<rule ref="WordPress.WP.DiscouragedConstants"/>
+
+</ruleset>

--- a/ci/wpcs/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
+++ b/ci/wpcs/WordPress/AbstractArrayAssignmentRestrictionsSniff.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress;
+
+use WordPress\Sniff;
+
+/**
+ * Restricts array assignment of certain keys.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.10.0 Class became a proper abstract class. This was already the behaviour.
+ *                 Moved the file and renamed the class from
+ *                 `WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff` to
+ *                 `WordPress_AbstractArrayAssignmentRestrictionsSniff`.
+ */
+abstract class AbstractArrayAssignmentRestrictionsSniff extends Sniff {
+
+	/**
+	 * Exclude groups.
+	 *
+	 * Example: 'foo,bar'
+	 *
+	 * @var string Comma-delimited group list.
+	 */
+	public $exclude = '';
+
+	/**
+	 * Groups of variable data to check against.
+	 * Don't use this in extended classes, override getGroups() instead.
+	 * This is only used for Unit tests.
+	 *
+	 * @var array
+	 */
+	public static $groups = array();
+
+	/**
+	 * Cache for the excluded groups information.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	protected $excluded_groups = array();
+
+	/**
+	 * Cache for the group information.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @var array
+	 */
+	protected $groups_cache = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		// Retrieve the groups only once and don't set up a listener if there are no groups.
+		if ( false === $this->setup_groups() ) {
+			return array();
+		}
+
+		return array(
+			T_DOUBLE_ARROW,
+			T_CLOSE_SQUARE_BRACKET,
+			T_CONSTANT_ENCAPSED_STRING,
+			T_DOUBLE_QUOTED_STRING,
+		);
+
+	}
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * This method should be overridden in extending classes.
+	 *
+	 * Example: groups => array(
+	 *  'groupname' => array(
+	 *      'type'     => 'error' | 'warning',
+	 *      'message'  => 'Dont use this one please!',
+	 *      'keys'     => array( 'key1', 'another_key' ),
+	 *      'callback' => array( 'class', 'method' ), // Optional.
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	abstract public function getGroups();
+
+	/**
+	 * Cache the groups.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @return bool True if the groups were setup. False if not.
+	 */
+	protected function setup_groups() {
+		$this->groups_cache = $this->getGroups();
+
+		if ( empty( $this->groups_cache ) && empty( self::$groups ) ) {
+			return false;
+		}
+
+		// Allow for adding extra unit tests.
+		if ( ! empty( self::$groups ) ) {
+			$this->groups_cache = array_merge( $this->groups_cache, self::$groups );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		$this->excluded_groups = $this->merge_custom_array( $this->exclude );
+		if ( array_diff_key( $this->groups_cache, $this->excluded_groups ) === array() ) {
+			// All groups have been excluded.
+			// Don't remove the listener as the exclude property can be changed inline.
+			return;
+		}
+
+		$token = $this->tokens[ $stackPtr ];
+
+		if ( T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
+			$equal = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			if ( T_EQUAL !== $this->tokens[ $equal ]['code'] ) {
+				return; // This is not an assignment!
+			}
+		}
+
+		// Instances: Multi-dimensional array, keyed by line.
+		$inst = array();
+
+		/*
+		 * Covers:
+		 * $foo = array( 'bar' => 'taz' );
+		 * $foo['bar'] = $taz;
+		 */
+		if ( in_array( $token['code'], array( T_CLOSE_SQUARE_BRACKET, T_DOUBLE_ARROW ), true ) ) {
+			$operator = $stackPtr; // T_DOUBLE_ARROW.
+			if ( T_CLOSE_SQUARE_BRACKET === $token['code'] ) {
+				$operator = $this->phpcsFile->findNext( T_EQUAL, ( $stackPtr + 1 ) );
+			}
+
+			$keyIdx = $this->phpcsFile->findPrevious( array( T_WHITESPACE, T_CLOSE_SQUARE_BRACKET ), ( $operator - 1 ), null, true );
+			if ( ! is_numeric( $this->tokens[ $keyIdx ]['content'] ) ) {
+				$key            = $this->strip_quotes( $this->tokens[ $keyIdx ]['content'] );
+				$valStart       = $this->phpcsFile->findNext( array( T_WHITESPACE ), ( $operator + 1 ), null, true );
+				$valEnd         = $this->phpcsFile->findNext( array( T_COMMA, T_SEMICOLON ), ( $valStart + 1 ), null, false, null, true );
+				$val            = $this->phpcsFile->getTokensAsString( $valStart, ( $valEnd - $valStart ) );
+				$val            = $this->strip_quotes( $val );
+				$inst[ $key ][] = array( $val, $token['line'] );
+			}
+		} elseif ( in_array( $token['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+			// $foo = 'bar=taz&other=thing';
+			if ( preg_match_all( '#(?:^|&)([a-z_]+)=([^&]*)#i', $this->strip_quotes( $token['content'] ), $matches ) <= 0 ) {
+				return; // No assignments here, nothing to check.
+			}
+			foreach ( $matches[1] as $i => $_k ) {
+				$inst[ $_k ][] = array( $matches[2][ $i ], $token['line'] );
+			}
+		}
+
+		if ( empty( $inst ) ) {
+			return;
+		}
+
+		foreach ( $this->groups_cache as $groupName => $group ) {
+
+			if ( isset( $this->excluded_groups[ $groupName ] ) ) {
+				continue;
+			}
+
+			$callback = ( isset( $group['callback'] ) && is_callable( $group['callback'] ) ) ? $group['callback'] : array( $this, 'callback' );
+
+			foreach ( $inst as $key => $assignments ) {
+				foreach ( $assignments as $occurance ) {
+					list( $val, $line ) = $occurance;
+
+					if ( ! in_array( $key, $group['keys'], true ) ) {
+						continue;
+					}
+
+					$output = call_user_func( $callback, $key, $val, $line, $group );
+
+					if ( ! isset( $output ) || false === $output ) {
+						continue;
+					} elseif ( true === $output ) {
+						$message = $group['message'];
+					} else {
+						$message = $output;
+					}
+
+					$this->addMessage(
+						$message,
+						$stackPtr,
+						( 'error' === $group['type'] ),
+						$this->string_to_errorcode( $groupName . '_' . $key ),
+						array( $key, $val )
+					);
+				}
+			}
+		}
+
+	} // End process_token().
+
+	/**
+	 * Callback to process each confirmed key, to check value.
+	 *
+	 * This method must be extended to add the logic to check assignment value.
+	 *
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
+	 *                       with custom error message passed to ->process().
+	 */
+	abstract public function callback( $key, $val, $line, $group );
+
+} // End class.

--- a/ci/wpcs/WordPress/AbstractClassRestrictionsSniff.php
+++ b/ci/wpcs/WordPress/AbstractClassRestrictionsSniff.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Restricts usage of some classes.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.10.0
+ */
+abstract class AbstractClassRestrictionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Regex pattern with placeholder for the class names.
+	 *
+	 * @var string
+	 */
+	protected $regex_pattern = '`^\\\\(?:%s)$`i';
+
+	/**
+	 * Temporary storage for retrieved class name.
+	 *
+	 * @var string
+	 */
+	protected $classname;
+
+	/**
+	 * Groups of classes to restrict.
+	 *
+	 * This method should be overridden in extending classes.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'    => 'error' | 'warning',
+	 *      'message' => 'Avoid direct calls to the database.',
+	 *      'classes' => array( 'PDO', '\Namespace\Classname' ),
+	 *  )
+	 * )
+	 *
+	 * You can use * wildcards to target a group of (namespaced) classes.
+	 * Aliased namespaces (use ..) are currently not supported.
+	 *
+	 * Documented here for clarity. Not (re)defined as it is already defined in the parent class.
+	 *
+	 * @return array
+	 *
+	abstract public function getGroups();
+	 */
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		// Prepare the function group regular expressions only once.
+		if ( false === $this->setup_groups( 'classes' ) ) {
+			return array();
+		}
+
+		return array(
+			T_DOUBLE_COLON,
+			T_NEW,
+			T_EXTENDS,
+			T_IMPLEMENTS,
+		);
+
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * {@internal Unlike in the `WordPress_AbstractFunctionRestrictionsSniff`,
+	 *            we can't do a preliminary check on classes as at this point
+	 *            we don't know the class name yet.}}
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+		// Reset the temporary storage before processing the token.
+		unset( $this->classname );
+
+		$this->excluded_groups = $this->merge_custom_array( $this->exclude );
+		if ( array_diff_key( $this->groups, $this->excluded_groups ) === array() ) {
+			// All groups have been excluded.
+			// Don't remove the listener as the exclude property can be changed inline.
+			return;
+		}
+
+		if ( true === $this->is_targetted_token( $stackPtr ) ) {
+			return $this->check_for_matches( $stackPtr );
+		}
+	}
+
+	/**
+	 * Determine if we have a valid classname for the target token.
+	 *
+	 * @since 0.11.0 This logic was originally contained in the `process()` method.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return bool
+	 */
+	public function is_targetted_token( $stackPtr ) {
+
+		$token     = $this->tokens[ $stackPtr ];
+		$classname = '';
+
+		if ( in_array( $token['code'], array( T_NEW, T_EXTENDS, T_IMPLEMENTS ), true ) ) {
+			if ( T_NEW === $token['code'] ) {
+				$nameEnd = ( $this->phpcsFile->findNext( array( T_OPEN_PARENTHESIS, T_WHITESPACE, T_SEMICOLON, T_OBJECT_OPERATOR ), ( $stackPtr + 2 ) ) - 1 );
+			} else {
+				$nameEnd = ( $this->phpcsFile->findNext( array( T_CLOSE_CURLY_BRACKET, T_WHITESPACE ), ( $stackPtr + 2 ) ) - 1 );
+			}
+
+			$length    = ( $nameEnd - ( $stackPtr + 1 ) );
+			$classname = $this->phpcsFile->getTokensAsString( ( $stackPtr + 2 ), $length );
+
+			if ( T_NS_SEPARATOR !== $this->tokens[ ( $stackPtr + 2 ) ]['code'] ) {
+				$classname = $this->get_namespaced_classname( $classname, ( $stackPtr - 1 ) );
+			}
+		}
+
+		if ( T_DOUBLE_COLON === $token['code'] ) {
+			$nameEnd   = $this->phpcsFile->findPrevious( T_STRING, ( $stackPtr - 1 ) );
+			$nameStart = ( $this->phpcsFile->findPrevious( array( T_STRING, T_NS_SEPARATOR, T_NAMESPACE ), ( $nameEnd - 1 ), null, true, null, true ) + 1 );
+			$length    = ( $nameEnd - ( $nameStart - 1 ) );
+			$classname = $this->phpcsFile->getTokensAsString( $nameStart, $length );
+
+			if ( T_NS_SEPARATOR !== $this->tokens[ $nameStart ]['code'] ) {
+				$classname = $this->get_namespaced_classname( $classname, ( $nameStart - 1 ) );
+			}
+		}
+
+		// Stop if we couldn't determine a classname.
+		if ( empty( $classname ) ) {
+			return false;
+		}
+
+		// Nothing to do if 'parent', 'self' or 'static'.
+		if ( in_array( $classname, array( 'parent', 'self', 'static' ), true ) ) {
+			return false;
+		}
+
+		$this->classname = $classname;
+		return true;
+
+	} // End is_targetted_token().
+
+	/**
+	 * Verify if the current token is one of the targetted classes.
+	 *
+	 * @since 0.11.0 Split out from the `process()` method.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function check_for_matches( $stackPtr ) {
+		$skip_to = array();
+
+		foreach ( $this->groups as $groupName => $group ) {
+
+			if ( isset( $this->excluded_groups[ $groupName ] ) ) {
+				continue;
+			}
+
+			if ( preg_match( $group['regex'], $this->classname ) === 1 ) {
+				$skip_to[] = $this->process_matched_token( $stackPtr, $groupName, $this->classname );
+			}
+		}
+
+		if ( empty( $skip_to ) || min( $skip_to ) === 0 ) {
+			return;
+		}
+
+		return min( $skip_to );
+
+	} // End is_targetted_token().
+
+	/**
+	 * Prepare the class name for use in a regular expression.
+	 *
+	 * The getGroups() method allows for providing class names with a wildcard * to target
+	 * a group of classes within a namespace. It also allows for providing class names as
+	 * 'ordinary' names or prefixed with one or more namespaces.
+	 * This prepare routine takes that into account while still safely escaping the
+	 * class name for use in a regular expression.
+	 *
+	 * @param string $classname Class name, potentially prefixed with namespaces.
+	 * @return string Regex escaped class name.
+	 */
+	protected function prepare_name_for_regex( $classname ) {
+		$classname = trim( $classname, '\\' ); // Make sure all classnames have a \ prefix, but only one.
+		return parent::prepare_name_for_regex( $classname );
+	}
+
+	/**
+	 * See if the classname was found in a namespaced file and if so, add the namespace to the classname.
+	 *
+	 * @param string $classname   The full classname as found.
+	 * @param int    $search_from The token position to search up from.
+	 * @return string Classname, potentially prefixed with the namespace.
+	 */
+	protected function get_namespaced_classname( $classname, $search_from ) {
+		// Don't do anything if this is already a fully qualified classname.
+		if ( empty( $classname ) || '\\' === $classname[0] ) {
+			return $classname;
+		}
+
+		// Remove the namespace keyword if used.
+		if ( 0 === strpos( $classname, 'namespace\\' ) ) {
+			$classname = substr( $classname, 10 );
+		}
+
+		$namespace_keyword = $this->phpcsFile->findPrevious( T_NAMESPACE, $search_from );
+		if ( false === $namespace_keyword ) {
+			// No namespace keyword found at all, so global namespace.
+			$classname = '\\' . $classname;
+		} else {
+			$namespace = $this->determine_namespace( $search_from );
+
+			if ( ! empty( $namespace ) ) {
+				$classname = '\\' . $namespace . '\\' . $classname;
+			} else {
+				// No actual namespace found, so global namespace.
+				$classname = '\\' . $classname;
+			}
+		}
+
+		return $classname;
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/AbstractFunctionParameterSniff.php
+++ b/ci/wpcs/WordPress/AbstractFunctionParameterSniff.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Advises about parameters used in function calls.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.11.0
+ */
+abstract class AbstractFunctionParameterSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * Intended to be overruled in the child class.
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'restricted_parameters';
+
+	/**
+	 * Functions this sniff is looking for. Should be defined in the child class.
+	 *
+	 * @var array The only requirement for this array is that the top level
+	 *            array keys are the names of the functions you're looking for.
+	 *            Other than that, the array can have arbitrary content
+	 *            depending on your needs.
+	 */
+	protected $target_functions = array();
+
+	/**
+	 * Groups of function to restrict.
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		if ( empty( $this->target_functions ) ) {
+			return array();
+		}
+
+		return array(
+			$this->group_name => array(
+				'functions' => array_keys( $this->target_functions ),
+			),
+		);
+	}
+
+	/**
+	 * Process a matched token.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
+
+		$parameters = $this->get_function_call_parameters( $stackPtr );
+
+		if ( empty( $parameters ) ) {
+			return $this->process_no_parameters( $stackPtr, $group_name, $matched_content );
+		} else {
+			return $this->process_parameters( $stackPtr, $group_name, $matched_content, $parameters );
+		}
+	}
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * This method has to be made concrete in child classes.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	abstract public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters );
+
+	/**
+	 * Process the function if no parameters were found.
+	 *
+	 * Defaults to doing nothing. Can be overloaded in child classes to handle functions
+	 * were parameters are expected, but none found.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {
+		return;
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/AbstractFunctionRestrictionsSniff.php
+++ b/ci/wpcs/WordPress/AbstractFunctionRestrictionsSniff.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Restricts usage of some functions.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.10.0 Class became a proper abstract class. This was already the behaviour.
+ *                 Moved the file and renamed the class from
+ *                 `WordPress_Sniffs_Functions_FunctionRestrictionsSniff` to
+ *                 `WordPress_AbstractFunctionRestrictionsSniff`.
+ * @since   0.11.0 Extends the WordPress_Sniff class.
+ */
+abstract class AbstractFunctionRestrictionsSniff extends Sniff {
+
+	/**
+	 * Exclude groups.
+	 *
+	 * Example: 'switch_to_blog,user_meta'
+	 *
+	 * @var string Comma-delimited group list.
+	 */
+	public $exclude = '';
+
+	/**
+	 * Groups of function data to check against.
+	 * Don't use this in extended classes, override getGroups() instead.
+	 * This is only used for Unit tests.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @var array
+	 */
+	public static $unittest_groups = array();
+
+	/**
+	 * Regex pattern with placeholder for the function names.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @var string
+	 */
+	protected $regex_pattern = '`\b(?:%s)\b`i';
+
+	/**
+	 * Cache for the group information.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @var array
+	 */
+	protected $groups = array();
+
+	/**
+	 * Cache for the excluded groups information.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	protected $excluded_groups = array();
+
+	/**
+	 * Regex containing the name of all functions handled by a sniff.
+	 *
+	 * Set in `register()` and used to do an initial check.
+	 *
+	 * @var string
+	 */
+	private $prelim_check_regex;
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * This method should be overridden in extending classes.
+	 *
+	 * Example: groups => array(
+	 *     'lambda' => array(
+	 *         'type'      => 'error' | 'warning',
+	 *         'message'   => 'Use anonymous functions instead please!',
+	 *         'functions' => array( 'file_get_contents', 'create_function', 'mysql_*' ),
+	 *         // Only useful when using wildcards:
+	 *         'whitelist' => array( 'mysql_to_rfc3339' => true, ),
+	 *     )
+	 * )
+	 *
+	 * You can use * wildcards to target a group of functions.
+	 * When you use * wildcards, you may inadvertently restrict too many
+	 * functions. In that case you can add the `whitelist` key to
+	 * whitelist individual functions to prevent false positives.
+	 *
+	 * @return array
+	 */
+	abstract public function getGroups();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		// Prepare the function group regular expressions only once.
+		if ( false === $this->setup_groups( 'functions' ) ) {
+			return array();
+		}
+
+		return array(
+			T_STRING,
+		);
+	}
+
+	/**
+	 * Set up the regular expressions for each group.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param string $key The group array index key where the input for the regular expression can be found.
+	 * @return bool True if the groups were setup. False if not.
+	 */
+	protected function setup_groups( $key ) {
+		// Prepare the function group regular expressions only once.
+		$this->groups = $this->getGroups();
+
+		if ( empty( $this->groups ) && empty( self::$unittest_groups ) ) {
+			return false;
+		}
+
+		// Allow for adding extra unit tests.
+		if ( ! empty( self::$unittest_groups ) ) {
+			$this->groups = array_merge( $this->groups, self::$unittest_groups );
+		}
+
+		$all_items = array();
+		foreach ( $this->groups as $groupName => $group ) {
+			if ( empty( $group[ $key ] ) ) {
+				unset( $this->groups[ $groupName ] );
+			} else {
+				$items       = array_map( array( $this, 'prepare_name_for_regex' ), $group[ $key ] );
+				$all_items[] = $items;
+				$items       = implode( '|', $items );
+
+				$this->groups[ $groupName ]['regex'] = sprintf( $this->regex_pattern, $items );
+			}
+		}
+
+		if ( empty( $this->groups ) ) {
+			return false;
+		}
+
+		// Create one "super-regex" to allow for initial filtering.
+		$all_items                = call_user_func_array( 'array_merge', $all_items );
+		$all_items                = implode( '|', array_unique( $all_items ) );
+		$this->prelim_check_regex = sprintf( $this->regex_pattern, $all_items );
+
+		return true;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+
+		$this->excluded_groups = $this->merge_custom_array( $this->exclude );
+		if ( array_diff_key( $this->groups, $this->excluded_groups ) === array() ) {
+			// All groups have been excluded.
+			// Don't remove the listener as the exclude property can be changed inline.
+			return;
+		}
+
+		// Preliminary check. If the content of the T_STRING is not one of the functions we're
+		// looking for, we can bow out before doing the heavy lifting of checking whether
+		// this is a function call.
+		if ( preg_match( $this->prelim_check_regex, $this->tokens[ $stackPtr ]['content'] ) !== 1 ) {
+			return;
+		}
+
+		if ( true === $this->is_targetted_token( $stackPtr ) ) {
+			return $this->check_for_matches( $stackPtr );
+		}
+
+	} // End process_token().
+
+	/**
+	 * Verify is the current token is a function call.
+	 *
+	 * @since 0.11.0 Split out from the `process()` method.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return bool
+	 */
+	public function is_targetted_token( $stackPtr ) {
+
+		// Exclude function definitions, class methods, and namespaced calls.
+		if ( T_STRING === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ ( $stackPtr - 1 ) ] ) ) {
+			$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+
+			if ( false !== $prev ) {
+				// Skip sniffing if calling a same-named method, or on function definitions.
+				$skipped = array(
+					T_FUNCTION        => T_FUNCTION,
+					T_DOUBLE_COLON    => T_DOUBLE_COLON,
+					T_OBJECT_OPERATOR => T_OBJECT_OPERATOR,
+				);
+
+				if ( isset( $skipped[ $this->tokens[ $prev ]['code'] ] ) ) {
+					return false;
+				}
+
+				// Skip namespaced functions, ie: \foo\bar() not \bar().
+				if ( T_NS_SEPARATOR === $this->tokens[ $prev ]['code'] ) {
+					$pprev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $prev - 1 ), null, true );
+					if ( false !== $pprev && T_STRING === $this->tokens[ $pprev ]['code'] ) {
+						return false;
+					}
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+
+	} // End is_targetted_token().
+
+	/**
+	 * Verify if the current token is one of the targetted functions.
+	 *
+	 * @since 0.11.0 Split out from the `process()` method.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function check_for_matches( $stackPtr ) {
+		$token_content = strtolower( $this->tokens[ $stackPtr ]['content'] );
+		$skip_to       = array();
+
+		foreach ( $this->groups as $groupName => $group ) {
+
+			if ( isset( $this->excluded_groups[ $groupName ] ) ) {
+				continue;
+			}
+
+			if ( isset( $group['whitelist'][ $token_content ] ) ) {
+				continue;
+			}
+
+			if ( preg_match( $group['regex'], $token_content ) === 1 ) {
+				$skip_to[] = $this->process_matched_token( $stackPtr, $groupName, $token_content );
+			}
+		}
+
+		if ( empty( $skip_to ) || min( $skip_to ) === 0 ) {
+			return;
+		}
+
+		return min( $skip_to );
+
+	} // End check_for_matches().
+
+	/**
+	 * Process a matched token.
+	 *
+	 * @since 0.11.0 Split out from the `process()` method.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param string $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
+
+		$this->addMessage(
+			$this->groups[ $group_name ]['message'],
+			$stackPtr,
+			( 'error' === $this->groups[ $group_name ]['type'] ),
+			$this->string_to_errorcode( $group_name . '_' . $matched_content ),
+			array( $matched_content )
+		);
+
+		return;
+	} // End process_matched_token().
+
+	/**
+	 * Prepare the function name for use in a regular expression.
+	 *
+	 * The getGroups() method allows for providing function names with a wildcard * to target
+	 * a group of functions. This prepare routine takes that into account while still safely
+	 * escaping the function name for use in a regular expression.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param string $function Function name.
+	 * @return string Regex escaped function name.
+	 */
+	protected function prepare_name_for_regex( $function ) {
+		$function = str_replace( array( '.*', '*' ), '#', $function ); // Replace wildcards with placeholder.
+		$function = preg_quote( $function, '`' );
+		$function = str_replace( '#', '.*', $function ); // Replace placeholder with regex wildcard.
+
+		return $function;
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/AbstractVariableRestrictionsSniff.php
+++ b/ci/wpcs/WordPress/AbstractVariableRestrictionsSniff.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress;
+
+use WordPress\Sniff;
+
+/**
+ * Restricts usage of some variables.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.10.0 Class became a proper abstract class. This was already the behaviour.
+ *                 Moved the file and renamed the class from
+ *                 `WordPress_Sniffs_Variables_VariableRestrictionsSniff` to
+ *                 `WordPress_AbstractVariableRestrictionsSniff`.
+ * @since   0.11.0 Extends the WordPress_Sniff class.
+ */
+abstract class AbstractVariableRestrictionsSniff extends Sniff {
+
+	/**
+	 * Exclude groups.
+	 *
+	 * Example: 'foo,bar'
+	 *
+	 * @var string Comma-delimited group list.
+	 */
+	public $exclude = '';
+
+	/**
+	 * Groups of variable data to check against.
+	 * Don't use this in extended classes, override getGroups() instead.
+	 * This is only used for Unit tests.
+	 *
+	 * @var array
+	 */
+	public static $groups = array();
+
+	/**
+	 * Cache for the excluded groups information.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	protected $excluded_groups = array();
+
+	/**
+	 * Cache for the group information.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @var array
+	 */
+	protected $groups_cache = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		// Retrieve the groups only once and don't set up a listener if there are no groups.
+		if ( false === $this->setup_groups() ) {
+			return array();
+		}
+
+		return array(
+			T_VARIABLE,
+			T_OBJECT_OPERATOR,
+			T_DOUBLE_COLON,
+			T_OPEN_SQUARE_BRACKET,
+			T_DOUBLE_QUOTED_STRING,
+			T_HEREDOC,
+		);
+
+	}
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * This method should be overridden in extending classes.
+	 *
+	 * Example: groups => array(
+	 *  'wpdb' => array(
+	 *      'type'          => 'error' | 'warning',
+	 *      'message'       => 'Dont use this one please!',
+	 *      'variables'     => array( '$val', '$var' ),
+	 *      'object_vars'   => array( '$foo->bar', .. ),
+	 *      'array_members' => array( '$foo['bar']', .. ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	abstract public function getGroups();
+
+	/**
+	 * Cache the groups.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @return bool True if the groups were setup. False if not.
+	 */
+	protected function setup_groups() {
+		$this->groups_cache = $this->getGroups();
+
+		if ( empty( $this->groups_cache ) && empty( self::$groups ) ) {
+			return false;
+		}
+
+		// Allow for adding extra unit tests.
+		if ( ! empty( self::$groups ) ) {
+			$this->groups_cache = array_merge( $this->groups_cache, self::$groups );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+
+		$token = $this->tokens[ $stackPtr ];
+
+		$this->excluded_groups = $this->merge_custom_array( $this->exclude );
+		if ( array_diff_key( $this->groups_cache, $this->excluded_groups ) === array() ) {
+			// All groups have been excluded.
+			// Don't remove the listener as the exclude property can be changed inline.
+			return;
+		}
+
+		// Check if it is a function not a variable.
+		if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON ), true ) ) { // This only works for object vars and array members.
+			$method               = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			$possible_parenthesis = $this->phpcsFile->findNext( T_WHITESPACE, ( $method + 1 ), null, true );
+			if ( T_OPEN_PARENTHESIS === $this->tokens[ $possible_parenthesis ]['code'] ) {
+				return; // So .. it is a function after all !
+			}
+		}
+
+		foreach ( $this->groups_cache as $groupName => $group ) {
+
+			if ( isset( $this->excluded_groups[ $groupName ] ) ) {
+				continue;
+			}
+
+			$patterns = array();
+
+			// Simple variable.
+			if ( in_array( $token['code'], array( T_VARIABLE, T_DOUBLE_QUOTED_STRING, T_HEREDOC ), true ) && ! empty( $group['variables'] ) ) {
+				$patterns = array_merge( $patterns, $group['variables'] );
+				$var      = $token['content'];
+
+			}
+
+			if ( in_array( $token['code'], array( T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_DOUBLE_QUOTED_STRING, T_HEREDOC ), true ) && ! empty( $group['object_vars'] ) ) {
+				// Object var, ex: $foo->bar / $foo::bar / Foo::bar / Foo::$bar .
+				$patterns = array_merge( $patterns, $group['object_vars'] );
+
+				$owner = $this->phpcsFile->findPrevious( array( T_VARIABLE, T_STRING ), $stackPtr );
+				$child = $this->phpcsFile->findNext( array( T_STRING, T_VAR, T_VARIABLE ), $stackPtr );
+				$var   = implode( '', array( $this->tokens[ $owner ]['content'], $token['content'], $this->tokens[ $child ]['content'] ) );
+
+			}
+
+			if ( in_array( $token['code'], array( T_OPEN_SQUARE_BRACKET, T_DOUBLE_QUOTED_STRING, T_HEREDOC ), true ) && ! empty( $group['array_members'] ) ) {
+				// Array members.
+				$patterns = array_merge( $patterns, $group['array_members'] );
+
+				if ( isset( $token['bracket_closer'] ) ) {
+					$owner  = $this->phpcsFile->findPrevious( T_VARIABLE, $stackPtr );
+					$inside = $this->phpcsFile->getTokensAsString( $stackPtr, ( $token['bracket_closer'] - $stackPtr + 1 ) );
+					$var    = implode( '', array( $this->tokens[ $owner ]['content'], $inside ) );
+				}
+			}
+
+			if ( empty( $patterns ) ) {
+				continue;
+			}
+
+			$patterns = array_map( array( $this, 'test_patterns' ), $patterns );
+			$pattern  = implode( '|', $patterns );
+			$delim    = ( T_OPEN_SQUARE_BRACKET !== $token['code'] && T_HEREDOC !== $token['code'] ) ? '\b' : '';
+
+			if ( T_DOUBLE_QUOTED_STRING === $token['code'] || T_HEREDOC === $token['code'] ) {
+				$var = $token['content'];
+			}
+
+			if ( empty( $var ) || preg_match( '#(' . $pattern . ')' . $delim . '#', $var, $match ) !== 1 ) {
+				continue;
+			}
+
+			$this->addMessage(
+				$group['message'],
+				$stackPtr,
+				( 'error' === $group['type'] ),
+				$this->string_to_errorcode( $groupName . '_' . $match[1] ),
+				array( $var )
+			);
+
+			return; // Show one error only.
+
+		}
+
+	} // End process_token().
+
+	/**
+	 * Transform a wildcard pattern to a usable regex pattern.
+	 *
+	 * @param string $pattern Pattern.
+	 * @return string
+	 */
+	private function test_patterns( $pattern ) {
+		$pattern = preg_quote( $pattern, '#' );
+		$pattern = preg_replace(
+			array( '#\\\\\*#', '[\'"]' ),
+			array( '.*', '\'' ),
+			$pattern
+		);
+		return $pattern;
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/PHPCSAliases.php
+++ b/ci/wpcs/WordPress/PHPCSAliases.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * PHPCS cross-version compatibility helper.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ * @since   0.13.0
+ */
+
+/*
+ * Alias a number of PHPCS 3.x classes to their PHPCS 2.x equivalents.
+ *
+ * This file is auto-loaded by PHPCS 3.x before any sniffs are loaded
+ * through the PHPCS 3.x `<autoload>` ruleset directive.
+ *
+ * {@internal The PHPCS files have been reorganized in PHPCS 3.x, quite
+ * a few "old" classes have been split and spread out over several "new"
+ * classes. In other words, this will only work for a limited number
+ * of classes.}}
+ *
+ * {@internal The `class_exists` wrappers are needed to play nice with other
+ * external PHPCS standards creating cross-version compatibility in the same
+ * manner.}}
+ */
+if ( ! defined( 'WPCS_PHPCS_ALIASES_SET' ) ) {
+	// PHPCS base classes/interface.
+	if ( ! interface_exists( '\PHP_CodeSniffer_Sniff' ) ) {
+		class_alias( 'PHP_CodeSniffer\Sniffs\Sniff', '\PHP_CodeSniffer_Sniff' );
+	}
+	if ( ! class_exists( '\PHP_CodeSniffer_File' ) ) {
+		class_alias( 'PHP_CodeSniffer\Files\File', '\PHP_CodeSniffer_File' );
+	}
+	if ( ! class_exists( '\PHP_CodeSniffer_Tokens' ) ) {
+		class_alias( 'PHP_CodeSniffer\Util\Tokens', '\PHP_CodeSniffer_Tokens' );
+	}
+
+	// PHPCS classes which are being extended by WPCS sniffs.
+	if ( ! class_exists( '\PHP_CodeSniffer_Standards_AbstractVariableSniff' ) ) {
+		class_alias( 'PHP_CodeSniffer\Sniffs\AbstractVariableSniff', '\PHP_CodeSniffer_Standards_AbstractVariableSniff' );
+	}
+	if ( ! class_exists( '\PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff' ) ) {
+		class_alias( 'PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff', '\PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff' );
+	}
+	if ( ! class_exists( '\Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff' ) ) {
+		class_alias( 'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff', '\Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff' );
+	}
+	if ( ! class_exists( '\Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff' ) ) {
+		class_alias( 'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SemicolonSpacingSniff', '\Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff' );
+	}
+
+	define( 'WPCS_PHPCS_ALIASES_SET', true );
+
+	/*
+	 * Register our own autoloader for the WPCS abstract classes & the helper class.
+	 *
+	 * This can be removed once the minimum required version of WPCS for the
+	 * PHPCS 3.x branch has gone up to 3.1.0 (unreleased as of yet) or
+	 * whichever version contains the fix for upstream #1591.
+	 *
+	 * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/1564
+	 * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/1591
+	 */
+	spl_autoload_register( function ( $class ) {
+		// Only try & load our own classes.
+		if ( stripos( $class, 'WordPress' ) !== 0 ) {
+			return;
+		}
+
+		// PHPCS handles the Test and Sniff classes without problem.
+		if ( stripos( $class, '\Tests\\' ) !== false || stripos( $class, '\Sniffs\\' ) !== false ) {
+			return;
+		}
+
+		$file = dirname( __DIR__ ) . DIRECTORY_SEPARATOR . strtr( $class, '\\', DIRECTORY_SEPARATOR ) . '.php';
+
+		if ( file_exists( $file ) ) {
+			include_once $file;
+		}
+	} );
+}

--- a/ci/wpcs/WordPress/PHPCSHelper.php
+++ b/ci/wpcs/WordPress/PHPCSHelper.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * PHPCS cross-version compatibility helper class.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress;
+
+use PHP_CodeSniffer_File as File;
+
+/**
+ * PHPCSHelper
+ *
+ * PHPCS cross-version compatibility helper class.
+ *
+ * Deals with files which cannot be aliased 1-on-1 as the original
+ * class was split up into several classes.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.13.0
+ */
+class PHPCSHelper {
+
+	/**
+	 * Get the PHPCS version number.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @return string
+	 */
+	public static function get_version() {
+		if ( defined( '\PHP_CodeSniffer\Config::VERSION' ) ) {
+			// PHPCS 3.x.
+			return \PHP_CodeSniffer\Config::VERSION;
+		} else {
+			// PHPCS 2.x.
+			return \PHP_CodeSniffer::VERSION;
+		}
+	}
+
+	/**
+	 * Pass config data to PHPCS.
+	 *
+	 * PHPCS cross-version compatibility helper.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @param string      $key   The name of the config value.
+	 * @param string|null $value The value to set. If null, the config entry
+	 *                           is deleted, reverting it to the default value.
+	 * @param boolean     $temp  Set this config data temporarily for this script run.
+	 *                           This will not write the config data to the config file.
+	 */
+	public static function set_config_data( $key, $value, $temp = false ) {
+		if ( method_exists( '\PHP_CodeSniffer\Config', 'setConfigData' ) ) {
+			// PHPCS 3.x.
+			\PHP_CodeSniffer\Config::setConfigData( $key, $value, $temp );
+		} else {
+			// PHPCS 2.x.
+			\PHP_CodeSniffer::setConfigData( $key, $value, $temp );
+		}
+	}
+
+	/**
+	 * Get the value of a single PHPCS config key.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @param string $key The name of the config value.
+	 *
+	 * @return string|null
+	 */
+	public static function get_config_data( $key ) {
+		if ( method_exists( '\PHP_CodeSniffer\Config', 'getConfigData' ) ) {
+			// PHPCS 3.x.
+			return \PHP_CodeSniffer\Config::getConfigData( $key );
+		} else {
+			// PHPCS 2.x.
+			return \PHP_CodeSniffer::getConfigData( $key );
+		}
+	}
+
+	/**
+	 * Get the tab width as passed to PHPCS from the command-line or the ruleset.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being processed.
+	 *
+	 * @return int Tab width. Defaults to 4.
+	 */
+	public static function get_tab_width( File $phpcsFile ) {
+		$tab_width = 4;
+
+		if ( class_exists( '\PHP_CodeSniffer\Config' ) ) {
+			// PHPCS 3.x.
+			if ( isset( $phpcsFile->config->tabWidth ) && $phpcsFile->config->tabWidth > 0 ) {
+				$tab_width = $phpcsFile->config->tabWidth;
+			}
+		} else {
+			// PHPCS 2.x.
+			$cli_values = $phpcsFile->phpcs->cli->getCommandLineValues();
+			if ( isset( $cli_values['tabWidth'] ) && $cli_values['tabWidth'] > 0 ) {
+				$tab_width = $cli_values['tabWidth'];
+			}
+		}
+
+		return $tab_width;
+	}
+
+	/**
+	 * Check whether the `--ignore-annotations` option has been used.
+	 *
+	 * @since 0.13.0
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile Optional. The current file being processed.
+	 *
+	 * @return bool True if annotations should be ignored, false otherwise.
+	 */
+	public static function ignore_annotations( File $phpcsFile = null ) {
+		if ( class_exists( '\PHP_CodeSniffer\Config' ) ) {
+			// PHPCS 3.x.
+			if ( isset( $phpcsFile, $phpcsFile->config->annotations ) ) {
+				return ! $phpcsFile->config->annotations;
+			} else {
+				$annotations = \PHP_CodeSniffer\Config::getConfigData( 'annotations' );
+				if ( isset( $annotations ) ) {
+					return ! $annotations;
+				}
+			}
+		}
+
+		// PHPCS 2.x does not support `--ignore-annotations`.
+		return false;
+	}
+
+}

--- a/ci/wpcs/WordPress/Sniff.php
+++ b/ci/wpcs/WordPress/Sniff.php
@@ -1,0 +1,2509 @@
+<?php
+/**
+ * Represents a PHP_CodeSniffer sniff for sniffing WordPress coding standards.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress;
+
+use PHP_CodeSniffer_Sniff as PHPCS_Sniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+use WordPress\PHPCSHelper;
+
+/**
+ * Represents a PHP_CodeSniffer sniff for sniffing WordPress coding standards.
+ *
+ * Provides a bootstrap for the sniffs, to reduce code duplication.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   0.4.0
+ *
+ * {@internal This class contains numerous properties where the array format looks
+ *            like `'string' => true`, i.e. the array item is set as the array key.
+ *            This allows for sniffs to verify whether something is in one of these
+ *            lists using `isset()` rather than `in_array()` which is a much more
+ *            efficient (faster) check to execute and therefore improves the
+ *            performance of the sniffs.
+ *            The `true` value in those cases is used as a placeholder and has no
+ *            meaning in and of itself.
+ *            In the rare few cases where the array values *do* have meaning, this
+ *            is documented in the property documentation.}}
+ */
+abstract class Sniff implements PHPCS_Sniff {
+
+	/**
+	 * Regex to get complex variables from T_DOUBLE_QUOTED_STRING or T_HEREDOC.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var string
+	 */
+	const REGEX_COMPLEX_VARS = '`(?:(\{)?(?<!\\\\)\$)?(\{)?(?<!\\\\)\$(\{)?(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:->\$?(?P>varname)|\[[^\]]+\]|::\$?(?P>varname)|\([^\)]*\))*(?(3)\}|)(?(2)\}|)(?(1)\}|)`';
+
+	/**
+	 * Minimum supported WordPress version.
+	 *
+	 * Currently used by the `WordPress.WP.DeprecatedClasses`,
+	 * `WordPress.WP.DeprecatedFunctions` and the `WordPress.WP.DeprecatedParameter` sniff.
+	 *
+	 * These sniffs will throw an error when usage of a deprecated class/function/parameter
+	 * is detected if the class/function/parameter was deprecated before the minimum
+	 * supported WP version; a warning otherwise.
+	 * By default, it is set to presume that a project will support the current
+	 * WP version and up to three releases before.
+	 *
+	 * This property allows changing the minimum supported WP version used by
+	 * these sniffs by setting a property in a custom phpcs.xml ruleset.
+	 * This property will need to be set for each sniff which uses it.
+	 *
+	 * Example usage:
+	 * <rule ref="WordPress.WP.DeprecatedClasses">
+	 *  <properties>
+	 *   <property name="minimum_supported_version" value="4.3"/>
+	 *  </properties>
+	 * </rule>
+	 *
+	 * Alternatively, the value can be passed in one go for all sniff using it via
+	 * the command line or by setting a `<config>` value in a custom phpcs.xml ruleset.
+	 * Note: the `_wp_` in the command line property name!
+	 *
+	 * CL: `phpcs --runtime-set minimum_supported_wp_version 4.5`
+	 * Ruleset: `<config name="minimum_supported_wp_version" value="4.5"/>`
+	 *
+	 * @since 0.14.0 Previously the individual sniffs each contained this property.
+	 *
+	 * @var string WordPress version.
+	 */
+	public $minimum_supported_version = '4.5';
+
+	/**
+	 * Custom list of classes which test classes can extend.
+	 *
+	 * This property allows end-users to add to the $test_class_whitelist via their ruleset.
+	 * This property will need to be set for each sniff which uses the
+	 * `is_test_class()` method.
+	 * Currently the method is used by the `WordPress.Variables.GlobalVariables`,
+	 * `WordPress.NamingConventions.PrefixAllGlobals` and the `WordPress.Files.Filename` sniffs.
+	 *
+	 * Example usage:
+	 * <rule ref="WordPress.[Subset].[Sniffname]">
+	 *  <properties>
+	 *   <property name="custom_test_class_whitelist" type="array" value="My_Plugin_First_Test_Class,My_Plugin_Second_Test_Class"/>
+	 *  </properties>
+	 * </rule>
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string|string[]
+	 */
+	public $custom_test_class_whitelist = array();
+
+	/**
+	 * List of the functions which verify nonces.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $nonceVerificationFunctions = array(
+		'wp_verify_nonce'     => true,
+		'check_admin_referer' => true,
+		'check_ajax_referer'  => true,
+	);
+
+	/**
+	 * Functions that escape values for display.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $escapingFunctions = array(
+		'absint'               => true,
+		'esc_attr__'           => true,
+		'esc_attr_e'           => true,
+		'esc_attr_x'           => true,
+		'esc_attr'             => true,
+		'esc_html__'           => true,
+		'esc_html_e'           => true,
+		'esc_html_x'           => true,
+		'esc_html'             => true,
+		'esc_js'               => true,
+		'esc_sql'              => true,
+		'esc_textarea'         => true,
+		'esc_url_raw'          => true,
+		'esc_url'              => true,
+		'filter_input'         => true,
+		'filter_var'           => true,
+		'floatval'             => true,
+		'intval'               => true,
+		'json_encode'          => true,
+		'like_escape'          => true,
+		'number_format'        => true,
+		'rawurlencode'         => true,
+		'sanitize_html_class'  => true,
+		'sanitize_user_field'  => true,
+		'tag_escape'           => true,
+		'urlencode_deep'       => true,
+		'urlencode'            => true,
+		'wp_json_encode'       => true,
+		'wp_kses_allowed_html' => true,
+		'wp_kses_data'         => true,
+		'wp_kses_post'         => true,
+		'wp_kses'              => true,
+	);
+
+	/**
+	 * Functions whose output is automatically escaped for display.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $autoEscapedFunctions = array(
+		'allowed_tags'              => true,
+		'bloginfo'                  => true,
+		'body_class'                => true,
+		'calendar_week_mod'         => true,
+		'cancel_comment_reply_link' => true,
+		'category_description'      => true,
+		'checked'                   => true,
+		'comment_author_email_link' => true,
+		'comment_author_email'      => true,
+		'comment_author_IP'         => true,
+		'comment_author_link'       => true,
+		'comment_author_rss'        => true,
+		'comment_author_url_link'   => true,
+		'comment_author_url'        => true,
+		'comment_author'            => true,
+		'comment_class'             => true,
+		'comment_date'              => true,
+		'comment_excerpt'           => true,
+		'comment_form_title'        => true,
+		'comment_form'              => true,
+		'comment_id_fields'         => true,
+		'comment_ID'                => true,
+		'comment_reply_link'        => true,
+		'comment_text_rss'          => true,
+		'comment_text'              => true,
+		'comment_time'              => true,
+		'comment_type'              => true,
+		'comments_link'             => true,
+		'comments_number'           => true,
+		'comments_popup_link'       => true,
+		'comments_popup_script'     => true,
+		'comments_rss_link'         => true,
+		'count'                     => true,
+		'delete_get_calendar_cache' => true,
+		'disabled'                  => true,
+		'do_shortcode'              => true,
+		'do_shortcode_tag'          => true,
+		'edit_bookmark_link'        => true,
+		'edit_comment_link'         => true,
+		'edit_post_link'            => true,
+		'edit_tag_link'             => true,
+		'get_archives_link'         => true,
+		'get_attachment_link'       => true,
+		'get_avatar'                => true,
+		'get_bookmark_field'        => true,
+		'get_bookmark'              => true,
+		'get_calendar'              => true,
+		'get_comment_author_link'   => true,
+		'get_comment_date'          => true,
+		'get_comment_time'          => true,
+		'get_current_blog_id'       => true,
+		'get_delete_post_link'      => true,
+		'get_footer'                => true,
+		'get_header'                => true,
+		'get_search_form'           => true,
+		'get_search_query'          => true,
+		'get_sidebar'               => true,
+		'get_template_part'         => true,
+		'get_the_author_link'       => true,
+		'get_the_author'            => true,
+		'get_the_date'              => true,
+		'get_the_ID'                => true,
+		'get_the_post_thumbnail'    => true,
+		'get_the_term_list'         => true,
+		'get_the_title'             => true,
+		'has_post_thumbnail'        => true,
+		'is_attachment'             => true,
+		'next_comments_link'        => true,
+		'next_image_link'           => true,
+		'next_post_link'            => true,
+		'next_posts_link'           => true,
+		'paginate_comments_links'   => true,
+		'permalink_anchor'          => true,
+		'post_password_required'    => true,
+		'post_type_archive_title'   => true,
+		'posts_nav_link'            => true,
+		'previous_comments_link'    => true,
+		'previous_image_link'       => true,
+		'previous_post_link'        => true,
+		'previous_posts_link'       => true,
+		'selected'                  => true,
+		'single_cat_title'          => true,
+		'single_month_title'        => true,
+		'single_post_title'         => true,
+		'single_tag_title'          => true,
+		'single_term_title'         => true,
+		'sticky_class'              => true,
+		'tag_description'           => true,
+		'term_description'          => true,
+		'the_attachment_link'       => true,
+		'the_author_link'           => true,
+		'the_author_meta'           => true,
+		'the_author_posts_link'     => true,
+		'the_author_posts'          => true,
+		'the_author'                => true,
+		'the_category_rss'          => true,
+		'the_category'              => true,
+		'the_content_rss'           => true,
+		'the_content'               => true,
+		'the_date_xml'              => true,
+		'the_date'                  => true,
+		'the_excerpt_rss'           => true,
+		'the_excerpt'               => true,
+		'the_feed_link'             => true,
+		'the_ID'                    => true,
+		'the_meta'                  => true,
+		'the_modified_author'       => true,
+		'the_modified_date'         => true,
+		'the_modified_time'         => true,
+		'the_permalink'             => true,
+		'the_post_thumbnail'        => true,
+		'the_search_query'          => true,
+		'the_shortlink'             => true,
+		'the_tags'                  => true,
+		'the_taxonomies'            => true,
+		'the_terms'                 => true,
+		'the_time'                  => true,
+		'the_title_attribute'       => true,
+		'the_title_rss'             => true,
+		'the_title'                 => true,
+		'vip_powered_wpcom'         => true,
+		'walk_nav_menu_tree'        => true,
+		'wp_attachment_is_image'    => true,
+		'wp_dropdown_categories'    => true,
+		'wp_dropdown_users'         => true,
+		'wp_enqueue_script'         => true,
+		'wp_generate_tag_cloud'     => true,
+		'wp_get_archives'           => true,
+		'wp_get_attachment_image'   => true,
+		'wp_get_attachment_link'    => true,
+		'wp_link_pages'             => true,
+		'wp_list_authors'           => true,
+		'wp_list_bookmarks'         => true,
+		'wp_list_categories'        => true,
+		'wp_list_comments'          => true,
+		'wp_login_form'             => true,
+		'wp_loginout'               => true,
+		'wp_meta'                   => true,
+		'wp_nav_menu'               => true,
+		'wp_register'               => true,
+		'wp_shortlink_header'       => true,
+		'wp_shortlink_wp_head'      => true,
+		'wp_tag_cloud'              => true,
+		'wp_title'                  => true,
+	);
+
+	/**
+	 * Functions that sanitize values.
+	 *
+	 * This list is complementary to the `$unslashingSanitizingFunctions`
+	 * list.
+	 * Sanitizing functions should be added to this list if they do *not*
+	 * implicitely unslash data and to the `$unslashingsanitizingFunctions`
+	 * list if they do.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $sanitizingFunctions = array(
+		'_wp_handle_upload'          => true,
+		'array_key_exists'           => true,
+		'esc_url_raw'                => true,
+		'filter_input'               => true,
+		'filter_var'                 => true,
+		'hash_equals'                => true,
+		'in_array'                   => true,
+		'is_email'                   => true,
+		'number_format'              => true,
+		'sanitize_bookmark_field'    => true,
+		'sanitize_bookmark'          => true,
+		'sanitize_email'             => true,
+		'sanitize_file_name'         => true,
+		'sanitize_hex_color_no_hash' => true,
+		'sanitize_hex_color'         => true,
+		'sanitize_html_class'        => true,
+		'sanitize_meta'              => true,
+		'sanitize_mime_type'         => true,
+		'sanitize_option'            => true,
+		'sanitize_sql_orderby'       => true,
+		'sanitize_term_field'        => true,
+		'sanitize_term'              => true,
+		'sanitize_text_field'        => true,
+		'sanitize_textarea_field'    => true,
+		'sanitize_title_for_query'   => true,
+		'sanitize_title_with_dashes' => true,
+		'sanitize_title'             => true,
+		'sanitize_user_field'        => true,
+		'sanitize_user'              => true,
+		'validate_file'              => true,
+		'wp_handle_sideload'         => true,
+		'wp_handle_upload'           => true,
+		'wp_kses_allowed_html'       => true,
+		'wp_kses_data'               => true,
+		'wp_kses_post'               => true,
+		'wp_kses'                    => true,
+		'wp_parse_id_list'           => true,
+		'wp_redirect'                => true,
+		'wp_safe_redirect'           => true,
+		'wp_strip_all_tags'          => true,
+	);
+
+	/**
+	 * Sanitizing functions that implicitly unslash the data passed to them.
+	 *
+	 * This list is complementary to the `$sanitizingFunctions` list.
+	 * Sanitizing functions should be added to this list if they also
+	 * implicitely unslash data and to the `$sanitizingFunctions` list
+	 * if they don't.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $unslashingSanitizingFunctions = array(
+		'absint'       => true,
+		'boolval'      => true,
+		'floatval'     => true,
+		'intval'       => true,
+		'is_array'     => true,
+		'sanitize_key' => true,
+	);
+
+	/**
+	 * Functions that format strings.
+	 *
+	 * These functions are often used for formatting values just before output, and
+	 * it is common practice to escape the individual parameters passed to them as
+	 * needed instead of escaping the entire result. This is especially true when the
+	 * string being formatted contains HTML, which makes escaping the full result
+	 * more difficult.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $formattingFunctions = array(
+		'array_fill' => true,
+		'ent2ncr'    => true,
+		'implode'    => true,
+		'join'       => true,
+		'nl2br'      => true,
+		'sprintf'    => true,
+		'vsprintf'   => true,
+		'wp_sprintf' => true,
+	);
+
+	/**
+	 * Functions which print output incorporating the values passed to them.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $printingFunctions = array(
+		'_deprecated_argument'    => true,
+		'_deprecated_constructor' => true,
+		'_deprecated_file'        => true,
+		'_deprecated_function'    => true,
+		'_deprecated_hook'        => true,
+		'_doing_it_wrong'         => true,
+		'_e'                      => true,
+		'_ex'                     => true,
+		'die'                     => true,
+		'echo'                    => true,
+		'exit'                    => true,
+		'print'                   => true,
+		'printf'                  => true,
+		'trigger_error'           => true,
+		'user_error'              => true,
+		'vprintf'                 => true,
+		'wp_die'                  => true,
+		'wp_dropdown_pages'       => true,
+	);
+
+	/**
+	 * Functions that escape values for use in SQL queries.
+	 *
+	 * @since 0.9.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $SQLEscapingFunctions = array(
+		'absint'      => true,
+		'esc_sql'     => true,
+		'floatval'    => true,
+		'intval'      => true,
+		'like_escape' => true,
+	);
+
+	/**
+	 * Functions whose output is automatically escaped for use in SQL queries.
+	 *
+	 * @since 0.9.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $SQLAutoEscapedFunctions = array(
+		'count' => true,
+	);
+
+	/**
+	 * A list of functions that get data from the cache.
+	 *
+	 * @since 0.6.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $cacheGetFunctions = array(
+		'wp_cache_get' => true,
+	);
+
+	/**
+	 * A list of functions that set data in the cache.
+	 *
+	 * @since 0.6.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $cacheSetFunctions = array(
+		'wp_cache_set' => true,
+		'wp_cache_add' => true,
+	);
+
+	/**
+	 * A list of functions that delete data from the cache.
+	 *
+	 * @since 0.6.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $cacheDeleteFunctions = array(
+		'wp_cache_delete'         => true,
+		'clean_attachment_cache'  => true,
+		'clean_blog_cache'        => true,
+		'clean_bookmark_cache'    => true,
+		'clean_category_cache'    => true,
+		'clean_comment_cache'     => true,
+		'clean_network_cache'     => true,
+		'clean_object_term_cache' => true,
+		'clean_page_cache'        => true,
+		'clean_post_cache'        => true,
+		'clean_term_cache'        => true,
+		'clean_user_cache'        => true,
+	);
+
+	/**
+	 * A list of functions that invoke WP hooks (filters/actions).
+	 *
+	 * @since 0.10.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $hookInvokeFunctions = array(
+		'do_action'                => true,
+		'do_action_ref_array'      => true,
+		'do_action_deprecated'     => true,
+		'apply_filters'            => true,
+		'apply_filters_ref_array'  => true,
+		'apply_filters_deprecated' => true,
+	);
+
+	/**
+	 * A list of functions that are used to interact with the WP plugins API.
+	 *
+	 * @since 0.10.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array <string function name> => <int position of the hook name argument in function signature>
+	 */
+	protected $hookFunctions = array(
+		'has_filter'         => 1,
+		'add_filter'         => 1,
+		'remove_filter'      => 1,
+		'remove_all_filters' => 1,
+		'doing_filter'       => 1, // Hook name optional.
+		'has_action'         => 1,
+		'add_action'         => 1,
+		'doing_action'       => 1, // Hook name optional.
+		'did_action'         => 1,
+		'remove_action'      => 1,
+		'remove_all_actions' => 1,
+		'current_filter'     => 0, // No hook name argument.
+	);
+
+	/**
+	 * List of global WP variables.
+	 *
+	 * @since 0.3.0
+	 * @since 0.11.0 Changed visibility from public to protected.
+	 * @since 0.12.0 Renamed from `$globals` to `$wp_globals` to be more descriptive.
+	 * @since 0.12.0 Moved from WordPress_Sniffs_Variables_GlobalVariablesSniff to WordPress_Sniff
+	 *
+	 * @var array
+	 */
+	protected $wp_globals = array(
+		'_links_add_base'                  => true,
+		'_links_add_target'                => true,
+		'_menu_item_sort_prop'             => true,
+		'_nav_menu_placeholder'            => true,
+		'_new_bundled_files'               => true,
+		'_old_files'                       => true,
+		'_parent_pages'                    => true,
+		'_registered_pages'                => true,
+		'_updated_user_settings'           => true,
+		'_wp_additional_image_sizes'       => true,
+		'_wp_admin_css_colors'             => true,
+		'_wp_default_headers'              => true,
+		'_wp_deprecated_widgets_callbacks' => true,
+		'_wp_last_object_menu'             => true,
+		'_wp_last_utility_menu'            => true,
+		'_wp_menu_nopriv'                  => true,
+		'_wp_nav_menu_max_depth'           => true,
+		'_wp_post_type_features'           => true,
+		'_wp_real_parent_file'             => true,
+		'_wp_registered_nav_menus'         => true,
+		'_wp_sidebars_widgets'             => true,
+		'_wp_submenu_nopriv'               => true,
+		'_wp_suspend_cache_invalidation'   => true,
+		'_wp_theme_features'               => true,
+		'_wp_using_ext_object_cache'       => true,
+		'action'                           => true,
+		'active_signup'                    => true,
+		'admin_body_class'                 => true,
+		'admin_page_hooks'                 => true,
+		'all_links'                        => true,
+		'allowedentitynames'               => true,
+		'allowedposttags'                  => true,
+		'allowedtags'                      => true,
+		'auth_secure_cookie'               => true,
+		'authordata'                       => true,
+		'avail_post_mime_types'            => true,
+		'avail_post_stati'                 => true,
+		'blog_id'                          => true,
+		'blog_title'                       => true,
+		'blogname'                         => true,
+		'cat'                              => true,
+		'cat_id'                           => true,
+		'charset_collate'                  => true,
+		'comment'                          => true,
+		'comment_alt'                      => true,
+		'comment_depth'                    => true,
+		'comment_status'                   => true,
+		'comment_thread_alt'               => true,
+		'comment_type'                     => true,
+		'comments'                         => true,
+		'compress_css'                     => true,
+		'compress_scripts'                 => true,
+		'concatenate_scripts'              => true,
+		'current_screen'                   => true,
+		'current_site'                     => true,
+		'current_user'                     => true,
+		'currentcat'                       => true,
+		'currentday'                       => true,
+		'currentmonth'                     => true,
+		'custom_background'                => true,
+		'custom_image_header'              => true,
+		'default_menu_order'               => true,
+		'descriptions'                     => true,
+		'domain'                           => true,
+		'editor_styles'                    => true,
+		'error'                            => true,
+		'errors'                           => true,
+		'EZSQL_ERROR'                      => true,
+		'feeds'                            => true,
+		'GETID3_ERRORARRAY'                => true,
+		'hook_suffix'                      => true,
+		'HTTP_RAW_POST_DATA'               => true,
+		'id'                               => true,
+		'in_comment_loop'                  => true,
+		'interim_login'                    => true,
+		'is_apache'                        => true,
+		'is_chrome'                        => true,
+		'is_gecko'                         => true,
+		'is_IE'                            => true,
+		'is_IIS'                           => true,
+		'is_iis7'                          => true,
+		'is_macIE'                         => true,
+		'is_NS4'                           => true,
+		'is_opera'                         => true,
+		'is_safari'                        => true,
+		'is_winIE'                         => true,
+		'l10n'                             => true,
+		'link'                             => true,
+		'link_id'                          => true,
+		'locale'                           => true,
+		'locked_post_status'               => true,
+		'lost'                             => true,
+		'm'                                => true,
+		'map'                              => true,
+		'menu'                             => true,
+		'menu_order'                       => true,
+		'merged_filters'                   => true,
+		'mode'                             => true,
+		'monthnum'                         => true,
+		'more'                             => true,
+		'multipage'                        => true,
+		'names'                            => true,
+		'nav_menu_selected_id'             => true,
+		'new_whitelist_options'            => true,
+		'numpages'                         => true,
+		'one_theme_location_no_menus'      => true,
+		'opml'                             => true,
+		'order'                            => true,
+		'orderby'                          => true,
+		'overridden_cpage'                 => true,
+		'page'                             => true,
+		'paged'                            => true,
+		'pagenow'                          => true,
+		'pages'                            => true,
+		'parent_file'                      => true,
+		'pass_allowed_html'                => true,
+		'pass_allowed_protocols'           => true,
+		'path'                             => true,
+		'per_page'                         => true,
+		'PHP_SELF'                         => true,
+		'phpmailer'                        => true,
+		'plugin_page'                      => true,
+		'plugins'                          => true,
+		'post'                             => true,
+		'post_default_category'            => true,
+		'post_default_title'               => true,
+		'post_ID'                          => true,
+		'post_id'                          => true,
+		'post_mime_types'                  => true,
+		'post_type'                        => true,
+		'post_type_object'                 => true,
+		'posts'                            => true,
+		'preview'                          => true,
+		'previouscat'                      => true,
+		'previousday'                      => true,
+		'previousweekday'                  => true,
+		'redir_tab'                        => true,
+		'required_mysql_version'           => true,
+		'required_php_version'             => true,
+		'rnd_value'                        => true,
+		'role'                             => true,
+		's'                                => true,
+		'search'                           => true,
+		'self'                             => true,
+		'shortcode_tags'                   => true,
+		'show_admin_bar'                   => true,
+		'sidebars_widgets'                 => true,
+		'status'                           => true,
+		'submenu'                          => true,
+		'submenu_file'                     => true,
+		'super_admins'                     => true,
+		'tab'                              => true,
+		'table_prefix'                     => true,
+		'tabs'                             => true,
+		'tag'                              => true,
+		'targets'                          => true,
+		'tax'                              => true,
+		'taxnow'                           => true,
+		'taxonomy'                         => true,
+		'term'                             => true,
+		'text_direction'                   => true,
+		'theme_field_defaults'             => true,
+		'themes_allowedtags'               => true,
+		'timeend'                          => true,
+		'timestart'                        => true,
+		'tinymce_version'                  => true,
+		'title'                            => true,
+		'totals'                           => true,
+		'type'                             => true,
+		'typenow'                          => true,
+		'updated_timestamp'                => true,
+		'upgrading'                        => true,
+		'urls'                             => true,
+		'user_email'                       => true,
+		'user_ID'                          => true,
+		'user_identity'                    => true,
+		'user_level'                       => true,
+		'user_login'                       => true,
+		'user_url'                         => true,
+		'userdata'                         => true,
+		'usersearch'                       => true,
+		'whitelist_options'                => true,
+		'withcomments'                     => true,
+		'wp'                               => true,
+		'wp_actions'                       => true,
+		'wp_admin_bar'                     => true,
+		'wp_cockneyreplace'                => true,
+		'wp_current_db_version'            => true,
+		'wp_current_filter'                => true,
+		'wp_customize'                     => true,
+		'wp_dashboard_control_callbacks'   => true,
+		'wp_db_version'                    => true,
+		'wp_did_header'                    => true,
+		'wp_embed'                         => true,
+		'wp_file_descriptions'             => true,
+		'wp_filesystem'                    => true,
+		'wp_filter'                        => true,
+		'wp_hasher'                        => true,
+		'wp_header_to_desc'                => true,
+		'wp_importers'                     => true,
+		'wp_json'                          => true,
+		'wp_list_table'                    => true,
+		'wp_local_package'                 => true,
+		'wp_locale'                        => true,
+		'wp_meta_boxes'                    => true,
+		'wp_object_cache'                  => true,
+		'wp_plugin_paths'                  => true,
+		'wp_post_statuses'                 => true,
+		'wp_post_types'                    => true,
+		'wp_queries'                       => true,
+		'wp_query'                         => true,
+		'wp_registered_sidebars'           => true,
+		'wp_registered_widget_controls'    => true,
+		'wp_registered_widget_updates'     => true,
+		'wp_registered_widgets'            => true,
+		'wp_rewrite'                       => true,
+		'wp_rich_edit'                     => true,
+		'wp_rich_edit_exists'              => true,
+		'wp_roles'                         => true,
+		'wp_scripts'                       => true,
+		'wp_settings_errors'               => true,
+		'wp_settings_fields'               => true,
+		'wp_settings_sections'             => true,
+		'wp_smiliessearch'                 => true,
+		'wp_styles'                        => true,
+		'wp_taxonomies'                    => true,
+		'wp_the_query'                     => true,
+		'wp_theme_directories'             => true,
+		'wp_themes'                        => true,
+		'wp_user_roles'                    => true,
+		'wp_version'                       => true,
+		'wp_widget_factory'                => true,
+		'wp_xmlrpc_server'                 => true,
+		'wpcommentsjavascript'             => true,
+		'wpcommentspopupfile'              => true,
+		'wpdb'                             => true,
+		'wpsmiliestrans'                   => true,
+		'year'                             => true,
+	);
+
+	/**
+	 * A list of superglobals that incorporate user input.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 Changed from static to non-static.
+	 *
+	 * @var string[]
+	 */
+	protected $input_superglobals = array(
+		'$_COOKIE',
+		'$_GET',
+		'$_FILES',
+		'$_POST',
+		'$_REQUEST',
+		'$_SERVER',
+	);
+
+	/**
+	 * Whitelist of classes which test classes can extend.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string[]
+	 */
+	protected $test_class_whitelist = array(
+		'WP_UnitTestCase'                            => true,
+		'WP_Ajax_UnitTestCase'                       => true,
+		'WP_Canonical_UnitTestCase'                  => true,
+		'WP_Test_REST_TestCase'                      => true,
+		'WP_Test_REST_Controller_Testcase'           => true,
+		'WP_Test_REST_Post_Type_Controller_Testcase' => true,
+		'WP_XMLRPC_UnitTestCase'                     => true,
+		'PHPUnit_Framework_TestCase'                 => true,
+		'PHPUnit\Framework\TestCase'                 => true,
+	);
+
+	/**
+	 * The current file being sniffed.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @var \PHP_CodeSniffer\Files\File
+	 */
+	protected $phpcsFile;
+
+	/**
+	 * The list of tokens in the current file being sniffed.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @var array
+	 */
+	protected $tokens;
+
+	/**
+	 * Set sniff properties and hand off to child class for processing of the token.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$this->init( $phpcsFile );
+		return $this->process_token( $stackPtr );
+	}
+
+	/**
+	 * Processes a sniff when one of its tokens is encountered.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	abstract public function process_token( $stackPtr );
+
+	/**
+	 * Initialize the class for the current process.
+	 *
+	 * This method must be called by child classes before using many of the methods
+	 * below.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file currently being processed.
+	 */
+	protected function init( File $phpcsFile ) {
+		$this->phpcsFile = $phpcsFile;
+		$this->tokens    = $phpcsFile->getTokens();
+	}
+
+	/**
+	 * Strip quotes surrounding an arbitrary string.
+	 *
+	 * Intended for use with the content of a T_CONSTANT_ENCAPSED_STRING / T_DOUBLE_QUOTED_STRING.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param string $string The raw string.
+	 * @return string String without quotes around it.
+	 */
+	public function strip_quotes( $string ) {
+		return preg_replace( '`^([\'"])(.*)\1$`Ds', '$2', $string );
+	}
+
+	/**
+	 * Add a PHPCS message to the output stack as either a warning or an error.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param string $message   The message.
+	 * @param int    $stackPtr  The position of the token the message relates to.
+	 * @param bool   $is_error  Optional. Whether to report the message as an 'error' or 'warning'.
+	 *                          Defaults to true (error).
+	 * @param string $code      Optional error code for the message. Defaults to 'Found'.
+	 * @param array  $data      Optional input for the data replacements.
+	 * @param int    $severity  Optional. Severity level. Defaults to 0 which will translate to
+	 *                          the PHPCS default severity level.
+	 * @return bool
+	 */
+	protected function addMessage( $message, $stackPtr, $is_error = true, $code = 'Found', $data = array(), $severity = 0 ) {
+		return $this->throwMessage( $message, $stackPtr, $is_error, $code, $data, $severity, false );
+	}
+
+	/**
+	 * Add a fixable PHPCS message to the output stack as either a warning or an error.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param string $message   The message.
+	 * @param int    $stackPtr  The position of the token the message relates to.
+	 * @param bool   $is_error  Optional. Whether to report the message as an 'error' or 'warning'.
+	 *                          Defaults to true (error).
+	 * @param string $code      Optional error code for the message. Defaults to 'Found'.
+	 * @param array  $data      Optional input for the data replacements.
+	 * @param int    $severity  Optional. Severity level. Defaults to 0 which will translate to
+	 *                          the PHPCS default severity level.
+	 * @return bool
+	 */
+	protected function addFixableMessage( $message, $stackPtr, $is_error = true, $code = 'Found', $data = array(), $severity = 0 ) {
+		return $this->throwMessage( $message, $stackPtr, $is_error, $code, $data, $severity, true );
+	}
+
+	/**
+	 * Add a PHPCS message to the output stack as either a warning or an error.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param string $message   The message.
+	 * @param int    $stackPtr  The position of the token the message relates to.
+	 * @param bool   $is_error  Optional. Whether to report the message as an 'error' or 'warning'.
+	 *                          Defaults to true (error).
+	 * @param string $code      Optional error code for the message. Defaults to 'Found'.
+	 * @param array  $data      Optional input for the data replacements.
+	 * @param int    $severity  Optional. Severity level. Defaults to 0 which will translate to
+	 *                          the PHPCS default severity level.
+	 * @param bool   $fixable   Optional. Whether this is a fixable error. Defaults to false.
+	 * @return bool
+	 */
+	private function throwMessage( $message, $stackPtr, $is_error = true, $code = 'Found', $data = array(), $severity = 0, $fixable = false ) {
+
+		$method = 'add';
+		if ( true === $fixable ) {
+			$method .= 'Fixable';
+		}
+
+		if ( true === $is_error ) {
+			$method .= 'Error';
+		} else {
+			$method .= 'Warning';
+		}
+
+		return call_user_func( array( $this->phpcsFile, $method ), $message, $stackPtr, $code, $data, $severity );
+	}
+
+	/**
+	 * Convert an arbitrary string to an alphanumeric string with underscores.
+	 *
+	 * Pre-empt issues with arbitrary strings being used as error codes in XML and PHP.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param string $base_string Arbitrary string.
+	 *
+	 * @return string
+	 */
+	protected function string_to_errorcode( $base_string ) {
+		return preg_replace( '`[^a-z0-9_]`i', '_', $base_string );
+	}
+
+	/**
+	 * Merge a pre-set array with a ruleset provided array or inline provided string.
+	 *
+	 * - Will correctly handle custom array properties which were set without
+	 *   the `type="array"` indicator.
+	 *   This also allows for making these custom array properties testable using
+	 *   a `@codingStandardsChangeSetting` comment in the unit tests.
+	 * - By default flips custom lists to allow for using `isset()` instead
+	 *   of `in_array()`.
+	 * - When `$flip` is true:
+	 *   * Presumes the base array is in a `'value' => true` format.
+	 *   * Any custom items will be given the value `false` to be able to
+	 *     distinguish them from pre-set (base array) values.
+	 *   * Will filter previously added custom items out from the base array
+	 *     before merging/returning to allow for resetting to the base array.
+	 *
+	 * {@internal Function is static as it doesn't use any of the properties or others
+	 * methods anyway and this way the `WordPress_Sniffs_NamingConventions_ValidVariableNameSniff`
+	 * which extends an upstream sniff can also use it.}}
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param array|string $custom Custom list as provided via a ruleset.
+	 *                             Can be either a comma-delimited string or
+	 *                             an array of values.
+	 * @param array        $base   Optional. Base list. Defaults to an empty array.
+	 *                             Expects `value => true` format when `$flip` is true.
+	 * @param bool         $flip   Optional. Whether or not to flip the custom list.
+	 *                             Defaults to true.
+	 * @return array
+	 */
+	public static function merge_custom_array( $custom, $base = array(), $flip = true ) {
+		if ( true === $flip ) {
+			$base = array_filter( $base );
+		}
+
+		if ( empty( $custom ) || ( ! is_array( $custom ) && ! is_string( $custom ) ) ) {
+			return $base;
+		}
+
+		// Allow for a comma delimited list.
+		if ( is_string( $custom ) ) {
+			$custom = explode( ',', $custom );
+		}
+
+		// Always trim whitespace from the values.
+		$custom = array_filter( array_map( 'trim', $custom ) );
+
+		if ( true === $flip ) {
+			$custom = array_fill_keys( $custom, false );
+		}
+
+		if ( empty( $base ) ) {
+			return $custom;
+		}
+
+		return array_merge( $base, $custom );
+	}
+
+	/**
+	 * Get the last pointer in a line.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param integer $stackPtr The position of the current token in the stack passed
+	 *                          in $tokens.
+	 *
+	 * @return integer Position of the last pointer on that line.
+	 */
+	protected function get_last_ptr_on_line( $stackPtr ) {
+
+		$tokens      = $this->tokens;
+		$currentLine = $tokens[ $stackPtr ]['line'];
+		$nextPtr     = ( $stackPtr + 1 );
+
+		while ( isset( $tokens[ $nextPtr ] ) && $tokens[ $nextPtr ]['line'] === $currentLine ) {
+			$nextPtr++;
+			// Do nothing, we just want the last token of the line.
+		}
+
+		// We've made it to the next line, back up one to the last in the previous line.
+		// We do this for micro-optimization of the above loop.
+		$lastPtr = ( $nextPtr - 1 );
+
+		return $lastPtr;
+	}
+
+	/**
+	 * Overrule the minimum supported WordPress version with a command-line/config value.
+	 *
+	 * Handle setting the minimum supported WP version in one go for all sniffs which
+	 * expect it via the command line or via a `<config>` variable in a ruleset.
+	 * The config variable overrules the default `$minimum_supported_version` and/or a
+	 * `$minimum_supported_version` set for individual sniffs through the ruleset.
+	 *
+	 * @since 0.14.0
+	 */
+	protected function get_wp_version_from_cl() {
+		$cl_supported_version = trim( PHPCSHelper::get_config_data( 'minimum_supported_wp_version' ) );
+		if ( ! empty( $cl_supported_version )
+			&& filter_var( $cl_supported_version, FILTER_VALIDATE_FLOAT ) !== false
+		) {
+			$this->minimum_supported_version = $cl_supported_version;
+		}
+	}
+
+	/**
+	 * Find whitelisting comment.
+	 *
+	 * Comment must be at the end of the line or at the end of the statement
+	 * and must use // format.
+	 * It can be prefixed or suffixed with anything e.g. "foobar" will match:
+	 * ... // foobar okay
+	 * ... // WPCS: foobar whitelist.
+	 *
+	 * There is an exception, and that is when PHP is being interspersed with HTML.
+	 * In that case, the comment should always come at the end of the statement (right
+	 * before the closing tag, ?>). For example:
+	 *
+	 * <input type="text" id="<?php echo $id; // XSS OK ?>" />
+	 *
+	 * @since 0.4.0
+	 * @since 0.14.0 Whitelist comments at the end of the statement are now also accepted.
+	 *
+	 * @param string  $comment  Comment to find.
+	 * @param integer $stackPtr The position of the current token in the stack passed
+	 *                          in $tokens.
+	 *
+	 * @return boolean True if whitelisting comment was found, false otherwise.
+	 */
+	protected function has_whitelist_comment( $comment, $stackPtr ) {
+
+		// Respect the PHPCS 3.x --ignore-annotations setting.
+		if ( true === PHPCSHelper::ignore_annotations( $this->phpcsFile ) ) {
+			return false;
+		}
+
+		$regex = '#\b' . preg_quote( $comment, '#' ) . '\b#i';
+
+		// There is a findEndOfStatement() method, but it considers more tokens than
+		// we need to here.
+		$end_of_statement = $this->phpcsFile->findNext( array( T_CLOSE_TAG, T_SEMICOLON ), $stackPtr );
+
+		if ( false !== $end_of_statement ) {
+			// If the statement was ended by a semicolon, check if there is a whitelist comment directly after it.
+			if ( T_SEMICOLON === $this->tokens[ $end_of_statement ]['code'] ) {
+				$lastPtr = $this->phpcsFile->findNext( T_WHITESPACE, ( $end_of_statement + 1 ), null, true );
+			} elseif ( T_CLOSE_TAG === $this->tokens[ $end_of_statement ]['code'] ) {
+				// If the semicolon was left out and it was terminated by an ending tag, we need to look backwards.
+				$lastPtr = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $end_of_statement - 1 ), null, true );
+			}
+
+			if ( T_COMMENT === $this->tokens[ $lastPtr ]['code']
+				&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $end_of_statement ]['line']
+				&& preg_match( $regex, $this->tokens[ $lastPtr ]['content'] ) === 1
+			) {
+				return true;
+			}
+		}
+
+		// No whitelist comment found so far. Check at the end of the stackPtr line.
+		// Note: a T_COMMENT includes the new line character, so may be the last token on the line!
+		$end_of_line = $this->get_last_ptr_on_line( $stackPtr );
+		$lastPtr     = $this->phpcsFile->findPrevious( T_WHITESPACE, $end_of_line, null, true );
+
+		if ( T_COMMENT === $this->tokens[ $lastPtr ]['code']
+			&& $this->tokens[ $lastPtr ]['line'] === $this->tokens[ $stackPtr ]['line']
+			&& preg_match( $regex, $this->tokens[ $lastPtr ]['content'] ) === 1
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if a token is used within a unit test.
+	 *
+	 * Unit test methods are identified as such:
+	 * - Method name starts with `test_`.
+	 * - Method is within a unit test class.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int $stackPtr The position of the token to be examined.
+	 *
+	 * @return bool True if the token is within a unit test, false otherwise.
+	 */
+	protected function is_token_in_test_method( $stackPtr ) {
+		// Is the token inside of a function definition ?
+		$functionToken = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+		if ( false === $functionToken ) {
+			return false;
+		}
+
+		// Is this a method inside of a class or a trait ?
+		$classToken = $this->phpcsFile->getCondition( $functionToken, T_CLASS );
+		$traitToken = $this->phpcsFile->getCondition( $functionToken, T_TRAIT );
+		if ( false === $classToken && false === $traitToken ) {
+			return false;
+		}
+
+		$structureToken = $classToken;
+		if ( false !== $traitToken ) {
+			$structureToken = $traitToken;
+		}
+
+		return $this->is_test_class( $structureToken );
+	}
+
+	/**
+	 * Check if a class token is part of a unit test suite.
+	 *
+	 * Unit test classes are identified as such:
+	 * - Class which either extends WP_UnitTestCase or PHPUnit_Framework_TestCase
+	 *   or a custom whitelisted unit test class.
+	 *
+	 * @since 0.12.0 Split off from the `is_token_in_test_method()` method.
+	 *
+	 * @param int $stackPtr The position of the token to be examined.
+	 *                      This should be a class, anonymous class or trait token.
+	 *
+	 * @return bool True if the class is a unit test class, false otherwise.
+	 */
+	protected function is_test_class( $stackPtr ) {
+
+		if ( ! isset( $this->tokens[ $stackPtr ] )
+			|| in_array( $this->tokens[ $stackPtr ]['type'], array( 'T_CLASS', 'T_ANON_CLASS', 'T_TRAIT' ), true ) === false
+		) {
+			return false;
+		}
+
+		// Add any potentially whitelisted custom test classes to the whitelist.
+		$whitelist = $this->merge_custom_array(
+			$this->custom_test_class_whitelist,
+			$this->test_class_whitelist
+		);
+
+		// Is the class/trait one of the whitelisted test classes ?
+		$className = $this->phpcsFile->getDeclarationName( $stackPtr );
+		if ( isset( $whitelist[ $className ] ) ) {
+			return true;
+		}
+
+		// Does the class/trait extend one of the whitelisted test classes ?
+		$extendedClassName = $this->phpcsFile->findExtendedClassName( $stackPtr );
+		if ( isset( $whitelist[ $extendedClassName ] ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if this variable is being assigned a value.
+	 *
+	 * E.g., $var = 'foo';
+	 *
+	 * Also handles array assignments to arbitrary depth:
+	 *
+	 * $array['key'][ $foo ][ something() ] = $bar;
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param int $stackPtr The index of the token in the stack. This must point to
+	 *                      either a T_VARIABLE or T_CLOSE_SQUARE_BRACKET token.
+	 *
+	 * @return bool Whether the token is a variable being assigned a value.
+	 */
+	protected function is_assignment( $stackPtr ) {
+
+		static $valid = array(
+			T_VARIABLE             => true,
+			T_CLOSE_SQUARE_BRACKET => true,
+		);
+
+		// Must be a variable, constant or closing square bracket (see below).
+		if ( ! isset( $valid[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
+			return false;
+		}
+
+		$next_non_empty = $this->phpcsFile->findNext(
+			Tokens::$emptyTokens,
+			( $stackPtr + 1 ),
+			null,
+			true,
+			null,
+			true
+		);
+
+		// No token found.
+		if ( false === $next_non_empty ) {
+			return false;
+		}
+
+		// If the next token is an assignment, that's all we need to know.
+		if ( isset( Tokens::$assignmentTokens[ $this->tokens[ $next_non_empty ]['code'] ] ) ) {
+			return true;
+		}
+
+		// Check if this is an array assignment, e.g., `$var['key'] = 'val';` .
+		if ( T_OPEN_SQUARE_BRACKET === $this->tokens[ $next_non_empty ]['code'] ) {
+			return $this->is_assignment( $this->tokens[ $next_non_empty ]['bracket_closer'] );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if this token has an associated nonce check.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack of tokens.
+	 *
+	 * @return bool
+	 */
+	protected function has_nonce_check( $stackPtr ) {
+
+		/**
+		 * A cache of the scope that we last checked for nonce verification in.
+		 *
+		 * @var array {
+		 *      @var string   $file        The name of the file.
+		 *      @var int      $start       The index of the token where the scope started.
+		 *      @var int      $end         The index of the token where the scope ended.
+		 *      @var bool|int $nonce_check The index of the token where an nonce check
+		 *                                 was found, or false if none was found.
+		 * }
+		 */
+		static $last;
+
+		$start = 0;
+		$end   = $stackPtr;
+
+		$tokens = $this->phpcsFile->getTokens();
+
+		// If we're in a function, only look inside of it.
+		$f = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+		if ( false !== $f ) {
+			$start = $tokens[ $f ]['scope_opener'];
+		} else {
+			$f = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+			if ( false !== $f ) {
+				$start = $tokens[ $f ]['scope_opener'];
+			}
+		}
+
+		$in_isset = $this->is_in_isset_or_empty( $stackPtr );
+
+		// We allow for isset( $_POST['var'] ) checks to come before the nonce check.
+		// If this is inside an isset(), check after it as well, all the way to the
+		// end of the scope.
+		if ( $in_isset ) {
+			$end = ( 0 === $start ) ? $this->phpcsFile->numTokens : $tokens[ $start ]['scope_closer'];
+		}
+
+		// Check if we've looked here before.
+		$filename = $this->phpcsFile->getFilename();
+
+		if (
+			$filename === $last['file']
+			&& $start === $last['start']
+		) {
+
+			if ( false !== $last['nonce_check'] ) {
+				// If we have already found an nonce check in this scope, we just
+				// need to check whether it comes before this token. It is OK if the
+				// check is after the token though, if this was only a isset() check.
+				return ( $in_isset || $last['nonce_check'] < $stackPtr );
+			} elseif ( $end <= $last['end'] ) {
+				// If not, we can still go ahead and return false if we've already
+				// checked to the end of the search area.
+				return false;
+			}
+
+			// We haven't checked this far yet, but we can still save work by
+			// skipping over the part we've already checked.
+			$start = $last['end'];
+		} else {
+			$last = array(
+				'file'  => $filename,
+				'start' => $start,
+				'end'   => $end,
+			);
+		}
+
+		// Loop through the tokens looking for nonce verification functions.
+		for ( $i = $start; $i < $end; $i++ ) {
+
+			// If this isn't a function name, skip it.
+			if ( T_STRING !== $tokens[ $i ]['code'] ) {
+				continue;
+			}
+
+			// If this is one of the nonce verification functions, we can bail out.
+			if ( isset( $this->nonceVerificationFunctions[ $tokens[ $i ]['content'] ] ) ) {
+				$last['nonce_check'] = $i;
+				return true;
+			}
+		}
+
+		// We're still here, so no luck.
+		$last['nonce_check'] = false;
+
+		return false;
+	}
+
+	/**
+	 * Check if a token is inside of an isset() or empty() statement.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param int $stackPtr The index of the token in the stack.
+	 *
+	 * @return bool Whether the token is inside an isset() or empty() statement.
+	 */
+	protected function is_in_isset_or_empty( $stackPtr ) {
+
+		if ( ! isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+			return false;
+		}
+
+		end( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+		$open_parenthesis = key( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+		reset( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+
+		return in_array( $this->tokens[ ( $open_parenthesis - 1 ) ]['code'], array( T_ISSET, T_EMPTY ), true );
+	}
+
+	/**
+	 * Check if something is only being sanitized.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param int $stackPtr The index of the token in the stack.
+	 *
+	 * @return bool Whether the token is only within a sanitization.
+	 */
+	protected function is_only_sanitized( $stackPtr ) {
+
+		// If it isn't being sanitized at all.
+		if ( ! $this->is_sanitized( $stackPtr ) ) {
+			return false;
+		}
+
+		// If this isn't set, we know the value must have only been casted, because
+		// is_sanitized() would have returned false otherwise.
+		if ( ! isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+			return true;
+		}
+
+		// At this point we're expecting the value to have not been casted. If it
+		// was, it wasn't *only* casted, because it's also in a function.
+		if ( $this->is_safe_casted( $stackPtr ) ) {
+			return false;
+		}
+
+		// The only parentheses should belong to the sanitizing function. If there's
+		// more than one set, this isn't *only* sanitization.
+		return ( count( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) === 1 );
+	}
+
+	/**
+	 * Check if something is being casted to a safe value.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param int $stackPtr The index of the token in the stack.
+	 *
+	 * @return bool Whether the token being casted.
+	 */
+	protected function is_safe_casted( $stackPtr ) {
+
+		// Get the last non-empty token.
+		$prev = $this->phpcsFile->findPrevious(
+			Tokens::$emptyTokens,
+			( $stackPtr - 1 ),
+			null,
+			true
+		);
+
+		// Check if it is a safe cast.
+		return in_array( $this->tokens[ $prev ]['code'], array( T_INT_CAST, T_DOUBLE_CAST, T_BOOL_CAST ), true );
+	}
+
+	/**
+	 * Check if something is being sanitized.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param int  $stackPtr        The index of the token in the stack.
+	 * @param bool $require_unslash Whether to give an error if wp_unslash() isn't
+	 *                              used on the variable before sanitization.
+	 *
+	 * @return bool Whether the token being sanitized.
+	 */
+	protected function is_sanitized( $stackPtr, $require_unslash = false ) {
+
+		// First we check if it is being casted to a safe value.
+		if ( $this->is_safe_casted( $stackPtr ) ) {
+			return true;
+		}
+
+		// If this isn't within a function call, we know already that it's not safe.
+		if ( ! isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+			if ( $require_unslash ) {
+				$this->add_unslash_error( $stackPtr );
+			}
+			return false;
+		}
+
+		// Get the function that it's in.
+		$function_closer = end( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+		$function_opener = key( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+		$function        = $this->tokens[ ( $function_opener - 1 ) ];
+
+		// If it is just being unset, the value isn't used at all, so it's safe.
+		if ( T_UNSET === $function['code'] ) {
+			return true;
+		}
+
+		// If this isn't a call to a function, it sure isn't sanitizing function.
+		if ( T_STRING !== $function['code'] ) {
+			if ( $require_unslash ) {
+				$this->add_unslash_error( $stackPtr );
+			}
+			return false;
+		}
+
+		$functionName = $function['content'];
+
+		// Check if wp_unslash() is being used.
+		if ( 'wp_unslash' === $functionName ) {
+
+			$is_unslashed    = true;
+			$function_closer = prev( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+
+			// If there is no other function being used, this value is unsanitized.
+			if ( ! $function_closer ) {
+				return false;
+			}
+
+			$function_opener = key( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+			$functionName    = $this->tokens[ ( $function_opener - 1 ) ]['content'];
+
+		} else {
+
+			$is_unslashed = false;
+		}
+
+		// Arrays might be sanitized via array_map().
+		if ( 'array_map' === $functionName ) {
+
+			// Get the first parameter.
+			$callback = $this->get_function_call_parameter( ( $function_opener - 1 ), 1 );
+
+			if ( ! empty( $callback ) ) {
+				/*
+				 * If this is a function callback (not a method callback array) and we're able
+				 * to resolve the function name, do so.
+				 */
+				$first_non_empty = $this->phpcsFile->findNext(
+					Tokens::$emptyTokens,
+					$callback['start'],
+					( $callback['end'] + 1 ),
+					true
+				);
+
+				if ( false !== $first_non_empty && T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $first_non_empty ]['code'] ) {
+					$functionName = $this->strip_quotes( $this->tokens[ $first_non_empty ]['content'] );
+				}
+			}
+		}
+
+		// If slashing is required, give an error.
+		if ( ! $is_unslashed && $require_unslash && ! isset( $this->unslashingSanitizingFunctions[ $functionName ] ) ) {
+			$this->add_unslash_error( $stackPtr );
+		}
+
+		// Check if this is a sanitizing function.
+		if ( isset( $this->sanitizingFunctions[ $functionName ] ) || isset( $this->unslashingSanitizingFunctions[ $functionName ] ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Add an error for missing use of wp_unslash().
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param int $stackPtr The index of the token in the stack.
+	 */
+	public function add_unslash_error( $stackPtr ) {
+
+		$this->phpcsFile->addError(
+			'Missing wp_unslash() before sanitization.',
+			$stackPtr,
+			'MissingUnslash',
+			array( $this->tokens[ $stackPtr ]['content'] )
+		);
+	}
+
+	/**
+	 * Get the index key of an array variable.
+	 *
+	 * E.g., "bar" in $foo['bar'].
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param int $stackPtr The index of the token in the stack.
+	 *
+	 * @return string|false The array index key whose value is being accessed.
+	 */
+	protected function get_array_access_key( $stackPtr ) {
+
+		// Find the next non-empty token.
+		$open_bracket = $this->phpcsFile->findNext(
+			Tokens::$emptyTokens,
+			( $stackPtr + 1 ),
+			null,
+			true
+		);
+
+		// If it isn't a bracket, this isn't an array-access.
+		if ( false === $open_bracket || T_OPEN_SQUARE_BRACKET !== $this->tokens[ $open_bracket ]['code'] ) {
+			return false;
+		}
+
+		$key = $this->phpcsFile->getTokensAsString(
+			( $open_bracket + 1 ),
+			( $this->tokens[ $open_bracket ]['bracket_closer'] - $open_bracket - 1 )
+		);
+
+		return trim( $key );
+	}
+
+	/**
+	 * Check if the existence of a variable is validated with isset() or empty().
+	 *
+	 * When $in_condition_only is false, (which is the default), this is considered
+	 * valid:
+	 *
+	 * ```php
+	 * if ( isset( $var ) ) {
+	 *     // Do stuff, like maybe return or exit (but could be anything)
+	 * }
+	 *
+	 * foo( $var );
+	 * ```
+	 *
+	 * When it is true, that would be invalid, the use of the variable must be within
+	 * the scope of the validating condition, like this:
+	 *
+	 * ```php
+	 * if ( isset( $var ) ) {
+	 *     foo( $var );
+	 * }
+	 * ```
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param int    $stackPtr          The index of this token in the stack.
+	 * @param string $array_key         An array key to check for ("bar" in $foo['bar']).
+	 * @param bool   $in_condition_only Whether to require that this use of the
+	 *                                  variable occur within the scope of the
+	 *                                  validating condition, or just in the same
+	 *                                  scope as it (default).
+	 *
+	 * @return bool Whether the var is validated.
+	 */
+	protected function is_validated( $stackPtr, $array_key = null, $in_condition_only = false ) {
+
+		if ( $in_condition_only ) {
+			/*
+			 * This is a stricter check, requiring the variable to be used only
+			 * within the validation condition.
+			 */
+
+			// If there are no conditions, there's no validation.
+			if ( empty( $this->tokens[ $stackPtr ]['conditions'] ) ) {
+				return false;
+			}
+
+			$conditions = $this->tokens[ $stackPtr ]['conditions'];
+			end( $conditions ); // Get closest condition.
+			$conditionPtr = key( $conditions );
+			$condition    = $this->tokens[ $conditionPtr ];
+
+			if ( ! isset( $condition['parenthesis_opener'] ) ) {
+				// Live coding or parse error.
+				return false;
+			}
+
+			$scope_start = $condition['parenthesis_opener'];
+			$scope_end   = $condition['parenthesis_closer'];
+
+		} else {
+			/*
+			 * We are are more loose, requiring only that the variable be validated
+			 * in the same function/file scope as it is used.
+			 */
+
+			$scope_start = 0;
+
+			// Check if we are in a function.
+			$function = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+
+			// If so, we check only within the function, otherwise the whole file.
+			if ( false !== $function ) {
+				$scope_start = $this->tokens[ $function ]['scope_opener'];
+			} else {
+				// Check if we are in a closure.
+				$closure = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+
+				// If so, we check only within the closure.
+				if ( false !== $closure ) {
+					$scope_start = $this->tokens[ $closure ]['scope_opener'];
+				}
+			}
+
+			$scope_end = $stackPtr;
+
+		}
+
+		for ( $i = ( $scope_start + 1 ); $i < $scope_end; $i++ ) {
+
+			if ( ! in_array( $this->tokens[ $i ]['code'], array( T_ISSET, T_EMPTY, T_UNSET ), true ) ) {
+				continue;
+			}
+
+			$issetOpener = $this->phpcsFile->findNext( T_OPEN_PARENTHESIS, $i );
+			$issetCloser = $this->tokens[ $issetOpener ]['parenthesis_closer'];
+
+			// Look for this variable. We purposely stomp $i from the parent loop.
+			for ( $i = ( $issetOpener + 1 ); $i < $issetCloser; $i++ ) {
+
+				if ( T_VARIABLE !== $this->tokens[ $i ]['code'] ) {
+					continue;
+				}
+
+				// If we're checking for a specific array key (ex: 'hello' in
+				// $_POST['hello']), that must match too.
+				if ( isset( $array_key ) && $this->get_array_access_key( $i ) !== $array_key ) {
+					continue;
+				}
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check whether a variable is being compared to another value.
+	 *
+	 * E.g., $var === 'foo', 1 <= $var, etc.
+	 *
+	 * Also recognizes `switch ( $var )`.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @param int $stackPtr The index of this token in the stack.
+	 *
+	 * @return bool Whether this is a comparison.
+	 */
+	protected function is_comparison( $stackPtr ) {
+
+		// We first check if this is a switch statement (switch ( $var )).
+		if ( isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+			$close_parenthesis = end( $this->tokens[ $stackPtr ]['nested_parenthesis'] );
+
+			if (
+				isset( $this->tokens[ $close_parenthesis ]['parenthesis_owner'] )
+				&& T_SWITCH === $this->tokens[ $this->tokens[ $close_parenthesis ]['parenthesis_owner'] ]['code']
+			) {
+				return true;
+			}
+		}
+
+		// Find the previous non-empty token. We check before the var first because
+		// yoda conditions are usually expected.
+		$previous_token = $this->phpcsFile->findPrevious(
+			Tokens::$emptyTokens,
+			( $stackPtr - 1 ),
+			null,
+			true
+		);
+
+		if ( isset( Tokens::$comparisonTokens[ $this->tokens[ $previous_token ]['code'] ] ) ) {
+			return true;
+		}
+
+		// Maybe the comparison operator is after this.
+		$next_token = $this->phpcsFile->findNext(
+			Tokens::$emptyTokens,
+			( $stackPtr + 1 ),
+			null,
+			true
+		);
+
+		// This might be an opening square bracket in the case of arrays ($var['a']).
+		while ( T_OPEN_SQUARE_BRACKET === $this->tokens[ $next_token ]['code'] ) {
+
+			$next_token = $this->phpcsFile->findNext(
+				Tokens::$emptyTokens,
+				( $this->tokens[ $next_token ]['bracket_closer'] + 1 ),
+				null,
+				true
+			);
+		}
+
+		if ( isset( Tokens::$comparisonTokens[ $this->tokens[ $next_token ]['code'] ] ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check what type of 'use' statement a token is part of.
+	 *
+	 * The T_USE token has multiple different uses:
+	 *
+	 * 1. In a closure: function () use ( $var ) {}
+	 * 2. In a class, to import a trait: use Trait_Name
+	 * 3. In a namespace, to import a class: use Some\Class;
+	 *
+	 * This function will check the token and return 'closure', 'trait', or 'class',
+	 * based on which of these uses the use is being used for.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param int $stackPtr The position of the token to check.
+	 *
+	 * @return string The type of use.
+	 */
+	protected function get_use_type( $stackPtr ) {
+
+		// USE keywords inside closures.
+		$next = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+
+		if ( T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code'] ) {
+			return 'closure';
+		}
+
+		// USE keywords for traits.
+		$valid_scopes = array(
+			'T_CLASS'      => true,
+			'T_ANON_CLASS' => true,
+			'T_TRAIT'      => true,
+		);
+		if ( true === $this->valid_direct_scope( $stackPtr, $valid_scopes ) ) {
+			return 'trait';
+		}
+
+		// USE keywords for classes to import to a namespace.
+		return 'class';
+	}
+
+	/**
+	 * Get the interpolated variable names from a string.
+	 *
+	 * Check if '$' is followed by a valid variable name, and that it is not preceded by an escape sequence.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param string $string A T_DOUBLE_QUOTED_STRING or T_HEREDOC token.
+	 *
+	 * @return array Variable names (without '$' sigil).
+	 */
+	protected function get_interpolated_variables( $string ) {
+		$variables = array();
+		if ( preg_match_all( '/(?P<backslashes>\\\\*)\$(?P<symbol>\w+)/', $string, $match_sets, PREG_SET_ORDER ) ) {
+			foreach ( $match_sets as $matches ) {
+				if ( ! isset( $matches['backslashes'] ) || ( strlen( $matches['backslashes'] ) % 2 ) === 0 ) {
+					$variables[] = $matches['symbol'];
+				}
+			}
+		}
+		return $variables;
+	}
+
+	/**
+	 * Strip variables from an arbitrary double quoted/heredoc string.
+	 *
+	 * Intended for use with the content of a T_DOUBLE_QUOTED_STRING or T_HEREDOC token.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param string $string The raw string.
+	 *
+	 * @return string String without variables in it.
+	 */
+	public function strip_interpolated_variables( $string ) {
+		if ( strpos( $string, '$' ) === false ) {
+			return $string;
+		}
+
+		return preg_replace( self::REGEX_COMPLEX_VARS, '', $string );
+	}
+
+	/**
+	 * Checks if a function call has parameters.
+	 *
+	 * Expects to be passed the T_STRING stack pointer for the function call.
+	 * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
+	 *
+	 * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer, it
+	 * will detect whether the array has values or is empty.
+	 *
+	 * @link https://github.com/wimg/PHPCompatibility/issues/120
+	 * @link https://github.com/wimg/PHPCompatibility/issues/152
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int $stackPtr The position of the function call token.
+	 *
+	 * @return bool
+	 */
+	public function does_function_call_have_parameters( $stackPtr ) {
+
+		// Check for the existence of the token.
+		if ( false === isset( $this->tokens[ $stackPtr ] ) ) {
+			return false;
+		}
+
+		// Is this one of the tokens this function handles ?
+		if ( false === in_array( $this->tokens[ $stackPtr ]['code'], array( T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY ), true ) ) {
+			return false;
+		}
+
+		$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+
+		// Deal with short array syntax.
+		if ( 'T_OPEN_SHORT_ARRAY' === $this->tokens[ $stackPtr ]['type'] ) {
+			if ( false === isset( $this->tokens[ $stackPtr ]['bracket_closer'] ) ) {
+				return false;
+			}
+
+			if ( $next_non_empty === $this->tokens[ $stackPtr ]['bracket_closer'] ) {
+				// No parameters.
+				return false;
+			} else {
+				return true;
+			}
+		}
+
+		// Deal with function calls & long arrays.
+		// Next non-empty token should be the open parenthesis.
+		if ( false === $next_non_empty && T_OPEN_PARENTHESIS !== $this->tokens[ $next_non_empty ]['code'] ) {
+			return false;
+		}
+
+		if ( false === isset( $this->tokens[ $next_non_empty ]['parenthesis_closer'] ) ) {
+			return false;
+		}
+
+		$close_parenthesis   = $this->tokens[ $next_non_empty ]['parenthesis_closer'];
+		$next_next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), ( $close_parenthesis + 1 ), true );
+
+		if ( $next_next_non_empty === $close_parenthesis ) {
+			// No parameters.
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Count the number of parameters a function call has been passed.
+	 *
+	 * Expects to be passed the T_STRING stack pointer for the function call.
+	 * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
+	 *
+	 * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer,
+	 * it will return the number of values in the array.
+	 *
+	 * @link https://github.com/wimg/PHPCompatibility/issues/111
+	 * @link https://github.com/wimg/PHPCompatibility/issues/114
+	 * @link https://github.com/wimg/PHPCompatibility/issues/151
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int $stackPtr The position of the function call token.
+	 *
+	 * @return int
+	 */
+	public function get_function_call_parameter_count( $stackPtr ) {
+		if ( false === $this->does_function_call_have_parameters( $stackPtr ) ) {
+			return 0;
+		}
+
+		return count( $this->get_function_call_parameters( $stackPtr ) );
+	}
+
+	/**
+	 * Get information on all parameters passed to a function call.
+	 *
+	 * Expects to be passed the T_STRING stack pointer for the function call.
+	 * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
+	 *
+	 * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer,
+	 * it will tokenize the values / key/value pairs contained in the array call.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int $stackPtr The position of the function call token.
+	 *
+	 * @return array Multi-dimentional array with parameter details or
+	 *               empty array if no parameter are found.
+	 *
+	 *               @type int $position 1-based index position of the parameter. {
+	 *                   @type int $start Stack pointer for the start of the parameter.
+	 *                   @type int $end   Stack pointer for the end of parameter.
+	 *                   @type int $raw   Trimmed raw parameter content.
+	 *               }
+	 */
+	public function get_function_call_parameters( $stackPtr ) {
+		if ( false === $this->does_function_call_have_parameters( $stackPtr ) ) {
+			return array();
+		}
+
+		/*
+		 * Ok, we know we have a T_STRING, T_ARRAY or T_OPEN_SHORT_ARRAY with parameters
+		 * and valid open & close brackets/parenthesis.
+		 */
+
+		// Mark the beginning and end tokens.
+		if ( 'T_OPEN_SHORT_ARRAY' === $this->tokens[ $stackPtr ]['type'] ) {
+			$opener = $stackPtr;
+			$closer = $this->tokens[ $stackPtr ]['bracket_closer'];
+
+			$nestedParenthesisCount = 0;
+		} else {
+			$opener = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+			$closer = $this->tokens[ $opener ]['parenthesis_closer'];
+
+			$nestedParenthesisCount = 1;
+		}
+
+		// Which nesting level is the one we are interested in ?
+		if ( isset( $this->tokens[ $opener ]['nested_parenthesis'] ) ) {
+			$nestedParenthesisCount += count( $this->tokens[ $opener ]['nested_parenthesis'] );
+		}
+
+		$parameters  = array();
+		$next_comma  = $opener;
+		$param_start = ( $opener + 1 );
+		$cnt         = 1;
+		while ( $next_comma = $this->phpcsFile->findNext( array( T_COMMA, $this->tokens[ $closer ]['code'], T_OPEN_SHORT_ARRAY ), ( $next_comma + 1 ), ( $closer + 1 ) ) ) {
+			// Ignore anything within short array definition brackets.
+			if ( 'T_OPEN_SHORT_ARRAY' === $this->tokens[ $next_comma ]['type']
+				&& ( isset( $this->tokens[ $next_comma ]['bracket_opener'] )
+					&& $this->tokens[ $next_comma ]['bracket_opener'] === $next_comma )
+				&& isset( $this->tokens[ $next_comma ]['bracket_closer'] )
+			) {
+				// Skip forward to the end of the short array definition.
+				$next_comma = $this->tokens[ $next_comma ]['bracket_closer'];
+				continue;
+			}
+
+			// Ignore comma's at a lower nesting level.
+			if ( T_COMMA === $this->tokens[ $next_comma ]['code']
+				&& isset( $this->tokens[ $next_comma ]['nested_parenthesis'] )
+				&& count( $this->tokens[ $next_comma ]['nested_parenthesis'] ) !== $nestedParenthesisCount
+			) {
+				continue;
+			}
+
+			// Ignore closing parenthesis/bracket if not 'ours'.
+			if ( $this->tokens[ $next_comma ]['type'] === $this->tokens[ $closer ]['type'] && $next_comma !== $closer ) {
+				continue;
+			}
+
+			// Ok, we've reached the end of the parameter.
+			$parameters[ $cnt ]['start'] = $param_start;
+			$parameters[ $cnt ]['end']   = ( $next_comma - 1 );
+			$parameters[ $cnt ]['raw']   = trim( $this->phpcsFile->getTokensAsString( $param_start, ( $next_comma - $param_start ) ) );
+
+			/*
+			 * Check if there are more tokens before the closing parenthesis.
+			 * Prevents code like the following from setting a third parameter:
+			 * functionCall( $param1, $param2, );
+			 */
+			$has_next_param = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_comma + 1 ), $closer, true, null, true );
+			if ( false === $has_next_param ) {
+				break;
+			}
+
+			// Prepare for the next parameter.
+			$param_start = ( $next_comma + 1 );
+			$cnt++;
+		}
+
+		return $parameters;
+	}
+
+	/**
+	 * Get information on a specific parameter passed to a function call.
+	 *
+	 * Expects to be passed the T_STRING stack pointer for the function call.
+	 * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
+	 *
+	 * Will return a array with the start token pointer, end token pointer and the raw value
+	 * of the parameter at a specific offset.
+	 * If the specified parameter is not found, will return false.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int $stackPtr     The position of the function call token.
+	 * @param int $param_offset The 1-based index position of the parameter to retrieve.
+	 *
+	 * @return array|false
+	 */
+	public function get_function_call_parameter( $stackPtr, $param_offset ) {
+		$parameters = $this->get_function_call_parameters( $stackPtr );
+
+		if ( false === isset( $parameters[ $param_offset ] ) ) {
+			return false;
+		}
+
+		return $parameters[ $param_offset ];
+	}
+
+	/**
+	 * Find the array opener & closer based on a T_ARRAY or T_OPEN_SHORT_ARRAY token.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @param int $stackPtr The stack pointer to the array token.
+	 *
+	 * @return array|bool Array with two keys `opener`, `closer` or false if
+	 *                    either or these could not be determined.
+	 */
+	protected function find_array_open_close( $stackPtr ) {
+		/*
+		 * Determine the array opener & closer.
+		 */
+		if ( T_ARRAY === $this->tokens[ $stackPtr ]['code'] ) {
+			if ( isset( $this->tokens[ $stackPtr ]['parenthesis_opener'] ) ) {
+				$opener = $this->tokens[ $stackPtr ]['parenthesis_opener'];
+
+				if ( isset( $this->tokens[ $opener ]['parenthesis_closer'] ) ) {
+					$closer = $this->tokens[ $opener ]['parenthesis_closer'];
+				}
+			}
+		} else {
+			// Short array syntax.
+			$opener = $stackPtr;
+
+			if ( isset( $this->tokens[ $stackPtr ]['bracket_closer'] ) ) {
+				$closer = $this->tokens[ $stackPtr ]['bracket_closer'];
+			}
+		}
+
+		if ( isset( $opener, $closer ) ) {
+			return array(
+				'opener' => $opener,
+				'closer' => $closer,
+			);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine the namespace name an arbitrary token lives in.
+	 *
+	 * @since 0.10.0
+	 * @since 0.12.0 Moved from the WordPress_AbstractClassRestrictionsSniff to this sniff.
+	 *
+	 * @param int $stackPtr The token position for which to determine the namespace.
+	 *
+	 * @return string Namespace name or empty string if it couldn't be determined or no namespace applies.
+	 */
+	public function determine_namespace( $stackPtr ) {
+
+		// Check for the existence of the token.
+		if ( ! isset( $this->tokens[ $stackPtr ] ) ) {
+			return '';
+		}
+
+		// Check for scoped namespace {}.
+		if ( ! empty( $this->tokens[ $stackPtr ]['conditions'] ) ) {
+			$namespacePtr = $this->phpcsFile->getCondition( $stackPtr, T_NAMESPACE );
+			if ( false !== $namespacePtr ) {
+				$namespace = $this->get_declared_namespace_name( $namespacePtr );
+				if ( false !== $namespace ) {
+					return $namespace;
+				}
+
+				// We are in a scoped namespace, but couldn't determine the name.
+				// Searching for a global namespace is futile.
+				return '';
+			}
+		}
+
+		/*
+		 * Not in a scoped namespace, so let's see if we can find a non-scoped namespace instead.
+		 * Keeping in mind that:
+		 * - there can be multiple non-scoped namespaces in a file (bad practice, but it happens).
+		 * - the namespace keyword can also be used as part of a function/method call and such.
+		 * - that a non-named namespace resolves to the global namespace.
+		 */
+		$previousNSToken = $stackPtr;
+		$namespace       = false;
+		do {
+			$previousNSToken = $this->phpcsFile->findPrevious( T_NAMESPACE, ( $previousNSToken - 1 ) );
+
+			// Stop if we encounter a scoped namespace declaration as we already know we're not in one.
+			if ( ! empty( $this->tokens[ $previousNSToken ]['scope_condition'] )
+				&& $this->tokens[ $previousNSToken ]['scope_condition'] === $previousNSToken
+			) {
+				break;
+			}
+
+			$namespace = $this->get_declared_namespace_name( $previousNSToken );
+
+		} while ( false === $namespace && false !== $previousNSToken );
+
+		// If we still haven't got a namespace, return an empty string.
+		if ( false === $namespace ) {
+			return '';
+		}
+
+		return $namespace;
+	}
+
+	/**
+	 * Get the complete namespace name for a namespace declaration.
+	 *
+	 * For hierarchical namespaces, the name will be composed of several tokens,
+	 * i.e. MyProject\Sub\Level which will be returned together as one string.
+	 *
+	 * @since 0.12.0 A lesser variant of this method previously existed in the
+	 *               WordPress_AbstractClassRestrictionsSniff.
+	 *
+	 * @param int|bool $stackPtr The position of a T_NAMESPACE token.
+	 *
+	 * @return string|false Namespace name or false if not a namespace declaration.
+	 *                      Namespace name can be an empty string for global namespace declaration.
+	 */
+	public function get_declared_namespace_name( $stackPtr ) {
+
+		// Check for the existence of the token.
+		if ( false === $stackPtr || ! isset( $this->tokens[ $stackPtr ] ) ) {
+			return false;
+		}
+
+		if ( T_NAMESPACE !== $this->tokens[ $stackPtr ]['code'] ) {
+			return false;
+		}
+
+		if ( T_NS_SEPARATOR === $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+			// Not a namespace declaration, but use of, i.e. `namespace\someFunction();`.
+			return false;
+		}
+
+		$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		if ( T_OPEN_CURLY_BRACKET === $this->tokens[ $nextToken ]['code'] ) {
+			// Declaration for global namespace when using multiple namespaces in a file.
+			// I.e.: `namespace {}`.
+			return '';
+		}
+
+		// Ok, this should be a namespace declaration, so get all the parts together.
+		$validTokens = array(
+			T_STRING       => true,
+			T_NS_SEPARATOR => true,
+			T_WHITESPACE   => true,
+		);
+
+		$namespaceName = '';
+		while ( isset( $validTokens[ $this->tokens[ $nextToken ]['code'] ] ) ) {
+			$namespaceName .= trim( $this->tokens[ $nextToken ]['content'] );
+			$nextToken++;
+		}
+
+		return $namespaceName;
+	}
+
+	/**
+	 * Check if a content string contains a specific html open tag.
+	 *
+	 * @since 0.11.0
+	 * @since 0.13.0 No longer allows for the PHP 5.2 bug for which the function was
+	 *               originally created.
+	 * @since 0.13.0 The $stackPtr parameter is now optional. Either that or the
+	 *               $content parameter has to be passed.
+	 *
+	 * @param string $tag_name The name of the HTML tag without brackets. So if
+	 *                         searching for '<span...', this would be 'span'.
+	 * @param int    $stackPtr Optional. The position of the current token in the
+	 *                         token stack.
+	 *                         This parameter needs to be passed if no $content is
+	 *                         passed.
+	 * @param string $content  Optionally, the current content string, might be a
+	 *                         substring of the original string.
+	 *                         Defaults to `false` to distinguish between a passed
+	 *                         empty string and not passing the $content string.
+	 *
+	 * @return bool True if the string contains an <tag_name> open tag, false otherwise.
+	 */
+	public function has_html_open_tag( $tag_name, $stackPtr = null, $content = false ) {
+		if ( false === $content && isset( $stackPtr ) ) {
+			$content = $this->tokens[ $stackPtr ]['content'];
+		}
+
+		if ( ! empty( $content ) && false !== strpos( $content, '<' . $tag_name ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check whether a T_CONST token is a class constant declaration.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int $stackPtr  The position in the stack of the T_CONST token to verify.
+	 *
+	 * @return bool
+	 */
+	public function is_class_constant( $stackPtr ) {
+		if ( ! isset( $this->tokens[ $stackPtr ] ) || T_CONST !== $this->tokens[ $stackPtr ]['code'] ) {
+			return false;
+		}
+
+		// Note: traits can not declare constants.
+		$valid_scopes = array(
+			'T_CLASS'      => true,
+			'T_ANON_CLASS' => true,
+			'T_INTERFACE'  => true,
+		);
+
+		return $this->valid_direct_scope( $stackPtr, $valid_scopes );
+	}
+
+	/**
+	 * Check whether a T_VARIABLE token is a class property declaration.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int $stackPtr  The position in the stack of the T_VARIABLE token to verify.
+	 *
+	 * @return bool
+	 */
+	public function is_class_property( $stackPtr ) {
+		if ( ! isset( $this->tokens[ $stackPtr ] ) || T_VARIABLE !== $this->tokens[ $stackPtr ]['code'] ) {
+			return false;
+		}
+
+		// Note: interfaces can not declare properties.
+		$valid_scopes = array(
+			'T_CLASS'      => true,
+			'T_ANON_CLASS' => true,
+			'T_TRAIT'      => true,
+		);
+
+		if ( $this->valid_direct_scope( $stackPtr, $valid_scopes ) ) {
+			// Make sure it's not a method parameter.
+			if ( empty( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check whether the direct wrapping scope of a token is within a limited set of
+	 * acceptable tokens.
+	 *
+	 * Used to check, for instance, if a T_CONST is a class constant.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int   $stackPtr     The position in the stack of the token to verify.
+	 * @param array $valid_scopes Array of token types.
+	 *                            Keys should be the token types in string format
+	 *                            to allow for newer token types.
+	 *                            Value is irrelevant.
+	 *
+	 * @return bool
+	 */
+	protected function valid_direct_scope( $stackPtr, array $valid_scopes ) {
+		if ( empty( $this->tokens[ $stackPtr ]['conditions'] ) ) {
+			return false;
+		}
+
+		/*
+		 * Check only the direct wrapping scope of the token.
+		 */
+		$conditions = array_keys( $this->tokens[ $stackPtr ]['conditions'] );
+		$ptr        = array_pop( $conditions );
+
+		if ( ! isset( $this->tokens[ $ptr ] ) ) {
+			return false;
+		}
+
+		return isset( $valid_scopes[ $this->tokens[ $ptr ]['type'] ] );
+	}
+
+	/**
+	 * Checks whether this is a call to a $wpdb method that we want to sniff.
+	 *
+	 * If available in the child class, the $methodPtr, $i and $end properties are
+	 * automatically set to correspond to the start and end of the method call.
+	 * The $i property is also set if this is not a method call but rather the
+	 * use of a $wpdb property.
+	 *
+	 * @since 0.8.0
+	 * @since 0.9.0  The return value is now always boolean. The $end and $i member
+	 *               vars are automatically updated.
+	 * @since 0.14.0 Moved this method from the `PreparedSQL` sniff to the base WP sniff.
+	 *
+	 * {@internal This method should probably be refactored.}}
+	 *
+	 * @param int   $stackPtr        The index of the $wpdb variable.
+	 * @param array $target_methods  Array of methods. Key(s) should be method name.
+	 *
+	 * @return bool Whether this is a $wpdb method call.
+	 */
+	protected function is_wpdb_method_call( $stackPtr, $target_methods ) {
+
+		// Check for wpdb.
+		if ( ( T_VARIABLE === $this->tokens[ $stackPtr ]['code'] && '$wpdb' !== $this->tokens[ $stackPtr ]['content'] )
+			|| ( T_STRING === $this->tokens[ $stackPtr ]['code'] && 'wpdb' !== $this->tokens[ $stackPtr ]['content'] )
+		) {
+			return false;
+		}
+
+		// Check that this is a method call.
+		$is_object_call = $this->phpcsFile->findNext(
+			array( T_OBJECT_OPERATOR, T_DOUBLE_COLON ),
+			( $stackPtr + 1 ),
+			null,
+			false,
+			null,
+			true
+		);
+		if ( false === $is_object_call ) {
+			return false;
+		}
+
+		$methodPtr = $this->phpcsFile->findNext( T_WHITESPACE, ( $is_object_call + 1 ), null, true, null, true );
+		if ( false === $methodPtr ) {
+			return false;
+		}
+
+		if ( T_STRING === $this->tokens[ $methodPtr ]['code'] && property_exists( $this, 'methodPtr' ) ) {
+			$this->methodPtr = $methodPtr;
+		}
+
+		// Find the opening parenthesis.
+		$opening_paren = $this->phpcsFile->findNext( T_WHITESPACE, ( $methodPtr + 1 ), null, true, null, true );
+
+		if ( false === $opening_paren ) {
+			return false;
+		}
+
+		if ( property_exists( $this, 'i' ) ) {
+			$this->i = $opening_paren;
+		}
+
+		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $opening_paren ]['code']
+			|| ! isset( $this->tokens[ $opening_paren ]['parenthesis_closer'] )
+		) {
+			return false;
+		}
+
+		// Check that this is one of the methods that we are interested in.
+		if ( ! isset( $target_methods[ $this->tokens[ $methodPtr ]['content'] ] ) ) {
+			return false;
+		}
+
+		// Find the end of the first parameter.
+		$end = $this->phpcsFile->findEndOfStatement( $opening_paren + 1 );
+
+		if ( T_COMMA !== $this->tokens[ $end ]['code'] ) {
+			++$end;
+		}
+
+		if ( property_exists( $this, 'end' ) ) {
+			$this->end = $end;
+		}
+
+		return true;
+	} // End is_wpdb_method_call().
+
+}

--- a/ci/wpcs/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Arrays/ArrayAssignmentRestrictionsSniff.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Arrays;
+
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
+/**
+ * Restricts array assignment of certain keys.
+ *
+ * @package    WPCS\WordPressCodingStandards
+ *
+ * @since      0.3.0
+ * @since      0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @deprecated 0.10.0 The functionality which used to be contained in this class has been moved to
+ *                    the WordPress_AbstractArrayAssignmentRestrictionsSniff class.
+ *                    This class is left here to prevent backward-compatibility breaks for
+ *                    custom sniffs extending the old class and references to this
+ *                    sniff from custom phpcs.xml files.
+ *                    This file is also still used to unit test the abstract class.
+ * @see        \WordPress\AbstractArrayAssignmentRestrictionsSniff
+ */
+class ArrayAssignmentRestrictionsSniff extends AbstractArrayAssignmentRestrictionsSniff {
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'groupname' => array(
+	 *      'type'     => 'error' | 'warning',
+	 *      'message'  => 'Dont use this one please!',
+	 *      'keys'     => array( 'key1', 'another_key' ),
+	 *      'callback' => array( 'class', 'method' ), // Optional.
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array();
+	}
+
+	/**
+	 * Callback to process each confirmed key, to check value.
+	 *
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
+	 *                       with custom error message passed to ->process().
+	 */
+	public function callback( $key, $val, $line, $group ) {
+		return true;
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Arrays/ArrayDeclarationSniff.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Arrays;
+
+use PHP_CodeSniffer_File as File;
+
+/**
+ * Enforces WordPress array format, based upon Squiz code.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since      0.1.0
+ * @since      0.5.0  Now extends `Squiz_Sniffs_Arrays_ArrayDeclarationSniff`.
+ * @since      0.11.0 The additional single-line array checks have been moved to their own
+ *                    sniff WordPress.Arrays.ArrayDeclarationSpacing.
+ *                    This class now only contains a slimmed down version of the upstream sniff.
+ * @since      0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @deprecated 0.13.0 This sniff has now been deprecated. Most checks which were previously
+ *                    contained herein had recently been excluded in favour of dedicated
+ *                    sniffs with higher precision. The last remaining checks which were not
+ *                    already covered elsewhere have been moved to the `ArrayDeclarationSpacing`
+ *                    sniff.
+ *                    This class is left here to prevent breaking custom rulesets which refer
+ *                    to this sniff.
+ */
+class ArrayDeclarationSniff {
+
+	/**
+	 * Don't use.
+	 *
+	 * @deprecated 0.13.0
+	 *
+	 * @return int[]
+	 */
+	public function register() {
+		return array();
+	}
+
+	/**
+	 * Don't use.
+	 *
+	 * @deprecated 0.13.0
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile A PHP_CodeSniffer file.
+	 * @param int                         $stackPtr  The position of the token.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Arrays/ArrayDeclarationSpacingSniff.php
@@ -1,0 +1,440 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Arrays;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Enforces WordPress array spacing format.
+ *
+ * - Check for no space between array keyword and array opener.
+ * - Check for no space between the parentheses of an empty array.
+ * - Checks for one space after the array opener / before the array closer in single-line arrays.
+ * - Checks that associative arrays are multi-line.
+ * - Checks that each array item in a multi-line array starts on a new line.
+ * - Checks that the array closer in a multi-line array is on a new line.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.11.0 - The WordPress specific additional checks have now been split off
+ *                 from the WordPress_Sniffs_Arrays_ArrayDeclaration sniff into
+ *                 this sniff.
+ *                 - Added sniffing & fixing for associative arrays.
+ * @since   0.12.0 Decoupled this sniff from the upstream sniff completely.
+ *                 This sniff now extends the `WordPress_Sniff` instead.
+ * @since   0.13.0 Added the last remaining checks from the `ArrayDeclaration` sniff
+ *                 which were not covered elsewhere. The `ArrayDeclaration` sniff has
+ *                 now been deprecated.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 Single item associative arrays are now by default exempt from the
+ *                 "must be multi-line" rule. This behaviour can be changed using the
+ *                 `allow_single_item_single_line_associative_arrays` property.
+ */
+class ArrayDeclarationSpacingSniff extends Sniff {
+
+	/**
+	 * Whether or not to allow single item associative arrays to be single line.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var bool Defaults to true.
+	 */
+	public $allow_single_item_single_line_associative_arrays = true;
+
+	/**
+	 * Token this sniff targets.
+	 *
+	 * Also used for distinguishing between the array and an array value
+	 * which is also an array.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var array
+	 */
+	private $targets = array(
+		T_ARRAY            => T_ARRAY,
+		T_OPEN_SHORT_ARRAY => T_OPEN_SHORT_ARRAY,
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return $this->targets;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.12.0 The actual checks contained in this method used to
+	 *               be in the `processSingleLineArray()` method.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		/*
+		 * Determine the array opener & closer.
+		 */
+		$array_open_close = $this->find_array_open_close( $stackPtr );
+		if ( false === $array_open_close ) {
+			// Array open/close could not be determined.
+			return;
+		}
+
+		$opener = $array_open_close['opener'];
+		$closer = $array_open_close['closer'];
+		unset( $array_open_close );
+
+		/*
+		 * Long arrays only: Check for space between the array keyword and the open parenthesis.
+		 */
+		if ( T_ARRAY === $this->tokens[ $stackPtr ]['code'] ) {
+
+			if ( ( $stackPtr + 1 ) !== $opener ) {
+				$error      = 'There must be no space between the "array" keyword and the opening parenthesis';
+				$error_code = 'SpaceAfterKeyword';
+
+				$nextNonWhitespace = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), ( $opener + 1 ), true );
+				if ( $nextNonWhitespace !== $opener ) {
+					// Don't auto-fix: Something other than whitespace found between keyword and open parenthesis.
+					$this->phpcsFile->addError( $error, $stackPtr, $error_code );
+				} else {
+
+					$fix = $this->phpcsFile->addFixableError( $error, $stackPtr, $error_code );
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->beginChangeset();
+						for ( $i = ( $stackPtr + 1 ); $i < $opener; $i++ ) {
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+						}
+						$this->phpcsFile->fixer->endChangeset();
+						unset( $i );
+					}
+				}
+				unset( $error, $error_code, $nextNonWhitespace, $fix );
+			}
+		}
+
+		/*
+		 * Check for empty arrays.
+		 */
+		$nextNonWhitespace = $this->phpcsFile->findNext( T_WHITESPACE, ( $opener + 1 ), ( $closer + 1 ), true );
+		if ( $nextNonWhitespace === $closer ) {
+
+			if ( ( $opener + 1 ) !== $closer ) {
+				$fix = $this->phpcsFile->addFixableError(
+					'Empty array declaration must have no space between the parentheses',
+					$stackPtr,
+					'SpaceInEmptyArray'
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->beginChangeset();
+					for ( $i = ( $opener + 1 ); $i < $closer; $i++ ) {
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+					}
+					$this->phpcsFile->fixer->endChangeset();
+					unset( $i );
+				}
+			}
+
+			// This array is empty, so the below checks aren't necessary.
+			return;
+		}
+		unset( $nextNonWhitespace );
+
+		// Pass off to either the single line or multi-line array analysis.
+		if ( $this->tokens[ $opener ]['line'] === $this->tokens[ $closer ]['line'] ) {
+			$this->process_single_line_array( $stackPtr, $opener, $closer );
+		} else {
+			$this->process_multi_line_array( $stackPtr, $opener, $closer );
+		}
+	}
+
+	/**
+	 * Process a single-line array.
+	 *
+	 * @since 0.13.0 The actual checks contained in this method used to
+	 *               be in the `process()` method.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 * @param int $opener   The position of the array opener.
+	 * @param int $closer   The position of the array closer.
+	 *
+	 * @return void
+	 */
+	protected function process_single_line_array( $stackPtr, $opener, $closer ) {
+		/*
+		 * Check that associative arrays are always multi-line.
+		 */
+		$array_has_keys = $this->phpcsFile->findNext( T_DOUBLE_ARROW, $opener, $closer );
+		if ( false !== $array_has_keys ) {
+
+			$array_items = $this->get_function_call_parameters( $stackPtr );
+
+			if ( ( false === $this->allow_single_item_single_line_associative_arrays
+					&& ! empty( $array_items ) )
+				|| ( true === $this->allow_single_item_single_line_associative_arrays
+					&& count( $array_items ) > 1 )
+			) {
+				/*
+				 * Make sure the double arrow is for *this* array, not for a nested one.
+				 */
+				$array_has_keys = false; // Reset before doing more detailed check.
+				foreach ( $array_items as $item ) {
+					for ( $ptr = $item['start']; $ptr <= $item['end']; $ptr++ ) {
+						if ( T_DOUBLE_ARROW === $this->tokens[ $ptr ]['code'] ) {
+							$array_has_keys = true;
+							break 2;
+						}
+
+						// Skip passed any nested arrays.
+						if ( isset( $this->targets[ $this->tokens[ $ptr ]['code'] ] ) ) {
+							$nested_array_open_close = $this->find_array_open_close( $ptr );
+							if ( false === $nested_array_open_close ) {
+								// Nested array open/close could not be determined.
+								continue;
+							}
+
+							$ptr = $nested_array_open_close['closer'];
+						}
+					}
+				}
+
+				if ( true === $array_has_keys ) {
+
+					$phrase = 'an';
+					if ( true === $this->allow_single_item_single_line_associative_arrays ) {
+						$phrase = 'a multi-item';
+					}
+					$fix = $this->phpcsFile->addFixableError(
+						'When %s array uses associative keys, each value should start on a new line.',
+						$closer,
+						'AssociativeArrayFound',
+						array( $phrase )
+					);
+
+					if ( true === $fix ) {
+
+						$this->phpcsFile->fixer->beginChangeset();
+
+						foreach ( $array_items as $item ) {
+							/*
+							 * Add a line break before the first non-empty token in the array item.
+							 * Prevents extraneous whitespace at the start of the line which could be
+							 * interpreted as alignment whitespace.
+							 */
+							$first_non_empty = $this->phpcsFile->findNext(
+								Tokens::$emptyTokens,
+								$item['start'],
+								( $item['end'] + 1 ),
+								true
+							);
+							if ( false === $first_non_empty ) {
+								continue;
+							}
+
+							if ( $item['start'] <= ( $first_non_empty - 1 )
+								&& T_WHITESPACE === $this->tokens[ ( $first_non_empty - 1 ) ]['code']
+							) {
+								// Remove whitespace which would otherwise becoming trailing
+								// (as it gives problems with the fixed file).
+								$this->phpcsFile->fixer->replaceToken( ( $first_non_empty - 1 ), '' );
+							}
+
+							$this->phpcsFile->fixer->addNewlineBefore( $first_non_empty );
+						}
+
+						$this->phpcsFile->fixer->endChangeset();
+					}
+
+					// No need to check for spacing around opener/closer as this array should be multi-line.
+					return;
+				}
+			}
+		}
+
+		/*
+		 * Check that there is a single space after the array opener and before the array closer.
+		 */
+		if ( T_WHITESPACE !== $this->tokens[ ( $opener + 1 ) ]['code'] ) {
+
+			$fix = $this->phpcsFile->addFixableError(
+				'Missing space after array opener.',
+				$opener,
+				'NoSpaceAfterArrayOpener'
+			);
+
+			if ( true === $fix ) {
+				$this->phpcsFile->fixer->addContent( $opener, ' ' );
+			}
+		} elseif ( ' ' !== $this->tokens[ ( $opener + 1 ) ]['content'] ) {
+
+			$fix = $this->phpcsFile->addFixableError(
+				'Expected 1 space after array opener, found %s.',
+				$opener,
+				'SpaceAfterArrayOpener',
+				array( strlen( $this->tokens[ ( $opener + 1 ) ]['content'] ) )
+			);
+
+			if ( true === $fix ) {
+				$this->phpcsFile->fixer->replaceToken( ( $opener + 1 ), ' ' );
+			}
+		}
+
+		if ( T_WHITESPACE !== $this->tokens[ ( $closer - 1 ) ]['code'] ) {
+
+			$fix = $this->phpcsFile->addFixableError(
+				'Missing space before array closer.',
+				$closer,
+				'NoSpaceBeforeArrayCloser'
+			);
+
+			if ( true === $fix ) {
+				$this->phpcsFile->fixer->addContentBefore( $closer, ' ' );
+			}
+		} elseif ( ' ' !== $this->tokens[ ( $closer - 1 ) ]['content'] ) {
+
+			$fix = $this->phpcsFile->addFixableError(
+				'Expected 1 space before array closer, found %s.',
+				$closer,
+				'SpaceBeforeArrayCloser',
+				array( strlen( $this->tokens[ ( $closer - 1 ) ]['content'] ) )
+			);
+
+			if ( true === $fix ) {
+				$this->phpcsFile->fixer->replaceToken( ( $closer - 1 ), ' ' );
+			}
+		}
+	}
+
+	/**
+	 * Process a multi-line array.
+	 *
+	 * @since 0.13.0 The actual checks contained in this method used to
+	 *               be in the `ArrayDeclaration` sniff.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 * @param int $opener   The position of the array opener.
+	 * @param int $closer   The position of the array closer.
+	 *
+	 * @return void
+	 */
+	protected function process_multi_line_array( $stackPtr, $opener, $closer ) {
+		/*
+		 * Check that the closing bracket is on a new line.
+		 */
+		$last_content = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $closer - 1 ), $opener, true );
+		if ( false !== $last_content
+			&& $this->tokens[ $last_content ]['line'] === $this->tokens[ $closer ]['line']
+		) {
+			$fix = $this->phpcsFile->addFixableError(
+				'Closing parenthesis of array declaration must be on a new line',
+				$closer,
+				'CloseBraceNewLine'
+			);
+			if ( true === $fix ) {
+				$this->phpcsFile->fixer->beginChangeset();
+
+				if ( $last_content < ( $closer - 1 )
+					&& T_WHITESPACE === $this->tokens[ ( $closer - 1 ) ]['code']
+				) {
+					// Remove whitespace which would otherwise becoming trailing
+					// (as it gives problems with the fixed file).
+					$this->phpcsFile->fixer->replaceToken( ( $closer - 1 ), '' );
+				}
+
+				$this->phpcsFile->fixer->addNewlineBefore( $closer );
+				$this->phpcsFile->fixer->endChangeset();
+			}
+		}
+
+		/*
+		 * Check that each array item starts on a new line.
+		 */
+		$array_items      = $this->get_function_call_parameters( $stackPtr );
+		$end_of_last_item = $opener;
+
+		foreach ( $array_items as $item ) {
+			$end_of_this_item = ( $item['end'] + 1 );
+
+			// Find the line on which the item starts.
+			$first_content = $this->phpcsFile->findNext(
+				array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+				$item['start'],
+				$end_of_this_item,
+				true
+			);
+
+			// Ignore comments after array items if the next real content starts on a new line.
+			if ( T_COMMENT === $this->tokens[ $first_content ]['code'] ) {
+				$next = $this->phpcsFile->findNext(
+					array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+					( $first_content + 1 ),
+					$end_of_this_item,
+					true
+				);
+
+				if ( false === $next ) {
+					// Shouldn't happen, but just in case.
+					$end_of_last_item = $end_of_this_item;
+					continue;
+				}
+
+				if ( $this->tokens[ $next ]['line'] !== $this->tokens[ $first_content ]['line'] ) {
+					$first_content = $next;
+				}
+			}
+
+			if ( false === $first_content ) {
+				// Shouldn't happen, but just in case.
+				$end_of_last_item = $end_of_this_item;
+				continue;
+			}
+
+			if ( $this->tokens[ $end_of_last_item ]['line'] === $this->tokens[ $first_content ]['line'] ) {
+
+				$fix = $this->phpcsFile->addFixableError(
+					'Each item in a multi-line array must be on a new line',
+					$first_content,
+					'ArrayItemNoNewLine'
+				);
+
+				if ( true === $fix ) {
+
+					$this->phpcsFile->fixer->beginChangeset();
+
+					if ( $item['start'] <= ( $first_content - 1 )
+						&& T_WHITESPACE === $this->tokens[ ( $first_content - 1 ) ]['code']
+					) {
+						// Remove whitespace which would otherwise becoming trailing
+						// (as it gives problems with the fixed file).
+						$this->phpcsFile->fixer->replaceToken( ( $first_content - 1 ), '' );
+					}
+
+					$this->phpcsFile->fixer->addNewlineBefore( $first_content );
+					$this->phpcsFile->fixer->endChangeset();
+				}
+			}
+
+			$end_of_last_item = $end_of_this_item;
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Arrays/ArrayIndentationSniff.php
@@ -1,0 +1,524 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Arrays;
+
+use WordPress\Sniff;
+use WordPress\PHPCSHelper;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Enforces WordPress array indentation for multi-line arrays.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * {@internal This sniff should eventually be pulled upstream as part of a solution
+ * for https://github.com/squizlabs/PHP_CodeSniffer/issues/582 }}
+ */
+class ArrayIndentationSniff extends Sniff {
+
+	/**
+	 * Should tabs be used for indenting?
+	 *
+	 * If TRUE, fixes will be made using tabs instead of spaces.
+	 * The size of each tab is important, so it should be specified
+	 * using the --tab-width CLI argument.
+	 *
+	 * {@internal While for WPCS this should always be `true`, this property
+	 * was added in anticipation of upstreaming the sniff.
+	 * This property is the same as used in `Generic.WhiteSpace.ScopeIndent`.}}
+	 *
+	 * @var bool
+	 */
+	public $tabIndent = true;
+
+	/**
+	 * The --tab-width CLI value that is being used.
+	 *
+	 * @var int
+	 */
+	private $tab_width;
+
+	/**
+	 * Tokens to ignore for subsequent lines in a multi-line array item.
+	 *
+	 * Property is set in the register() method.
+	 *
+	 * @var array
+	 */
+	private $ignore_tokens = array();
+
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		/*
+		 * Set the $ignore_tokens property.
+		 *
+		 * Existing heredoc, nowdoc and inline HTML indentation should be respected at all times.
+		 */
+		$this->ignore_tokens = Tokens::$heredocTokens;
+		unset( $this->ignore_tokens[ T_START_HEREDOC ], $this->ignore_tokens[ T_START_NOWDOC ] );
+		$this->ignore_tokens[ T_INLINE_HTML ] = T_INLINE_HTML;
+
+		return array(
+			T_ARRAY,
+			T_OPEN_SHORT_ARRAY,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		if ( ! isset( $this->tab_width ) ) {
+			$this->tab_width = PHPCSHelper::get_tab_width( $this->phpcsFile );
+		}
+
+		/*
+		 * Determine the array opener & closer.
+		 */
+		$array_open_close = $this->find_array_open_close( $stackPtr );
+		if ( false === $array_open_close ) {
+			// Array open/close could not be determined.
+			return;
+		}
+
+		$opener = $array_open_close['opener'];
+		$closer = $array_open_close['closer'];
+
+		if ( $this->tokens[ $opener ]['line'] === $this->tokens[ $closer ]['line'] ) {
+			// Not interested in single line arrays.
+			return;
+		}
+
+		/*
+		 * Check the closing bracket is lined up with the start of the content on the line
+		 * containing the array opener.
+		 */
+		$opener_line_spaces = $this->get_indentation_size( $opener );
+		$closer_line_spaces = ( $this->tokens[ $closer ]['column'] - 1 );
+
+		if ( $closer_line_spaces !== $opener_line_spaces ) {
+			$error      = 'Array closer not aligned correctly; expected %s space(s) but found %s';
+			$error_code = 'CloseBraceNotAligned';
+
+			/*
+			 * Report & fix the issue if the close brace is on its own line with
+			 * nothing or only indentation whitespace before it.
+			 */
+			if ( 0 === $closer_line_spaces
+				|| ( T_WHITESPACE === $this->tokens[ ( $closer - 1 ) ]['code']
+					&& 1 === $this->tokens[ ( $closer - 1 ) ]['column'] )
+			) {
+				$this->add_array_alignment_error(
+					$closer,
+					$error,
+					$error_code,
+					$opener_line_spaces,
+					$closer_line_spaces,
+					$this->get_indentation_string( $opener_line_spaces )
+				);
+			} else {
+				/*
+				 * Otherwise, only report the error, don't try and fix it (yet).
+				 *
+				 * It will get corrected in a future loop of the fixer once the closer
+				 * has been moved to its own line by the `ArrayDeclarationSpacing` sniff.
+				 */
+				$this->phpcsFile->addError(
+					$error,
+					$closer,
+					$error_code,
+					array( $opener_line_spaces, $closer_line_spaces )
+				);
+			}
+
+			unset( $error, $error_code );
+		}
+
+		/*
+		 * Verify & correct the array item indentation.
+		 */
+		$array_items = $this->get_function_call_parameters( $stackPtr );
+		if ( empty( $array_items ) ) {
+			// Strange, no array items found.
+			return;
+		}
+
+		$expected_spaces      = ( $opener_line_spaces + $this->tab_width );
+		$expected_indent      = $this->get_indentation_string( $expected_spaces );
+		$end_of_previous_item = $opener;
+
+		foreach ( $array_items as $item ) {
+			$end_of_this_item = ( $item['end'] + 1 );
+
+			// Find the line on which the item starts.
+			$first_content = $this->phpcsFile->findNext(
+				array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+				$item['start'],
+				$end_of_this_item,
+				true
+			);
+
+			// Deal with trailing comments.
+			if ( false !== $first_content
+				&& T_COMMENT === $this->tokens[ $first_content ]['code']
+				&& $this->tokens[ $first_content ]['line'] === $this->tokens[ $end_of_previous_item ]['line']
+			) {
+				$first_content = $this->phpcsFile->findNext(
+					array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+					( $first_content + 1 ),
+					$end_of_this_item,
+					true
+				);
+			}
+
+			if ( false === $first_content ) {
+				$end_of_previous_item = $end_of_this_item;
+				continue;
+			}
+
+			// Bow out from reporting and fixing mixed multi-line/single-line arrays.
+			// That is handled by the ArrayDeclarationSpacingSniff.
+			if ( $this->tokens[ $first_content ]['line'] === $this->tokens[ $end_of_previous_item ]['line']
+				|| ( 1 !== $this->tokens[ $first_content ]['column']
+					&& T_WHITESPACE !== $this->tokens[ ( $first_content - 1 ) ]['code'] )
+			) {
+				return $closer;
+			}
+
+			$found_spaces = ( $this->tokens[ $first_content ]['column'] - 1 );
+
+			if ( $found_spaces !== $expected_spaces ) {
+				$this->add_array_alignment_error(
+					$first_content,
+					'Array item not aligned correctly; expected %s spaces but found %s',
+					'ItemNotAligned',
+					$expected_spaces,
+					$found_spaces,
+					$expected_indent
+				);
+			}
+
+			// No need for further checking if this is a one-line array item.
+			if ( $this->tokens[ $first_content ]['line'] === $this->tokens[ $item['end'] ]['line'] ) {
+				$end_of_previous_item = $end_of_this_item;
+				continue;
+			}
+
+			/*
+			 * Multi-line array items.
+			 *
+			 * Verify & if needed, correct the indentation of subsequent lines.
+			 * Subsequent lines may be indented more or less than the mimimum expected indent,
+			 * but the "first line after" should be indented - at least - as much as the very first line
+			 * of the array item.
+			 * Indentation correction for subsequent lines will be based on that diff.
+			 */
+
+			// Find first token on second line of the array item.
+			// If the second line is a heredoc/nowdoc, continue on until we find a line with a different token.
+			// Same for the second line of a multi-line text string.
+			for ( $ptr = ( $first_content + 1 ); $ptr <= $item['end']; $ptr++ ) {
+				if ( $this->tokens[ $first_content ]['line'] !== $this->tokens[ $ptr ]['line']
+					&& 1 === $this->tokens[ $ptr ]['column']
+					&& false === $this->ignore_token( $ptr )
+				) {
+					break;
+				}
+			}
+
+			$first_content_on_line2 = $this->phpcsFile->findNext(
+				array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+				$ptr,
+				$end_of_this_item,
+				true
+			);
+
+			if ( false === $first_content_on_line2 ) {
+				/*
+				 * Apparently there were only tokens in the ignore list on subsequent lines.
+				 *
+				 * In that case, the comma after the array item might be on a line by itself,
+				 * so check its placement.
+				 */
+				if ( $this->tokens[ $item['end'] ]['line'] !== $this->tokens[ $end_of_this_item ]['line']
+					&& T_COMMA === $this->tokens[ $end_of_this_item ]['code']
+					&& ( $this->tokens[ $end_of_this_item ]['column'] - 1 ) !== $expected_spaces
+				) {
+					$this->add_array_alignment_error(
+						$end_of_this_item,
+						'Comma after multi-line array item not aligned correctly; expected %s spaces, but found %s',
+						'MultiLineArrayItemCommaNotAligned',
+						$expected_spaces,
+						( $this->tokens[ $end_of_this_item ]['column'] - 1 ),
+						$expected_indent
+					);
+				}
+
+				$end_of_previous_item = $end_of_this_item;
+				continue;
+			}
+
+			$found_spaces_on_line2    = $this->get_indentation_size( $first_content_on_line2 );
+			$expected_spaces_on_line2 = $expected_spaces;
+
+			if ( $found_spaces < $found_spaces_on_line2 ) {
+				$expected_spaces_on_line2 += ( $found_spaces_on_line2 - $found_spaces );
+			}
+
+			if ( $found_spaces_on_line2 !== $expected_spaces_on_line2 ) {
+
+				$fix = $this->phpcsFile->addFixableError(
+					'Multi-line array item not aligned correctly; expected %s spaces, but found %s',
+					$first_content_on_line2,
+					'MultiLineArrayItemNotAligned',
+					array(
+						$expected_spaces_on_line2,
+						$found_spaces_on_line2,
+					)
+				);
+
+				if ( true === $fix ) {
+					$expected_indent_on_line2 = $this->get_indentation_string( $expected_spaces_on_line2 );
+
+					$this->phpcsFile->fixer->beginChangeset();
+
+					// Fix second line for the array item.
+					if ( 1 === $this->tokens[ $first_content_on_line2 ]['column']
+						&& T_COMMENT === $this->tokens[ $first_content_on_line2 ]['code']
+					) {
+						$actual_comment = ltrim( $this->tokens[ $first_content_on_line2 ]['content'] );
+						$replacement    = $expected_indent_on_line2 . $actual_comment;
+
+						$this->phpcsFile->fixer->replaceToken( $first_content_on_line2, $replacement );
+
+					} else {
+						$this->fix_alignment_error( $first_content_on_line2, $expected_indent_on_line2 );
+					}
+
+					// Fix subsequent lines.
+					for ( $i = ( $first_content_on_line2 + 1 ); $i <= $item['end']; $i++ ) {
+						// We're only interested in the first token on each line.
+						if ( 1 !== $this->tokens[ $i ]['column'] ) {
+							if ( $this->tokens[ $i ]['line'] === $this->tokens[ $item['end'] ]['line'] ) {
+								// We might as well quit if we're past the first token on the last line.
+								break;
+							}
+							continue;
+						}
+
+						$first_content_on_line = $this->phpcsFile->findNext(
+							array( T_WHITESPACE, T_DOC_COMMENT_WHITESPACE ),
+							$i,
+							$end_of_this_item,
+							true
+						);
+
+						if ( false === $first_content_on_line ) {
+							break;
+						}
+
+						// Ignore lines with heredoc and nowdoc tokens and subsequent lines in multi-line strings.
+						if ( true === $this->ignore_token( $first_content_on_line ) ) {
+							$i = $first_content_on_line;
+							continue;
+						}
+
+						$found_spaces_on_line    = $this->get_indentation_size( $first_content_on_line );
+						$expected_spaces_on_line = ( $expected_spaces_on_line2 + ( $found_spaces_on_line - $found_spaces_on_line2 ) );
+						$expected_spaces_on_line = max( $expected_spaces_on_line, 0 ); // Can't be below 0.
+						$expected_indent_on_line = $this->get_indentation_string( $expected_spaces_on_line );
+
+						if ( $found_spaces_on_line !== $expected_spaces_on_line ) {
+							if ( 1 === $this->tokens[ $first_content_on_line ]['column']
+								&& T_COMMENT === $this->tokens[ $first_content_on_line ]['code']
+							) {
+								$actual_comment = ltrim( $this->tokens[ $first_content_on_line ]['content'] );
+								$replacement    = $expected_indent_on_line . $actual_comment;
+
+								$this->phpcsFile->fixer->replaceToken( $first_content_on_line, $replacement );
+							} else {
+								$this->fix_alignment_error( $first_content_on_line, $expected_indent_on_line );
+							}
+						}
+
+						// Move past any potential empty lines between the previous non-empty line and this one.
+						// No need to do the fixes twice.
+						$i = $first_content_on_line;
+					}
+
+					/*
+					 * Check the placement of the comma after the array item as it might be on a line by itself.
+					 */
+					if ( $this->tokens[ $item['end'] ]['line'] !== $this->tokens[ $end_of_this_item ]['line']
+						&& T_COMMA === $this->tokens[ $end_of_this_item ]['code']
+						&& ( $this->tokens[ $end_of_this_item ]['column'] - 1 ) !== $expected_spaces
+					) {
+						$this->add_array_alignment_error(
+							$end_of_this_item,
+							'Comma after array item not aligned correctly; expected %s spaces, but found %s',
+							'MultiLineArrayItemCommaNotAligned',
+							$expected_spaces,
+							( $this->tokens[ $end_of_this_item ]['column'] - 1 ),
+							$expected_indent
+						);
+					}
+
+					$this->phpcsFile->fixer->endChangeset();
+				}
+			}
+
+			$end_of_previous_item = $end_of_this_item;
+		}
+
+	} // End process_token().
+
+
+	/**
+	 * Should the token be ignored ?
+	 *
+	 * This method is only intended to be used with the first token on a line
+	 * for subsequent lines in an multi-line array item.
+	 *
+	 * @param int $ptr Stack pointer to the first token on a line.
+	 *
+	 * @return bool
+	 */
+	protected function ignore_token( $ptr ) {
+		$token_code = $this->tokens[ $ptr ]['code'];
+
+		if ( isset( $this->ignore_tokens[ $token_code ] ) ) {
+			return true;
+		}
+
+		// If it's a subsequent line of a multi-line sting, it will not start with a quote character.
+		if ( ( T_CONSTANT_ENCAPSED_STRING === $token_code
+			|| T_DOUBLE_QUOTED_STRING === $token_code )
+			&& "'" !== $this->tokens[ $ptr ]['content'][0]
+			&& '"' !== $this->tokens[ $ptr ]['content'][0]
+		) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine the line indentation whitespace.
+	 *
+	 * @param int $ptr Stack pointer to an arbitrary token on a line.
+	 *
+	 * @return int Nr of spaces found. Where necessary, tabs are translated to spaces.
+	 */
+	protected function get_indentation_size( $ptr ) {
+
+		// Find the first token on the line.
+		for ( ; $ptr >= 0; $ptr-- ) {
+			if ( 1 === $this->tokens[ $ptr ]['column'] ) {
+				break;
+			}
+		}
+
+		$whitespace = '';
+
+		if ( T_WHITESPACE === $this->tokens[ $ptr ]['code']
+			|| T_DOC_COMMENT_WHITESPACE === $this->tokens[ $ptr ]['code']
+		) {
+			return $this->tokens[ $ptr ]['length'];
+		}
+
+		/*
+		 * Special case for multi-line, non-docblock comments.
+		 * Only applicable for subsequent lines in an array item.
+		 *
+		 * First/Single line is tokenized as T_WHITESPACE + T_COMMENT
+		 * Subsequent lines are tokenized as T_COMMENT including the indentation whitespace.
+		 */
+		if ( T_COMMENT === $this->tokens[ $ptr ]['code'] ) {
+			$content        = $this->tokens[ $ptr ]['content'];
+			$actual_comment = ltrim( $content );
+			$whitespace     = str_replace( $actual_comment, '', $content );
+		}
+
+		return strlen( $whitespace );
+	}
+
+	/**
+	 * Create an indentation string.
+	 *
+	 * @param int $nr Number of spaces the indentation should be.
+	 *
+	 * @return string
+	 */
+	protected function get_indentation_string( $nr ) {
+		if ( 0 >= $nr ) {
+			return '';
+		}
+
+		// Space-based indentation.
+		if ( false === $this->tabIndent ) {
+			return str_repeat( ' ', $nr );
+		}
+
+		// Tab-based indentation.
+		$num_tabs    = (int) floor( $nr / $this->tab_width );
+		$remaining   = ( $nr % $this->tab_width );
+		$tab_indent  = str_repeat( "\t", $num_tabs );
+		$tab_indent .= str_repeat( ' ', $remaining );
+
+		return $tab_indent;
+	}
+
+	/**
+	 * Throw an error and fix incorrect array alignment.
+	 *
+	 * @param int    $ptr        Stack pointer to the first content on the line.
+	 * @param string $error      Error message.
+	 * @param string $error_code Error code.
+	 * @param int    $expected   Expected nr of spaces (tabs translated to space value).
+	 * @param int    $found      Found nr of spaces (tabs translated to space value).
+	 * @param string $new_indent Whitespace indent replacement content.
+	 */
+	protected function add_array_alignment_error( $ptr, $error, $error_code, $expected, $found, $new_indent ) {
+
+		$fix = $this->phpcsFile->addFixableError( $error, $ptr, $error_code, array( $expected, $found ) );
+		if ( true === $fix ) {
+			$this->fix_alignment_error( $ptr, $new_indent );
+		}
+	}
+
+	/**
+	 * Fix incorrect array alignment.
+	 *
+	 * @param int    $ptr        Stack pointer to the first content on the line.
+	 * @param string $new_indent Whitespace indent replacement content.
+	 */
+	protected function fix_alignment_error( $ptr, $new_indent ) {
+		if ( 1 === $this->tokens[ $ptr ]['column'] ) {
+			$this->phpcsFile->fixer->addContentBefore( $ptr, $new_indent );
+		} else {
+			$this->phpcsFile->fixer->replaceToken( ( $ptr - 1 ), $new_indent );
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Arrays/ArrayKeySpacingRestrictionsSniff.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Arrays;
+
+use WordPress\Sniff;
+
+/**
+ * Check for proper spacing in array key references.
+ *
+ * @link    http://make.wordpress.org/core/handbook/coding-standards/php/#space-usage
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.7.0  This sniff now has the ability to fix a number of the issues it flags.
+ * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class ArrayKeySpacingRestrictionsSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_OPEN_SQUARE_BRACKET,
+		);
+
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		$token = $this->tokens[ $stackPtr ];
+		if ( ! isset( $token['bracket_closer'] ) ) {
+			$this->phpcsFile->addWarning( 'Missing bracket closer.', $stackPtr, 'MissingBracketCloser' );
+			return;
+		}
+
+		$need_spaces = $this->phpcsFile->findNext(
+			array( T_CONSTANT_ENCAPSED_STRING, T_LNUMBER, T_WHITESPACE, T_MINUS ),
+			( $stackPtr + 1 ),
+			$token['bracket_closer'],
+			true
+		);
+
+		$spaced1 = ( T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code'] );
+		$spaced2 = ( T_WHITESPACE === $this->tokens[ ( $token['bracket_closer'] - 1 ) ]['code'] );
+
+		// It should have spaces unless if it only has strings or numbers as the key.
+		if ( false !== $need_spaces && ! ( $spaced1 && $spaced2 ) ) {
+			$error = 'Array keys must be surrounded by spaces unless they contain a string or an integer.';
+			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpacesAroundArrayKeys' );
+			if ( true === $fix ) {
+				if ( ! $spaced1 ) {
+					$this->phpcsFile->fixer->addContentBefore( ( $stackPtr + 1 ), ' ' );
+				}
+				if ( ! $spaced2 ) {
+					$this->phpcsFile->fixer->addContentBefore( $token['bracket_closer'], ' ' );
+				}
+			}
+		} elseif ( false === $need_spaces && ( $spaced1 || $spaced2 ) ) {
+			$error = 'Array keys must NOT be surrounded by spaces if they only contain a string or an integer.';
+			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpacesAroundArrayKeys' );
+			if ( true === $fix ) {
+				if ( $spaced1 ) {
+					$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), '' );
+				}
+				if ( $spaced2 ) {
+					$this->phpcsFile->fixer->replaceToken( ( $token['bracket_closer'] - 1 ), '' );
+				}
+			}
+		}
+
+	} // End process().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Arrays/CommaAfterArrayItemSniff.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Arrays;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Enforces a comma after each array item and the spacing around it.
+ *
+ * Rules:
+ * - For multi-line arrays, a comma is needed after each array item.
+ * - Same for single-line arrays, but no comma is allowed after the last array item.
+ * - There should be no space between the comma and the end of the array item.
+ * - There should be exactly one space between the comma and the start of the
+ *   next array item for single-line items.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class CommaAfterArrayItemSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_ARRAY,
+			T_OPEN_SHORT_ARRAY,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		/*
+		 * Determine the array opener & closer.
+		 */
+		$array_open_close = $this->find_array_open_close( $stackPtr );
+		if ( false === $array_open_close ) {
+			// Array open/close could not be determined.
+			return;
+		}
+
+		$opener = $array_open_close['opener'];
+		$closer = $array_open_close['closer'];
+		unset( $array_open_close );
+
+		// This array is empty, so the below checks aren't necessary.
+		if ( ( $opener + 1 ) === $closer ) {
+			return;
+		}
+
+		$single_line = true;
+		if ( $this->tokens[ $opener ]['line'] !== $this->tokens[ $closer ]['line'] ) {
+			$single_line = false;
+		}
+
+		$array_items = $this->get_function_call_parameters( $stackPtr );
+		if ( empty( $array_items ) ) {
+			// Strange, no array items found.
+			return;
+		}
+
+		$array_item_count = count( $array_items );
+
+		// Note: $item_index is 1-based and the array items are split on the commas!
+		foreach ( $array_items as $item_index => $item ) {
+			$maybe_comma = ( $item['end'] + 1 );
+			$is_comma    = false;
+			if ( isset( $this->tokens[ $maybe_comma ] ) && T_COMMA === $this->tokens[ $maybe_comma ]['code'] ) {
+				$is_comma = true;
+			}
+
+			/*
+			 * Check if this is a comma at the end of the last item in a single line array.
+			 */
+			if ( true === $single_line && $item_index === $array_item_count ) {
+
+				if ( true === $is_comma ) {
+					$fix = $this->phpcsFile->addFixableError(
+						'Comma not allowed after last value in single-line array declaration',
+						$maybe_comma,
+						'CommaAfterLast'
+					);
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->replaceToken( $maybe_comma, '' );
+					}
+				}
+
+				/*
+				 * No need to do the spacing checks for the last item in a single line array.
+				 * This is handled by another sniff checking the spacing before the array closer.
+				 */
+				continue;
+			}
+
+			$last_content = $this->phpcsFile->findPrevious(
+				Tokens::$emptyTokens,
+				$item['end'],
+				$item['start'],
+				true
+			);
+
+			if ( false === $last_content ) {
+				// Shouldn't be able to happen, but just in case, ignore this array item.
+				continue;
+			}
+
+			/**
+			 * Make sure every item in a multi-line array has a comma at the end.
+			 *
+			 * Should in reality only be triggered by the last item in a multi-line array
+			 * as otherwise we'd have a parse error already.
+			 */
+			if ( false === $is_comma && false === $single_line ) {
+
+				$fix = $this->phpcsFile->addFixableError(
+					'Each array item in a multi-line array declaration must end in a comma',
+					$last_content,
+					'NoComma'
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->addContent( $last_content, ',' );
+				}
+			}
+
+			if ( false === $is_comma ) {
+				// Can't check spacing around the comma if there is no comma.
+				continue;
+			}
+
+			/*
+			 * Check for whitespace at the end of the array item.
+			 */
+			if ( $last_content !== $item['end']
+				// Ignore whitespace at the end of a multi-line item if it is the end of a heredoc/nowdoc.
+				&& ( true === $single_line
+					|| ! isset( Tokens::$heredocTokens[ $this->tokens[ $last_content ]['code'] ] ) )
+			) {
+				$newlines = 0;
+				$spaces   = 0;
+				for ( $i = $item['end']; $i > $last_content; $i-- ) {
+
+					if ( T_WHITESPACE === $this->tokens[ $i ]['code'] ) {
+						if ( $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar ) {
+							$newlines++;
+						} else {
+							$spaces += $this->tokens[ $i ]['length'];
+						}
+					} elseif ( T_COMMENT === $this->tokens[ $i ]['code'] ) {
+						break;
+					}
+				}
+
+				$space_phrases = array();
+				if ( $spaces > 0 ) {
+					$space_phrases[] = $spaces . ' spaces';
+				}
+				if ( $newlines > 0 ) {
+					$space_phrases[] = $newlines . ' newlines';
+				}
+				unset( $newlines, $spaces );
+
+				$fix = $this->phpcsFile->addFixableError(
+					'Expected 0 spaces between "%s" and comma; %s found',
+					$maybe_comma,
+					'SpaceBeforeComma',
+					array(
+						$this->tokens[ $last_content ]['content'],
+						implode( ' and ', $space_phrases ),
+					)
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->beginChangeset();
+					for ( $i = $item['end']; $i > $last_content; $i-- ) {
+
+						if ( T_WHITESPACE === $this->tokens[ $i ]['code'] ) {
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+
+						} elseif ( T_COMMENT === $this->tokens[ $i ]['code'] ) {
+							// We need to move the comma to before the comment.
+							$this->phpcsFile->fixer->addContent( $last_content, ',' );
+							$this->phpcsFile->fixer->replaceToken( $maybe_comma, '' );
+
+							/*
+							 * No need to worry about removing too much whitespace in
+							 * combination with a `//` comment as in that case, the newline
+							 * is part of the comment, so we're good.
+							 */
+
+							break;
+						}
+					}
+					$this->phpcsFile->fixer->endChangeset();
+				}
+			}
+
+			if ( ! isset( $this->tokens[ ( $maybe_comma + 1 ) ] ) ) {
+				// Shouldn't be able to happen, but just in case.
+				continue;
+			}
+
+			/*
+			 * Check whitespace after the comma.
+			 */
+			$next_token = $this->tokens[ ( $maybe_comma + 1 ) ];
+
+			if ( T_WHITESPACE === $next_token['code'] ) {
+
+				if ( false === $single_line && $this->phpcsFile->eolChar === $next_token['content'] ) {
+					continue;
+				}
+
+				$next_non_whitespace = $this->phpcsFile->findNext(
+					T_WHITESPACE,
+					( $maybe_comma + 1 ),
+					$closer,
+					true
+				);
+
+				if ( false === $next_non_whitespace
+					|| ( false === $single_line
+						&& $this->tokens[ $next_non_whitespace ]['line'] === $this->tokens[ $maybe_comma ]['line']
+						&& T_COMMENT === $this->tokens[ $next_non_whitespace ]['code'] )
+				) {
+					continue;
+				}
+
+				$space_length = $next_token['length'];
+				if ( 1 === $space_length ) {
+					continue;
+				}
+
+				$fix = $this->phpcsFile->addFixableError(
+					'Expected 1 space between comma and "%s"; %s found',
+					$maybe_comma,
+					'SpaceAfterComma',
+					array(
+						$this->tokens[ $next_non_whitespace ]['content'],
+						$space_length,
+					)
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->replaceToken( ( $maybe_comma + 1 ), ' ' );
+				}
+			} else {
+				// This is either a comment or a mixed single/multi-line array.
+				// Just add a space and let other sniffs sort out the array layout.
+				$fix = $this->phpcsFile->addFixableError(
+					'Expected 1 space between comma and "%s"; 0 found',
+					$maybe_comma,
+					'NoSpaceAfterComma',
+					array( $next_token['content'] )
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->addContent( $maybe_comma, ' ' );
+				}
+			}
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Arrays/MultipleStatementAlignmentSniff.php
@@ -1,0 +1,609 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Arrays;
+
+use WordPress\Sniff;
+
+/**
+ * Enforces alignment of the double arrow assignment operator for multi-item, multi-line arrays.
+ *
+ * - Align the double arrow operator to the same column for each item in a multi-item array.
+ * - Allows for setting a maxColumn property to aid in managing line-length.
+ * - Allows for new line(s) before a double arrow (configurable).
+ * - Allows for handling multi-line array items differently if so desired (configurable).
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ *
+ * {@internal This sniff should eventually be pulled upstream as part of a solution
+ * for https://github.com/squizlabs/PHP_CodeSniffer/issues/582 }}
+ */
+class MultipleStatementAlignmentSniff extends Sniff {
+
+	/**
+	 * Whether or not to ignore an array item for the purpose of alignment
+	 * when a new line is found between the array key and the double arrow.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var bool
+	 */
+	public $ignoreNewlines = true;
+
+	/**
+	 * Whether the alignment should be exact.
+	 *
+	 * Exact in this context means "largest index key + 1 space".
+	 * When `false`, that is seen as the minimum alignment.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var bool
+	 */
+	public $exact = true;
+
+	/**
+	 * The maximum column on which the double arrow alignment should be set.
+	 *
+	 * This property allows for limiting the whitespace padding to prevent
+	 * overly long lines.
+	 *
+	 * If this value is set to, for instance, 60, it will:
+	 * - if the expected column < 60, align at the expected column.
+	 * - if the expected column >= 60, align at column 60.
+	 *   - for the outliers, i.e. the array indexes where the end position
+	 *     goes past column 60, it will not align the arrow, the sniff will
+	 *     just make sure there is only one space between the end of the
+	 *     array index and the double arrow.
+	 *
+	 * The column value is regarded as a hard value, i.e. includes indentation,
+	 * so setting it very low is not a good idea.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var int
+	 */
+	public $maxColumn = 1000;
+
+	/**
+	 * Whether or not to align the arrow operator for multi-line array items.
+	 *
+	 * Whether or not an item is regarded as multi-line is based on the **value**
+	 * of the item, not the key.
+	 *
+	 * Valid values are:
+	 * - 'always':   Default. Align all arrays items regardless of single/multi-line.
+	 * - 'never':    Never align array items which span multiple lines.
+	 *               This will enforce one space between the array index and the
+	 *               double arrow operator for multi-line array items, independently
+	 *               of the alignment of the rest of the array items.
+	 *               Multi-line items where the arrow is already aligned with the
+	 *               "expected" alignment, however, will be left alone.
+	 * - operator :  Only align the operator for multi-line arrays items if the
+	 *   + number    percentage of multi-line items passes the comparison.
+	 *               - As it is a percentage, the number has to be between 0 and 100.
+	 *               - Supported operators: <, <=, >, >=, ==, =, !=, <>
+	 *               - The percentage is calculated against all array items
+	 *                 (with and without assignment operator).
+	 *               - The (new) expected alignment will be calculated based only
+	 *                 on the items being aligned.
+	 *               - Multi-line items where the arrow is already aligned with the
+	 *                 (new) "expected" alignment, however, will be left alone.
+	 *               Examples:
+	 *               * Setting this to `!=100` or `<100` means that alignment will
+	 *                 be enforced, unless *all* array items are multi-line.
+	 *                 This is probably the most commonly desired situation.
+	 *               * Setting this to `=100` means that alignment will only
+	 *                 be enforced, if *all* array items are multi-line.
+	 *               * Setting this to `<50` means that the majority of array items
+	 *                 need to be single line before alignment is enforced for
+	 *                 multi-line items in the array.
+	 *               * Setting this to `=0` is useless as in that case there are
+	 *                 no multi-line items in the array anyway.
+	 *
+	 * This setting will respect the `ignoreNewlines` and `maxColumnn` settings.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var string|int
+	 */
+	public $alignMultilineItems = 'always';
+
+	/**
+	 * Storage for parsed $alignMultilineItems operator part.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var string
+	 */
+	private $operator;
+
+	/**
+	 * Storage for parsed $alignMultilineItems numeric part.
+	 *
+	 * Stored as a string as the comparison will be done string based.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var string
+	 */
+	private $number;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_ARRAY,
+			T_OPEN_SHORT_ARRAY,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+		/*
+		 * Determine the array opener & closer.
+		 */
+		$array_open_close = $this->find_array_open_close( $stackPtr );
+		if ( false === $array_open_close ) {
+			// Array open/close could not be determined.
+			return;
+		}
+
+		$opener = $array_open_close['opener'];
+		$closer = $array_open_close['closer'];
+
+		$array_items = $this->get_function_call_parameters( $stackPtr );
+		if ( empty( $array_items ) ) {
+			return;
+		}
+
+		// Pass off to either the single line or multi-line array analysis.
+		if ( $this->tokens[ $opener ]['line'] === $this->tokens[ $closer ]['line'] ) {
+			return $this->process_single_line_array( $stackPtr, $array_items, $opener, $closer );
+		} else {
+			return $this->process_multi_line_array( $stackPtr, $array_items, $opener, $closer );
+		}
+	}
+
+	/**
+	 * Process a single-line array.
+	 *
+	 * While the WP standard does not allow single line multi-item associative arrays,
+	 * this sniff should function independently of that.
+	 *
+	 * The `WordPress.WhiteSpace.OperatorSpacing` sniff already covers checking that
+	 * there is a space between the array key and the double arrow, but doesn't
+	 * enforce it to be exactly one space for single line arrays.
+	 * That is what this method covers.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int   $stackPtr The position of the current token in the stack.
+	 * @param array $items    Info array containing information on each array item.
+	 * @param int   $opener   The position of the array opener.
+	 * @param int   $closer   The position of the array closer.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	protected function process_single_line_array( $stackPtr, $items, $opener, $closer ) {
+		/*
+		 * For single line arrays, we don't care about what level the arrow is from.
+		 * Just find and fix them all.
+		 */
+		$next_arrow = $this->phpcsFile->findNext(
+			T_DOUBLE_ARROW,
+			( $opener + 1 ),
+			$closer
+		);
+
+		while ( false !== $next_arrow ) {
+			if ( T_WHITESPACE === $this->tokens[ ( $next_arrow - 1 ) ]['code'] ) {
+				$space_length = $this->tokens[ ( $next_arrow - 1 ) ]['length'];
+				if ( 1 !== $space_length ) {
+					$error = 'Expected 1 space between "%s" and double arrow; %s found';
+					$data  = array(
+						$this->tokens[ ( $next_arrow - 2 ) ]['content'],
+						$space_length,
+					);
+
+					$fix = $this->phpcsFile->addFixableWarning( $error, $next_arrow, 'SpaceBeforeDoubleArrow', $data );
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->replaceToken( ( $next_arrow - 1 ), ' ' );
+					}
+				}
+			}
+
+			// Find the position of the next double arrow.
+			$next_arrow = $this->phpcsFile->findNext(
+				T_DOUBLE_ARROW,
+				( $next_arrow + 1 ),
+				$closer
+			);
+		}
+
+		// Ignore any child-arrays as the double arrows in these will already have been handled.
+		return ( $closer + 1 );
+	}
+
+	/**
+	 * Process a multi-line array.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int   $stackPtr The position of the current token in the stack.
+	 * @param array $items    Info array containing information on each array item.
+	 * @param int   $opener   The position of the array opener.
+	 * @param int   $closer   The position of the array closer.
+	 *
+	 * @return void
+	 */
+	protected function process_multi_line_array( $stackPtr, $items, $opener, $closer ) {
+
+		$this->maxColumn = (int) $this->maxColumn;
+		$this->validate_align_multiline_items();
+
+		/*
+		 * Determine what the spacing before the arrow should be.
+		 *
+		 * Will unset any array items without double arrow and with new line whitespace
+		 * if newlines are to be ignored, so the second foreach loop only has to deal
+		 * with items which need attention.
+		 *
+		 * This sniff does not take incorrect indentation of array keys into account.
+		 * That's for the `WordPress.Arrays.ArrayIndentation` sniff to fix.
+		 * If that would affect the alignment, a second (or third) loop of the fixer
+		 * will correct it (again) after the indentation has been fixed.
+		 */
+		$index_end_cols    = array(); // Keep track of the end column position of index keys.
+		$double_arrow_cols = array(); // Keep track of arrow column position and count.
+		$multi_line_count  = 0;
+		$total_items       = count( $items );
+
+		foreach ( $items as $key => $item ) {
+			if ( strpos( $item['raw'], '=>' ) === false ) {
+				// Ignore items without assignment operators.
+				unset( $items[ $key ] );
+				continue;
+			}
+
+			// Find the position of the first double arrow.
+			$double_arrow = $this->phpcsFile->findNext(
+				T_DOUBLE_ARROW,
+				$item['start'],
+				( $item['end'] + 1 )
+			);
+
+			if ( false === $double_arrow ) {
+				// Shouldn't happen, just in case.
+				unset( $items[ $key ] );
+				continue;
+			}
+
+			// Make sure the arrow is for this item and not for a nested array value assignment.
+			$has_array_opener = $this->phpcsFile->findNext(
+				$this->register(),
+				$item['start'],
+				$double_arrow
+			);
+
+			if ( false !== $has_array_opener ) {
+				// Double arrow is for a nested array.
+				unset( $items[ $key ] );
+				continue;
+			}
+
+			// Find the end of the array key.
+			$last_index_token = $this->phpcsFile->findPrevious(
+				T_WHITESPACE,
+				( $double_arrow - 1 ),
+				$item['start'],
+				true
+			);
+
+			if ( false === $last_index_token ) {
+				// Shouldn't happen, but just in case.
+				unset( $items[ $key ] );
+				continue;
+			}
+
+			if ( true === $this->ignoreNewlines
+				&& $this->tokens[ $last_index_token ]['line'] !== $this->tokens[ $double_arrow ]['line']
+			) {
+				// Ignore this item as it has a new line between the item key and the double arrow.
+				unset( $items[ $key ] );
+				continue;
+			}
+
+			$index_end_position                = ( $this->tokens[ $last_index_token ]['column'] + ( $this->tokens[ $last_index_token ]['length'] - 1 ) );
+			$items[ $key ]['operatorPtr']      = $double_arrow;
+			$items[ $key ]['last_index_token'] = $last_index_token;
+			$items[ $key ]['last_index_col']   = $index_end_position;
+
+			if ( $this->tokens[ $last_index_token ]['line'] === $this->tokens[ $item['end'] ]['line'] ) {
+				$items[ $key ]['single_line'] = true;
+			} else {
+				$items[ $key ]['single_line'] = false;
+				$multi_line_count++;
+			}
+
+			if ( ( $index_end_position + 2 ) <= $this->maxColumn ) {
+				$index_end_cols[] = $index_end_position;
+			}
+
+			if ( ! isset( $double_arrow_cols[ $this->tokens[ $double_arrow ]['column'] ] ) ) {
+				$double_arrow_cols[ $this->tokens[ $double_arrow ]['column'] ] = 1;
+			} else {
+				$double_arrow_cols[ $this->tokens[ $double_arrow ]['column'] ]++;
+			}
+		}
+		unset( $key, $item, $double_arrow, $has_array_opener, $last_index_token );
+
+		if ( empty( $items ) || empty( $index_end_cols ) ) {
+			// No actionable array items found.
+			return;
+		}
+
+		/*
+		 * Determine whether the operators for multi-line items should be aligned.
+		 */
+		if ( 'always' === $this->alignMultilineItems ) {
+			$alignMultilineItems = true;
+		} elseif ( 'never' === $this->alignMultilineItems ) {
+			$alignMultilineItems = false;
+		} else {
+			$percentage = (string) round( ( $multi_line_count / $total_items ) * 100, 0 );
+
+			// Bit hacky, but this is the only comparison function in PHP which allows to
+			// pass the comparison operator. And hey, it works ;-).
+			$alignMultilineItems = version_compare( $percentage, $this->number, $this->operator );
+		}
+
+		/*
+		 * If necessary, rebuild the $index_end_cols and $double_arrow_cols arrays
+		 * excluding multi-line items.
+		 */
+		if ( false === $alignMultilineItems ) {
+			$select_index_end_cols = array();
+			$double_arrow_cols     = array();
+
+			foreach ( $items as $item ) {
+				if ( false === $item['single_line'] ) {
+					continue;
+				}
+
+				if ( ( $item['last_index_col'] + 2 ) <= $this->maxColumn ) {
+					$select_index_end_cols[] = $item['last_index_col'];
+				}
+
+				if ( ! isset( $double_arrow_cols[ $this->tokens[ $item['operatorPtr'] ]['column'] ] ) ) {
+					$double_arrow_cols[ $this->tokens[ $item['operatorPtr'] ]['column'] ] = 1;
+				} else {
+					$double_arrow_cols[ $this->tokens[ $item['operatorPtr'] ]['column'] ]++;
+				}
+			}
+		}
+
+		/*
+		 * Determine the expected position of the double arrows.
+		 */
+		if ( ! empty( $select_index_end_cols ) ) {
+			$max_index_width = max( $select_index_end_cols );
+		} else {
+			$max_index_width = max( $index_end_cols );
+		}
+
+		$expected_col = ( $max_index_width + 2 );
+
+		if ( false === $this->exact && ! empty( $double_arrow_cols ) ) {
+			/*
+			 * If the alignment does not have to be exact, see if a majority
+			 * group of the arrows is already at an acceptable position.
+			 */
+			arsort( $double_arrow_cols, SORT_NUMERIC );
+			reset( $double_arrow_cols );
+			$count = current( $double_arrow_cols );
+
+			if ( $count > 1 || ( 1 === $count && count( $items ) === 1 ) ) {
+				// Allow for several groups of arrows having the same $count.
+				$filtered_double_arrow_cols = array_keys( $double_arrow_cols, $count, true );
+
+				foreach ( $filtered_double_arrow_cols as $col ) {
+					if ( $col > $expected_col && $col <= $this->maxColumn ) {
+						$expected_col = $col;
+						break;
+					}
+				}
+			}
+		}
+		unset( $max_index_width, $count, $filtered_double_arrow_cols, $col );
+
+		/*
+		 * Verify and correct the spacing around the double arrows.
+		 */
+		foreach ( $items as $item ) {
+			if ( $this->tokens[ $item['operatorPtr'] ]['column'] === $expected_col
+				&& $this->tokens[ $item['operatorPtr'] ]['line'] === $this->tokens[ $item['last_index_token'] ]['line']
+			) {
+				// Already correctly aligned.
+				continue;
+			}
+
+			if ( T_WHITESPACE !== $this->tokens[ ( $item['operatorPtr'] - 1 ) ]['code'] ) {
+				$before = 0;
+			} else {
+				if ( $this->tokens[ $item['last_index_token'] ]['line'] !== $this->tokens[ $item['operatorPtr'] ]['line'] ) {
+					$before = 'newline';
+				} else {
+					$before = $this->tokens[ ( $item['operatorPtr'] - 1 ) ]['length'];
+				}
+			}
+
+			/*
+			 * Deal with index sizes larger than maxColumn and with multi-line
+			 * array items which should not be aligned.
+			 */
+			if ( ( $item['last_index_col'] + 2 ) > $this->maxColumn
+				|| ( false === $alignMultilineItems && false === $item['single_line'] )
+			) {
+
+				if ( ( $item['last_index_col'] + 2 ) === $this->tokens[ $item['operatorPtr'] ]['column']
+					&& $this->tokens[ $item['operatorPtr'] ]['line'] === $this->tokens[ $item['last_index_token'] ]['line']
+				) {
+					// MaxColumn/Multi-line item exception, already correctly aligned.
+					continue;
+				}
+
+				$prefix = 'LongIndex';
+				if ( false === $alignMultilineItems && false === $item['single_line'] ) {
+					$prefix = 'MultilineItem';
+				}
+
+				$error_code = $prefix . 'SpaceBeforeDoubleArrow';
+				if ( 0 === $before ) {
+					$error_code = $prefix . 'NoSpaceBeforeDoubleArrow';
+				}
+
+				$fix = $this->phpcsFile->addFixableWarning(
+					'Expected 1 space between "%s" and double arrow; %s found.',
+					$item['operatorPtr'],
+					$error_code,
+					array(
+						$this->tokens[ $item['last_index_token'] ]['content'],
+						$before,
+					)
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->beginChangeset();
+
+					// Remove whitespace tokens between the end of the index and the arrow, if any.
+					for ( $i = ( $item['last_index_token'] + 1 ); $i < $item['operatorPtr']; $i++ ) {
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+					}
+
+					// Add the correct whitespace.
+					$this->phpcsFile->fixer->addContent( $item['last_index_token'], ' ' );
+
+					$this->phpcsFile->fixer->endChangeset();
+				}
+				continue;
+			}
+
+			/*
+			 * Deal with the space before double arrows in all other cases.
+			 */
+			$expected_whitespace = $expected_col - ( $this->tokens[ $item['last_index_token'] ]['column'] + $this->tokens[ $item['last_index_token'] ]['length'] );
+
+			$fix = $this->phpcsFile->addFixableWarning(
+				'Array double arrow not aligned correctly; expected %s space(s) between "%s" and double arrow, but found %s.',
+				$item['operatorPtr'],
+				'DoubleArrowNotAligned',
+				array(
+					$expected_whitespace,
+					$this->tokens[ $item['last_index_token'] ]['content'],
+					$before,
+				)
+			);
+
+			if ( true === $fix ) {
+				if ( 0 === $before || 'newline' === $before ) {
+					$this->phpcsFile->fixer->beginChangeset();
+
+					// Remove whitespace tokens between the end of the index and the arrow, if any.
+					for ( $i = ( $item['last_index_token'] + 1 ); $i < $item['operatorPtr']; $i++ ) {
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+					}
+
+					// Add the correct whitespace.
+					$this->phpcsFile->fixer->addContent(
+						$item['last_index_token'],
+						str_repeat( ' ', $expected_whitespace )
+					);
+
+					$this->phpcsFile->fixer->endChangeset();
+				} elseif ( $expected_whitespace > $before ) {
+					// Add to the existing whitespace to prevent replacing tabs with spaces.
+					// That's the concern of another sniff.
+					$this->phpcsFile->fixer->addContent(
+						( $item['operatorPtr'] - 1 ),
+						str_repeat( ' ', ( $expected_whitespace - $before ) )
+					);
+				} else {
+					// Too much whitespace found.
+					$this->phpcsFile->fixer->replaceToken(
+						( $item['operatorPtr'] - 1 ),
+						str_repeat( ' ', $expected_whitespace )
+					);
+				}
+			}
+		}
+	} // End process_multi_line_array().
+
+	/**
+	 * Validate that a valid value has been received for the alignMultilineItems property.
+	 *
+	 * This message may be thrown more than once if the property is being changed inline in a file.
+	 *
+	 * @since 0.14.0
+	 */
+	protected function validate_align_multiline_items() {
+		$alignMultilineItems = $this->alignMultilineItems;
+
+		if ( 'always' === $alignMultilineItems || 'never' === $alignMultilineItems ) {
+			return;
+		} else {
+			// Correct for a potentially added % sign.
+			$alignMultilineItems = rtrim( $alignMultilineItems, '%' );
+
+			if ( preg_match( '`^([=<>!]{1,2})(100|[0-9]{1,2})$`', $alignMultilineItems, $matches ) > 0 ) {
+				$operator = $matches[1];
+				$number   = (int) $matches[2];
+
+				if ( in_array( $operator, array( '<', '<=', '>', '>=', '==', '=', '!=', '<>' ), true ) === true
+					&& ( $number >= 0 && $number <= 100 )
+				) {
+					$this->alignMultilineItems = $alignMultilineItems;
+					$this->number              = (string) $number;
+					$this->operator            = $operator;
+					return;
+				}
+			}
+		}
+
+		$this->phpcsFile->addError(
+			'Invalid property value passed: "%s". The value for the "alignMultilineItems" property for the "WordPress.Arrays.MultipleStatementAlignment" sniff should be either "always", "never" or an comparison operator + a number between 0 and 100.',
+			0,
+			'InvalidPropertyPassed',
+			array( $this->alignMultilineItems )
+		);
+
+		// Reset to the default if an invalid value was received.
+		$this->alignMultilineItems = 'always';
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/CSRF/NonceVerificationSniff.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\CSRF;
+
+use WordPress\Sniff;
+
+/**
+ * Checks that nonce verification accompanies form processing.
+ *
+ * @link    https://developer.wordpress.org/plugins/security/nonces/ Nonces on Plugin Developer Handbook
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.5.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class NonceVerificationSniff extends Sniff {
+
+	/**
+	 * Superglobals to notify about when not accompanied by an nonce check.
+	 *
+	 * A value of `true` results in an error. A value of `false` in a warning.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var array
+	 */
+	protected $superglobals = array(
+		'$_POST'    => true,
+		'$_FILE'    => true,
+		'$_GET'     => false,
+		'$_REQUEST' => false,
+	);
+
+	/**
+	 * Superglobals to give an error for when not accompanied by an nonce check.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 Changed visibility from public to protected.
+	 *
+	 * @deprecated 0.12.0 Replaced by $superglobals property.
+	 *
+	 * @var array
+	 */
+	protected $errorForSuperGlobals = array();
+
+	/**
+	 * Superglobals to give a warning for when not accompanied by an nonce check.
+	 *
+	 * If the variable is also in the error list, that takes precedence.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 Changed visibility from public to protected.
+	 *
+	 * @deprecated 0.12.0 Replaced by $superglobals property.
+	 *
+	 * @var array
+	 */
+	protected $warnForSuperGlobals = array();
+
+	/**
+	 * Custom list of functions which verify nonces.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customNonceVerificationFunctions = array();
+
+	/**
+	 * Custom list of functions that sanitize the values passed to them.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customSanitizingFunctions = array();
+
+	/**
+	 * Custom sanitizing functions that implicitly unslash the values passed to them.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customUnslashingSanitizingFunctions = array();
+
+	/**
+	 * Cache of previously added custom functions.
+	 *
+	 * Prevents having to do the same merges over and over again.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 - Changed from public static to protected non-static.
+	 *               - Changed the format from simple bool to array.
+	 *
+	 * @var array
+	 */
+	protected $addedCustomFunctions = array(
+		'nonce'           => null,
+		'sanitize'        => null,
+		'unslashsanitize' => null,
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+
+		return array(
+			T_VARIABLE,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		$instance = $this->tokens[ $stackPtr ];
+
+		if ( ! isset( $this->superglobals[ $instance['content'] ] ) ) {
+			return;
+		}
+
+		if ( $this->has_whitelist_comment( 'CSRF', $stackPtr ) ) {
+			return;
+		}
+
+		if ( $this->is_assignment( $stackPtr ) ) {
+			return;
+		}
+
+		$this->mergeFunctionLists();
+
+		if ( $this->is_only_sanitized( $stackPtr ) ) {
+			return;
+		}
+
+		if ( $this->has_nonce_check( $stackPtr ) ) {
+			return;
+		}
+
+		// If we're still here, no nonce-verification function was found.
+		$this->addMessage(
+			'Processing form data without nonce verification.',
+			$stackPtr,
+			$this->superglobals[ $instance['content'] ],
+			'NoNonceVerification'
+		);
+
+	} // End process_token().
+
+	/**
+	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.
+	 *
+	 * @since 0.11.0 Split out from the `process()` method.
+	 *
+	 * @return void
+	 */
+	protected function mergeFunctionLists() {
+		if ( $this->customNonceVerificationFunctions !== $this->addedCustomFunctions['nonce'] ) {
+			$this->nonceVerificationFunctions = $this->merge_custom_array(
+				$this->customNonceVerificationFunctions,
+				$this->nonceVerificationFunctions
+			);
+
+			$this->addedCustomFunctions['nonce'] = $this->customNonceVerificationFunctions;
+		}
+
+		if ( $this->customSanitizingFunctions !== $this->addedCustomFunctions['sanitize'] ) {
+			$this->sanitizingFunctions = $this->merge_custom_array(
+				$this->customSanitizingFunctions,
+				$this->sanitizingFunctions
+			);
+
+			$this->addedCustomFunctions['sanitize'] = $this->customSanitizingFunctions;
+		}
+
+		if ( $this->customUnslashingSanitizingFunctions !== $this->addedCustomFunctions['unslashsanitize'] ) {
+			$this->unslashingSanitizingFunctions = $this->merge_custom_array(
+				$this->customUnslashingSanitizingFunctions,
+				$this->unslashingSanitizingFunctions
+			);
+
+			$this->addedCustomFunctions['unslashsanitize'] = $this->customUnslashingSanitizingFunctions;
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Classes/ClassInstantiationSniff.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Classes;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Verifies object instantiation statements.
+ *
+ * - Demand the use of parenthesis.
+ * - Demand no space between the class name and the parenthesis.
+ * - Forbid assigning new by reference.
+ *
+ * {@internal Note: This sniff currently does not examine the parenthesis of new object
+ * instantiations where the class name is held in a variable variable.}}
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class ClassInstantiationSniff extends Sniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+		'JS',
+	);
+
+	/**
+	 * Tokens which can be part of a "classname".
+	 *
+	 * Set from within the register() method.
+	 *
+	 * @var array
+	 */
+	protected $classname_tokens = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		/*
+		 * Set the $classname_tokens property.
+		 *
+		 * Currently does not account for classnames passed as a variable variable.
+		 */
+		$this->classname_tokens                   = Tokens::$emptyTokens;
+		$this->classname_tokens[ T_NS_SEPARATOR ] = T_NS_SEPARATOR;
+		$this->classname_tokens[ T_STRING ]       = T_STRING;
+		$this->classname_tokens[ T_SELF ]         = T_SELF;
+		$this->classname_tokens[ T_STATIC ]       = T_STATIC;
+		$this->classname_tokens[ T_PARENT ]       = T_PARENT;
+		$this->classname_tokens[ T_ANON_CLASS ]   = T_ANON_CLASS;
+
+		// Classname in a variable.
+		$this->classname_tokens[ T_VARIABLE ]                 = T_VARIABLE;
+		$this->classname_tokens[ T_DOUBLE_COLON ]             = T_DOUBLE_COLON;
+		$this->classname_tokens[ T_OBJECT_OPERATOR ]          = T_OBJECT_OPERATOR;
+		$this->classname_tokens[ T_OPEN_SQUARE_BRACKET ]      = T_OPEN_SQUARE_BRACKET;
+		$this->classname_tokens[ T_CLOSE_SQUARE_BRACKET ]     = T_CLOSE_SQUARE_BRACKET;
+		$this->classname_tokens[ T_CONSTANT_ENCAPSED_STRING ] = T_CONSTANT_ENCAPSED_STRING;
+		$this->classname_tokens[ T_LNUMBER ]                  = T_LNUMBER;
+
+		return array(
+			T_NEW,
+			T_STRING, // JS.
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		// Make sure we have the right token, JS vs PHP.
+		if ( ( 'PHP' === $this->phpcsFile->tokenizerType && T_NEW !== $this->tokens[ $stackPtr ]['code'] )
+			|| ( 'JS' === $this->phpcsFile->tokenizerType
+				&& ( T_STRING !== $this->tokens[ $stackPtr ]['code']
+				|| 'new' !== strtolower( $this->tokens[ $stackPtr ]['content'] ) ) )
+		) {
+			return;
+		}
+
+		/*
+		 * Check for new by reference used in PHP files.
+		 */
+		if ( 'PHP' === $this->phpcsFile->tokenizerType ) {
+			$prev_non_empty = $this->phpcsFile->findPrevious(
+				Tokens::$emptyTokens,
+				( $stackPtr - 1 ),
+				null,
+				true
+			);
+
+			if ( false !== $prev_non_empty && 'T_BITWISE_AND' === $this->tokens[ $prev_non_empty ]['type'] ) {
+				$this->phpcsFile->recordMetric( $stackPtr, 'Assigning new by reference', 'yes' );
+
+				$this->phpcsFile->addError(
+					'Assigning the return value of new by reference is no longer supported by PHP.',
+					$stackPtr,
+					'NewByReferenceFound'
+				);
+			} else {
+				$this->phpcsFile->recordMetric( $stackPtr, 'Assigning new by reference', 'no' );
+			}
+		}
+
+		/*
+		 * Check for parenthesis & correct placement thereof.
+		 */
+		$next_non_empty_after_class_name = $this->phpcsFile->findNext(
+			$this->classname_tokens,
+			( $stackPtr + 1 ),
+			null,
+			true,
+			null,
+			true
+		);
+
+		if ( false === $next_non_empty_after_class_name ) {
+			// Live coding.
+			return;
+		}
+
+		// Walk back to the last part of the class name.
+		$has_comment = false;
+		for ( $classname_ptr = ( $next_non_empty_after_class_name - 1 ); $classname_ptr >= $stackPtr; $classname_ptr-- ) {
+			if ( ! isset( Tokens::$emptyTokens[ $this->tokens[ $classname_ptr ]['code'] ] ) ) {
+				// Prevent a false positive on variable variables, disregard them for now.
+				if ( $stackPtr === $classname_ptr ) {
+					return;
+				}
+
+				break;
+			}
+
+			if ( T_WHITESPACE !== $this->tokens[ $classname_ptr ]['code'] ) {
+				$has_comment = true;
+			}
+		}
+
+		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $next_non_empty_after_class_name ]['code'] ) {
+			$this->phpcsFile->recordMetric( $stackPtr, 'Object instantiation with parenthesis', 'no' );
+
+			$fix = $this->phpcsFile->addFixableError(
+				'Parenthesis should always be used when instantiating a new object.',
+				$classname_ptr,
+				'MissingParenthesis'
+			);
+
+			if ( true === $fix ) {
+				$this->phpcsFile->fixer->addContent( $classname_ptr, '()' );
+			}
+		} else {
+			$this->phpcsFile->recordMetric( $stackPtr, 'Object instantiation with parenthesis', 'yes' );
+
+			if ( ( $next_non_empty_after_class_name - 1 ) !== $classname_ptr ) {
+				$this->phpcsFile->recordMetric(
+					$stackPtr,
+					'Space between classname and parenthesis',
+					( $next_non_empty_after_class_name - $classname_ptr )
+				);
+
+				$error      = 'There must be no spaces between the class name and the open parenthesis when instantiating a new object.';
+				$error_code = 'SpaceBeforeParenthesis';
+
+				if ( false === $has_comment ) {
+					$fix = $this->phpcsFile->addFixableError( $error, $next_non_empty_after_class_name, $error_code );
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->beginChangeset();
+						for ( $i = ( $next_non_empty_after_class_name - 1 ); $i > $classname_ptr; $i-- ) {
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+						}
+						$this->phpcsFile->fixer->endChangeset();
+					}
+				} else {
+					$fix = $this->phpcsFile->addError( $error, $next_non_empty_after_class_name, $error_code );
+				}
+			} else {
+				$this->phpcsFile->recordMetric( $stackPtr, 'Space between classname and parenthesis', 0 );
+			}
+		}
+	} // End process_token().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/CodeAnalysis/AssignmentInConditionSniff.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\CodeAnalysis;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Detects variable assignments being made within conditions.
+ *
+ * This is a typical code smell and more often than not a comparison was intended.
+ *
+ * Note: this sniff does not detect variable assignments in ternaries without parentheses!
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ *
+ * {@internal This sniff is a duplicate of the same sniff as pulled upstream.
+ * Once the upstream sniff has been merged and the minimum WPCS PHPCS requirement has gone up to
+ * the version in which the sniff was merged, this version can be safely removed.
+ * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1594} }}
+ */
+class AssignmentInConditionSniff extends Sniff {
+
+	/**
+	 * Assignment tokens to trigger on.
+	 *
+	 * Set in the register() method.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var array
+	 */
+	protected $assignment_tokens = array();
+
+	/**
+	 * The tokens that indicate the start of a condition.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var array
+	 */
+	protected $condition_start_tokens = array();
+
+	/**
+	 * Registers the tokens that this sniff wants to listen for.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		$this->assignment_tokens = Tokens::$assignmentTokens;
+		unset( $this->assignment_tokens[ T_DOUBLE_ARROW ] );
+
+		$starters                       = Tokens::$booleanOperators;
+		$starters[ T_SEMICOLON ]        = T_SEMICOLON;
+		$starters[ T_OPEN_PARENTHESIS ] = T_OPEN_PARENTHESIS;
+		$starters[ T_INLINE_ELSE ]      = T_INLINE_ELSE;
+
+		$this->condition_start_tokens = $starters;
+
+		return array(
+			T_IF,
+			T_ELSEIF,
+			T_FOR,
+			T_SWITCH,
+			T_CASE,
+			T_WHILE,
+			T_INLINE_THEN,
+		);
+
+	}//end register()
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		$token = $this->tokens[ $stackPtr ];
+
+		// Find the condition opener/closer.
+		if ( T_FOR === $token['code'] ) {
+			if ( isset( $token['parenthesis_opener'], $token['parenthesis_closer'] ) === false ) {
+				return;
+			}
+
+			$semicolon = $this->phpcsFile->findNext( T_SEMICOLON, ( $token['parenthesis_opener'] + 1 ), $token['parenthesis_closer'] );
+			if ( false === $semicolon ) {
+				return;
+			}
+
+			$opener    = $semicolon;
+			$semicolon = $this->phpcsFile->findNext( T_SEMICOLON, ( $opener + 1 ), $token['parenthesis_closer'] );
+			if ( false === $semicolon ) {
+				return;
+			}
+
+			$closer = $semicolon;
+			unset( $semicolon );
+
+		} elseif ( T_CASE === $token['code'] ) {
+			if ( isset( $token['scope_opener'] ) === false ) {
+				return;
+			}
+
+			$opener = $stackPtr;
+			$closer = $token['scope_opener'];
+
+		} elseif ( T_INLINE_THEN === $token['code'] ) {
+			// Check if the condition for the ternary is bracketed.
+			$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+			if ( false === $prev ) {
+				// Shouldn't happen, but in that case we don't have anything to examine anyway.
+				return;
+			}
+
+			if ( T_CLOSE_PARENTHESIS === $this->tokens[ $prev ]['code'] ) {
+				if ( ! isset( $this->tokens[ $prev ]['parenthesis_opener'] ) ) {
+					return;
+				}
+
+				$opener = $this->tokens[ $prev ]['parenthesis_opener'];
+				$closer = $prev;
+			} elseif ( isset( $token['nested_parenthesis'] ) ) {
+				end( $token['nested_parenthesis'] );
+				$opener = key( $token['nested_parenthesis'] );
+				$closer = $stackPtr;
+			} else {
+				// No parenthesis found, can't determine where the conditional part of the ternary starts.
+				return;
+			}
+		} else {
+			if ( isset( $token['parenthesis_opener'], $token['parenthesis_closer'] ) === false ) {
+				return;
+			}
+
+			$opener = $token['parenthesis_opener'];
+			$closer = $token['parenthesis_closer'];
+		}
+
+		$startPos = $opener;
+
+		do {
+			$hasAssignment = $this->phpcsFile->findNext( $this->assignment_tokens, ( $startPos + 1 ), $closer );
+			if ( false === $hasAssignment ) {
+				return;
+			}
+
+			// Examine whether the left side is a variable.
+			$hasVariable       = false;
+			$conditionStart    = $startPos;
+			$altConditionStart = $this->phpcsFile->findPrevious(
+				$this->condition_start_tokens,
+				( $hasAssignment - 1 ),
+				$startPos
+			);
+			if ( false !== $altConditionStart ) {
+				$conditionStart = $altConditionStart;
+			}
+
+			for ( $i = $hasAssignment; $i > $conditionStart; $i-- ) {
+				if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+					continue;
+				}
+
+				// If this is a variable or array, we've seen all we need to see.
+				if ( T_VARIABLE === $this->tokens[ $i ]['code']
+					|| T_CLOSE_SQUARE_BRACKET === $this->tokens[ $i ]['code']
+				) {
+					$hasVariable = true;
+					break;
+				}
+
+				// If this is a function call or something, we are OK.
+				if ( T_CLOSE_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
+					break;
+				}
+			}
+
+			if ( true === $hasVariable ) {
+				$errorCode = 'Found';
+				if ( T_WHILE === $token['code'] ) {
+					$errorCode = 'FoundInWhileCondition';
+				}
+
+				$this->phpcsFile->addWarning(
+					'Variable assignment found within a condition. Did you mean to do a comparison?',
+					$hasAssignment,
+					$errorCode
+				);
+			} else {
+				$this->phpcsFile->addWarning(
+					'Assignment found within a condition. Did you mean to do a comparison?',
+					$hasAssignment,
+					'NonVariableAssignmentFound'
+				);
+			}
+
+			$startPos = $hasAssignment;
+
+		} while ( $startPos < $closer );
+
+	}
+
+}

--- a/ci/wpcs/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/CodeAnalysis/EmptyStatementSniff.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\CodeAnalysis;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Checks against empty statements.
+ *
+ * - Check against two semi-colons with no executable code in between.
+ * - Check against an empty PHP open - close tag combination.
+ *
+ * {@internal This check should at some point in the future be pulled upstream and probably
+ *            merged into the upstream `Generic.CodeAnalysis.EmptyStatement` sniff.
+ *            This will need to wait until the WPCS minimum requirements have gone up
+ *            beyond PHPCS 3.x though as it is not likely that new features will be accepted
+ *            still for the PHPCS 2.x branch.}}
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class EmptyStatementSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_SEMICOLON,
+			T_CLOSE_TAG,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int Integer stack pointer to skip the rest of the file.
+	 */
+	public function process_token( $stackPtr ) {
+
+		switch ( $this->tokens[ $stackPtr ]['type'] ) {
+			/*
+			 * Detect `something();;`.
+			 */
+			case 'T_SEMICOLON':
+				$prevNonEmpty = $this->phpcsFile->findPrevious(
+					Tokens::$emptyTokens,
+					( $stackPtr - 1 ),
+					null,
+					true
+				);
+
+				if ( false === $prevNonEmpty
+					|| ( T_SEMICOLON !== $this->tokens[ $prevNonEmpty ]['code']
+						&& T_OPEN_TAG !== $this->tokens[ $prevNonEmpty ]['code'] )
+				) {
+					return;
+				}
+
+				$fix = $this->phpcsFile->addFixableWarning(
+					'Empty PHP statement detected: superfluous semi-colon.',
+					$stackPtr,
+					'SemicolonWithoutCodeDetected'
+				);
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->beginChangeset();
+
+					if ( T_OPEN_TAG === $this->tokens[ $prevNonEmpty ]['code'] ) {
+						/*
+						 * Check for superfluous whitespace after the semi-colon which will be
+						 * removed as the `<?php ` open tag token already contains whitespace,
+						 * either a space or a new line and in case of a new line, the indentation
+						 * should be done via tabs, so spaces can be safely removed.
+						 */
+						if ( T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+							$replacement = str_replace( ' ', '', $this->tokens[ ( $stackPtr + 1 ) ]['content'] );
+							$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), $replacement );
+						}
+					}
+
+					for ( $i = $stackPtr; $i > $prevNonEmpty; $i-- ) {
+						if ( T_SEMICOLON !== $this->tokens[ $i ]['code']
+							&& T_WHITESPACE !== $this->tokens[ $i ]['code']
+						) {
+							break;
+						}
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+					}
+
+					$this->phpcsFile->fixer->endChangeset();
+				}
+				break;
+
+			/*
+			 * Detect `<?php ?>`.
+			 */
+			case 'T_CLOSE_TAG':
+				$prevNonEmpty = $this->phpcsFile->findPrevious(
+					T_WHITESPACE,
+					( $stackPtr - 1 ),
+					null,
+					true
+				);
+
+				if ( false === $prevNonEmpty || T_OPEN_TAG !== $this->tokens[ $prevNonEmpty ]['code'] ) {
+					return;
+				}
+
+				$fix = $this->phpcsFile->addFixableWarning(
+					'Empty PHP open/close tag combination detected.',
+					$prevNonEmpty,
+					'EmptyPHPOpenCloseTagsDetected'
+				);
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->beginChangeset();
+					for ( $i = $prevNonEmpty; $i <= $stackPtr; $i++ ) {
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+					}
+					$this->phpcsFile->fixer->endChangeset();
+				}
+				break;
+
+			default:
+				/* Deliberately left empty. */
+				break;
+		}
+
+	} // End process_token().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/DB/PreparedSQLPlaceholdersSniff.php
@@ -1,0 +1,661 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\DB;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Check for incorrect use of the $wpdb->prepare method.
+ *
+ * Check the following issues:
+ * - The only placeholders supported are: %d, %f (%F) and %s and their variations.
+ * - Literal % signs need to be properly escaped as `%%`.
+ * - Simple placeholders (%d, %f, %F, %s) should be left unquoted in the query string.
+ * - Complex placeholders - numbered and formatted variants - will not be quoted
+ *   automagically by $wpdb->prepare(), so if used for values, should be quoted in
+ *   the query string.
+ * - Either an array of replacements should be passed matching the number of
+ *   placeholders found or individual parameters for each placeholder should
+ *   be passed.
+ * - Wildcards for LIKE compare values should be passed in via a replacement parameter.
+ *
+ * The sniff allows for a specific pattern with a variable number of placeholders
+ * created using code along the lines of:
+ * `sprintf( 'query .... IN (%s) ...', implode( ',', array_fill( 0, count( $something ), '%s' ) ) )`.
+ *
+ * A "PreparedSQLPlaceholders replacement count" whitelist comment is supported
+ * specifically to silence the `ReplacementsWrongNumber` and `UnfinishedPrepare`
+ * error codes. The other error codes are not affected by it.
+ *
+ * @link https://developer.wordpress.org/reference/classes/wpdb/prepare/
+ * @link https://core.trac.wordpress.org/changeset/41496
+ * @link https://core.trac.wordpress.org/changeset/41471
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class PreparedSQLPlaceholdersSniff extends Sniff {
+
+	/**
+	 * These regexes copied from http://php.net/manual/en/function.sprintf.php#93552
+	 * and adjusted for limitations in `$wpdb->prepare()`.
+	 *
+	 * Near duplicate of the one used in the WP.I18n sniff, but with fewer types allowed.
+	 *
+	 * Note: The regex delimiters and modifiers are not included to allow this regex to be
+	 * concatenated together with other regex partials.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var string
+	 */
+	const PREPARE_PLACEHOLDER_REGEX = '(?:
+		(?<![^%]%)                     # Don\'t match a literal % (%%), including when it could overlap with a placeholder.
+		(?:
+			%                          # Start of placeholder.
+			(?:[0-9]+\\\\?\$)?         # Optional ordering of the placeholders.
+			[+-]?                      # Optional sign specifier.
+			(?:
+				(?:0|\'.)?                 # Optional padding specifier - excluding the space.
+				-?                         # Optional alignment specifier.
+				[0-9]*                     # Optional width specifier.
+				(?:\.(?:[ 0]|\'.)?[0-9]+)? # Optional precision specifier with optional padding character.
+				|                      # Only recognize the space as padding in combination with a width specifier.
+				(?:[ ])?                   # Optional space padding specifier.
+				-?                         # Optional alignment specifier.
+				[0-9]+                     # Width specifier.
+				(?:\.(?:[ 0]|\'.)?[0-9]+)? # Optional precision specifier with optional padding character.
+			)
+			[dfFs]                     # Type specifier.
+		)
+	)';
+
+	/**
+	 * Similar to above, but for the placeholder types *not* supported.
+	 *
+	 * Note: all optional parts are forced to be greedy to allow for the negative look ahead
+	 * at the end to work.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var string
+	 */
+	const UNSUPPORTED_PLACEHOLDER_REGEX = '`(?:
+		(?<!%)                     # Don\'t match a literal % (%%).
+		(
+			%                          # Start of placeholder.
+			(?!                        # Negative look ahead.
+				%[^%]                       # Not a correct literal % (%%).
+				|
+				%%[dfFs]                    # Nor a correct literal % (%%), followed by a simple placeholder.
+			)
+			(?:[0-9]+\\\\??\$)?+       # Optional ordering of the placeholders.
+			[+-]?+                     # Optional sign specifier.
+			(?:
+				(?:0|\'.)?+                 # Optional padding specifier - excluding the space.
+				-?+                         # Optional alignment specifier.
+				[0-9]*+                     # Optional width specifier.
+				(?:\.(?:[ 0]|\'.)?[0-9]+)?+ # Optional precision specifier with optional padding character.
+				|                      # Only recognize the space as padding in combination with a width specifier.
+				(?:[ ])?+                   # Optional space padding specifier.
+				-?+                         # Optional alignment specifier.
+				[0-9]++                     # Width specifier.
+				(?:\.(?:[ 0]|\'.)?[0-9]+)?+ # Optional precision specifier with optional padding character.
+			)
+			(?![dfFs])                 # Negative look ahead: not one of the supported placeholders.
+			(?:[^ \'"]*|$)             # but something else instead.
+		)
+	)`x';
+
+	/**
+	 * List of $wpdb methods we are interested in.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var array
+	 */
+	protected $target_methods = array(
+		'prepare' => true,
+	);
+
+	/**
+	 * Storage for the stack pointer to the method call token.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var int
+	 */
+	protected $methodPtr;
+
+	/**
+	 * Simple regex snippet to recognize and remember quotes.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var string
+	 */
+	private $regex_quote = '["\']';
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_VARIABLE,
+			T_STRING,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		if ( ! $this->is_wpdb_method_call( $stackPtr, $this->target_methods ) ) {
+			return;
+		}
+
+		$parameters = $this->get_function_call_parameters( $this->methodPtr );
+		if ( empty( $parameters ) ) {
+			return;
+		}
+
+		$query                    = $parameters[1];
+		$text_string_tokens_found = false;
+		$variable_found           = false;
+		$sql_wildcard_found       = false;
+		$total_placeholders       = 0;
+		$total_parameters         = count( $parameters );
+		$valid_in_clauses         = array(
+			'uses_in'          => 0,
+			'implode_fill'     => 0,
+			'adjustment_count' => 0,
+		);
+
+		for ( $i = $query['start']; $i <= $query['end']; $i++ ) {
+			// Skip over groups of tokens if they are part of an inline function call.
+			if ( isset( $skip_from, $skip_to ) && $i >= $skip_from && $i < $skip_to ) {
+				$i = $skip_to;
+				continue;
+			}
+
+			if ( ! isset( Tokens::$textStringTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+				if ( T_VARIABLE === $this->tokens[ $i ]['code'] ) {
+					if ( '$wpdb' !== $this->tokens[ $i ]['content'] ) {
+						$variable_found = true;
+					}
+					continue;
+				}
+
+				// Detect a specific pattern for variable replacements in combination with `IN`.
+				if ( T_STRING === $this->tokens[ $i ]['code'] ) {
+
+					if ( 'sprintf' === strtolower( $this->tokens[ $i ]['content'] ) ) {
+						$sprintf_parameters = $this->get_function_call_parameters( $i );
+
+						if ( ! empty( $sprintf_parameters ) ) {
+							$skip_from  = ( $sprintf_parameters[1]['end'] + 1 );
+							$last_param = end( $sprintf_parameters );
+							$skip_to    = ( $last_param['end'] + 1 );
+
+							$valid_in_clauses['implode_fill']     += $this->analyse_sprintf( $sprintf_parameters );
+							$valid_in_clauses['adjustment_count'] += ( count( $sprintf_parameters ) - 1 );
+						}
+						unset( $sprintf_parameters, $last_param );
+
+					} elseif ( 'implode' === strtolower( $this->tokens[ $i ]['content'] ) ) {
+						$prev = $this->phpcsFile->findPrevious(
+							Tokens::$textStringTokens,
+							( $i - 1 ),
+							$query['start']
+						);
+
+						$prev_content = $this->strip_quotes( $this->tokens[ $prev ]['content'] );
+						$regex_quote  = $this->get_regex_quote_snippet( $prev_content, $this->tokens[ $prev ]['content'] );
+
+						// Only examine the implode if preceded by an ` IN (`.
+						if ( preg_match( '`\s+IN\s*\(\s*(' . $regex_quote . ')?$`i', $prev_content, $match ) > 0 ) {
+
+							if ( isset( $match[1] ) && $regex_quote !== $this->regex_quote ) {
+								$this->phpcsFile->addError(
+									'Dynamic placeholder generation should not have surrounding quotes.',
+									$i,
+									'QuotedDynamicPlaceholderGeneration'
+								);
+							}
+
+							if ( $this->analyse_implode( $i ) === true ) {
+								++$valid_in_clauses['uses_in'];
+								++$valid_in_clauses['implode_fill'];
+
+								$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $i + 1 ), null, true );
+								if ( T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code']
+									&& isset( $this->tokens[ $next ]['parenthesis_closer'] )
+								) {
+									$skip_from = ( $i + 1 );
+									$skip_to   = ( $this->tokens[ $next ]['parenthesis_closer'] + 1 );
+								}
+							}
+						}
+						unset( $prev, $next, $prev_content, $regex_quote, $match );
+					}
+				}
+
+				continue;
+			}
+
+			$text_string_tokens_found = true;
+			$content                  = $this->tokens[ $i ]['content'];
+
+			$regex_quote = $this->regex_quote;
+			if ( isset( Tokens::$stringTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+				$content     = $this->strip_quotes( $content );
+				$regex_quote = $this->get_regex_quote_snippet( $content, $this->tokens[ $i ]['content'] );
+			}
+
+			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $i ]['code']
+				|| T_HEREDOC === $this->tokens[ $i ]['code']
+			) {
+				// Only interested in actual query text, so strip out variables.
+				$stripped_content = $this->strip_interpolated_variables( $content );
+				if ( $stripped_content !== $content ) {
+					$interpolated_vars = $this->get_interpolated_variables( $content );
+					$vars_without_wpdb = array_diff( $interpolated_vars, array( 'wpdb' ) );
+					$content           = $stripped_content;
+
+					if ( ! empty( $vars_without_wpdb ) ) {
+						$variable_found = true;
+					}
+				}
+				unset( $stripped_content, $interpolated_vars, $vars_without_wpdb );
+			}
+
+			$placeholders = preg_match_all( '`' . self::PREPARE_PLACEHOLDER_REGEX . '`x', $content, $matches );
+			if ( $placeholders > 0 ) {
+				$total_placeholders += $placeholders;
+			}
+
+			/*
+			 * Analyse the query for incorrect LIKE queries.
+			 *
+			 * - `LIKE %s` is the only correct one.
+			 * - `LIKE '%s'` or `LIKE "%s"` will not be reported here, but in the quote check.
+			 * - Any other `LIKE` statement should be reported, either for using `LIKE` without
+			 *   SQL wildcards or for not passing the SQL wildcards via the replacement.
+			 */
+			$regex = '`\s+LIKE\s*(?:(' . $regex_quote . ')(?!%s(?:\1|$))(?P<content>.*?)(?:\1|$)|(?:concat\((?![^\)]*%s[^\)]*\))(?P<concat>[^\)]*))\))`i';
+			if ( preg_match_all( $regex, $content, $matches ) > 0 ) {
+				$walk = array();
+				if ( ! empty( $matches['content'] ) ) {
+					$matches['content'] = array_filter( $matches['content'] );
+					if ( ! empty( $matches['content'] ) ) {
+						$walk[] = 'content';
+					}
+				}
+				if ( ! empty( $matches['concat'] ) ) {
+					$matches['concat'] = array_filter( $matches['concat'] );
+					if ( ! empty( $matches['concat'] ) ) {
+						$walk[] = 'concat';
+					}
+				}
+
+				if ( ! empty( $walk ) ) {
+					foreach ( $walk as $match_key ) {
+						foreach ( $matches[ $match_key ] as $index => $match ) {
+							$data = array( $matches[0][ $index ] );
+
+							// Both a `%` as well as a `_` are wildcards in SQL.
+							if ( strpos( $match, '%' ) === false && strpos( $match, '_' ) === false ) {
+								$this->phpcsFile->addWarning(
+									'Unless you are using SQL wildcards, using LIKE is inefficient. Use a straight compare instead. Found: %s.',
+									$i,
+									'LikeWithoutWildcards',
+									$data
+								);
+							} else {
+								$sql_wildcard_found = true;
+
+								if ( strpos( $match, '%s' ) === false ) {
+									$this->phpcsFile->addError(
+										'SQL wildcards for a LIKE query should be passed in through a replacement parameter. Found: %s.',
+										$i,
+										'LikeWildcardsInQuery',
+										$data
+									);
+								} else {
+									$this->phpcsFile->addError(
+										'SQL wildcards for a LIKE query should be passed in through a replacement parameter and the variable part of the replacement should be escaped using "esc_like()". Found: %s.',
+										$i,
+										'LikeWildcardsInQueryWithPlaceholder',
+										$data
+									);
+								}
+							}
+
+							/*
+							 * Don't throw `UnescapedLiteral`, `UnsupportedPlaceholder` or `QuotedPlaceholder`
+							 * for this part of the SQL query.
+							 */
+							$content = preg_replace( '`' . preg_quote( $match ) . '`', '', $content, 1 );
+						}
+					}
+				}
+				unset( $matches, $index, $match, $data );
+			}
+
+			if ( strpos( $content, '%' ) === false ) {
+				continue;
+			}
+
+			/*
+			 * Analyse the query for unsupported placeholders.
+			 */
+			if ( preg_match_all( self::UNSUPPORTED_PLACEHOLDER_REGEX, $content, $matches ) > 0 ) {
+				if ( ! empty( $matches[0] ) ) {
+					foreach ( $matches[0] as $match ) {
+						if ( '%' === $match ) {
+							$this->phpcsFile->addError(
+								'Found unescaped literal "%%" character.',
+								$i,
+								'UnescapedLiteral',
+								array( $match )
+							);
+						} else {
+							$this->phpcsFile->addError(
+								'Unsupported placeholder used in $wpdb->prepare(). Found: "%s".',
+								$i,
+								'UnsupportedPlaceholder',
+								array( $match )
+							);
+						}
+					}
+				}
+				unset( $match, $matches );
+			}
+
+			/*
+			 * Analyse the query for quoted placeholders.
+			 */
+			$regex = '`(' . $regex_quote . ')%[dfFs]\1`';
+			if ( preg_match_all( $regex, $content, $matches ) > 0 ) {
+				if ( ! empty( $matches[0] ) ) {
+					foreach ( $matches[0] as $match ) {
+						$this->phpcsFile->addError(
+							'Simple placeholders should not be quoted in the query string in $wpdb->prepare(). Found: %s.',
+							$i,
+							'QuotedSimplePlaceholder',
+							array( $match )
+						);
+					}
+				}
+				unset( $match, $matches );
+			}
+
+			/*
+			 * Analyse the query for unquoted complex placeholders.
+			 */
+			$regex = '`(?<!' . $regex_quote . ')' . self::PREPARE_PLACEHOLDER_REGEX . '(?!' . $regex_quote . ')`x';
+			if ( preg_match_all( $regex, $content, $matches ) > 0 ) {
+				if ( ! empty( $matches[0] ) ) {
+					foreach ( $matches[0] as $match ) {
+						if ( preg_match( '`%[dfFs]`', $match ) !== 1 ) {
+							$this->phpcsFile->addWarning(
+								'Complex placeholders used for values in the query string in $wpdb->prepare() will NOT be quoted automagically. Found: %s.',
+								$i,
+								'UnquotedComplexPlaceholder',
+								array( $match )
+							);
+						}
+					}
+				}
+				unset( $match, $matches );
+			}
+
+			/*
+			 * Check for an ` IN (%s)` clause.
+			 */
+			$found_in = preg_match_all( '`\s+IN\s*\(\s*%s\s*\)`i', $content, $matches );
+			if ( $found_in > 0 ) {
+				$valid_in_clauses['uses_in'] += $found_in;
+			}
+			unset( $found_in );
+		}
+
+		if ( false === $text_string_tokens_found ) {
+			// Query string passed in as a variable or function call, nothing to examine.
+			return;
+		}
+
+		$count_diff_whitelisted = $this->has_whitelist_comment(
+			'PreparedSQLPlaceholders replacement count',
+			$stackPtr
+		);
+
+		if ( 0 === $total_placeholders ) {
+			if ( 1 === $total_parameters ) {
+				if ( false === $variable_found && false === $sql_wildcard_found ) {
+					/*
+					 * Only throw this warning if the PreparedSQL sniff won't throw one about
+					 * variables being found.
+					 * Also don't throw it if we just advised to use a replacement variable to pass a
+					 * string containing an SQL wildcard.
+					 */
+					$this->phpcsFile->addWarning(
+						'It is not necessary to prepare a query which doesn\'t use variable replacement.',
+						$i,
+						'UnnecessaryPrepare'
+					);
+				}
+			} elseif ( false === $count_diff_whitelisted && 0 === $valid_in_clauses['uses_in'] ) {
+				$this->phpcsFile->addWarning(
+					'Replacement variables found, but no valid placeholders found in the query.',
+					$i,
+					'UnfinishedPrepare'
+				);
+			}
+
+			return;
+		}
+
+		if ( 1 === $total_parameters ) {
+			$this->phpcsFile->addError(
+				'Placeholders found in the query passed to $wpdb->prepare(), but no replacements found. Expected %d replacement(s) parameters.',
+				$stackPtr,
+				'MissingReplacements',
+				array( $total_placeholders )
+			);
+			return;
+		}
+
+		if ( true === $count_diff_whitelisted ) {
+			return;
+		}
+
+		$replacements = $parameters;
+		array_shift( $replacements ); // Remove the query.
+
+		// The parameters may have been passed as an array in parameter 2.
+		if ( isset( $parameters[2] ) && 2 === $total_parameters ) {
+			$next = $this->phpcsFile->findNext(
+				Tokens::$emptyTokens,
+				$parameters[2]['start'],
+				( $parameters[2]['end'] + 1 ),
+				true
+			);
+
+			if ( false !== $next
+				&& ( T_ARRAY === $this->tokens[ $next ]['code']
+					|| T_OPEN_SHORT_ARRAY === $this->tokens[ $next ]['code'] )
+			) {
+				$replacements = $this->get_function_call_parameters( $next );
+			}
+		}
+
+		$total_replacements  = count( $replacements );
+		$total_placeholders -= $valid_in_clauses['adjustment_count'];
+
+		// Bow out when `IN` clauses have been used which appear to be correct.
+		if ( $valid_in_clauses['uses_in'] > 0
+			&& $valid_in_clauses['uses_in'] === $valid_in_clauses['implode_fill']
+			&& 1 === $total_replacements
+		) {
+			return;
+		}
+
+		/*
+		 * Verify that the correct amount of replacements have been passed.
+		 */
+		if ( $total_replacements !== $total_placeholders ) {
+			$this->phpcsFile->addWarning(
+				'Incorrect number of replacements passed to $wpdb->prepare(). Found %d replacement parameters, expected %d.',
+				$stackPtr,
+				'ReplacementsWrongNumber',
+				array( $total_replacements, $total_placeholders )
+			);
+		}
+	}
+
+	/**
+	 * Retrieve a regex snippet to recognize and remember quotes based on the quote style
+	 * used in the original string (if any).
+	 *
+	 * This allows for recognizing `"` and `\'` in single quoted strings,
+	 * recognizing `'` and `\"` in double quotes strings and `'` and `"`when the quote
+	 * style is unknown or it is a non-quoted string (heredoc/nowdoc and such).
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param string $stripped_content Text string content without surrounding quotes.
+	 * @param string $original_content Original content for the same text string.
+	 *
+	 * @return string
+	 */
+	protected function get_regex_quote_snippet( $stripped_content, $original_content ) {
+		$regex_quote = $this->regex_quote;
+
+		if ( $original_content !== $stripped_content ) {
+			$quote_style = $original_content[0];
+
+			if ( '"' === $quote_style ) {
+				$regex_quote = '\\\\"|\'';
+			} elseif ( "'" === $quote_style ) {
+				$regex_quote = '"|\\\\\'';
+			}
+		}
+
+		return $regex_quote;
+	}
+
+	/**
+	 * Analyse a sprintf() query wrapper to see if it contains a specific code pattern
+	 * to deal correctly with `IN` queries.
+	 *
+	 * The pattern we are searching for is:
+	 * `sprintf( 'query ....', implode( ',', array_fill( 0, count( $something ), '%s' ) ) )`
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param array $sprintf_params Parameters details for the sprintf call.
+	 *
+	 * @return int The number of times the pattern was found in the replacements.
+	 */
+	protected function analyse_sprintf( $sprintf_params ) {
+		$found = 0;
+
+		unset( $sprintf_params[1] );
+
+		foreach ( $sprintf_params as $sprintf_param ) {
+			if ( strpos( strtolower( $sprintf_param['raw'] ), 'implode' ) === false ) {
+				continue;
+			}
+
+			$implode = $this->phpcsFile->findNext(
+				Tokens::$emptyTokens,
+				$sprintf_param['start'],
+				$sprintf_param['end'],
+				true
+			);
+			if ( T_STRING === $this->tokens[ $implode ]['code']
+				&& 'implode' === strtolower( $this->tokens[ $implode ]['content'] )
+			) {
+				if ( $this->analyse_implode( $implode ) === true ) {
+					++$found;
+				}
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Analyse an implode() function call to see if it contains a specific code pattern
+	 * to dynamically create placeholders.
+	 *
+	 * The pattern we are searching for is:
+	 * `implode( ',', array_fill( 0, count( $something ), '%s' ) )`
+	 *
+	 * This pattern presumes unquoted placeholders!
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int $implode_token The stackPtr to the implode function call.
+	 *
+	 * @return bool True if the pattern is found, false otherwise.
+	 */
+	protected function analyse_implode( $implode_token ) {
+		$implode_params = $this->get_function_call_parameters( $implode_token );
+
+		if ( empty( $implode_params ) || count( $implode_params ) !== 2 ) {
+			return false;
+		}
+
+		if ( preg_match( '`^(["\']), ?\1$`', $implode_params[1]['raw'] ) !== 1 ) {
+			return false;
+		}
+
+		if ( strpos( strtolower( $implode_params[2]['raw'] ), 'array_fill' ) === false ) {
+			return false;
+		}
+
+		$array_fill = $this->phpcsFile->findNext(
+			Tokens::$emptyTokens,
+			$implode_params[2]['start'],
+			$implode_params[2]['end'],
+			true
+		);
+
+		if ( T_STRING !== $this->tokens[ $array_fill ]['code']
+			|| 'array_fill' !== strtolower( $this->tokens[ $array_fill ]['content'] )
+		) {
+			return false;
+		}
+
+		$array_fill_params = $this->get_function_call_parameters( $array_fill );
+
+		if ( empty( $array_fill_params ) || count( $array_fill_params ) !== 3 ) {
+			return false;
+		}
+
+		return (bool) preg_match( '`^(["\'])%[dfFs]\1$`', $array_fill_params[3]['raw'] );
+	}
+
+}

--- a/ci/wpcs/WordPress/Sniffs/DB/RestrictedClassesSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/DB/RestrictedClassesSniff.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\DB;
+
+use WordPress\AbstractClassRestrictionsSniff;
+
+/**
+ * Verifies that no database related PHP classes are used.
+ *
+ * "Avoid touching the database directly. If there is a defined function that can get
+ *  the data you need, use it. Database abstraction (using functions instead of queries)
+ *  helps keep your code forward-compatible and, in cases where results are cached in memory,
+ *  it can be many times faster."
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#database-queries
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.10.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class RestrictedClassesSniff extends AbstractClassRestrictionsSniff {
+
+	/**
+	 * Groups of classes to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'    => 'error' | 'warning',
+	 *      'message' => 'Avoid direct calls to the database.',
+	 *      'classes' => array( 'PDO', '\Namespace\Classname' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+
+			'mysql' => array(
+				'type'    => 'error',
+				'message' => 'Accessing the database directly should be avoided. Please use the $wpdb object and associated functions instead. Found: %s.',
+				'classes' => array(
+					'mysqli',
+					'PDO',
+					'PDOStatement',
+				),
+			),
+
+		);
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/DB/RestrictedFunctionsSniff.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\DB;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Verifies that no database related PHP functions are used.
+ *
+ * "Avoid touching the database directly. If there is a defined function that can get
+ *  the data you need, use it. Database abstraction (using functions instead of queries)
+ *  helps keep your code forward-compatible and, in cases where results are cached in memory,
+ *  it can be many times faster."
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#database-queries
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.10.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+
+			'mysql' => array(
+				'type'      => 'error',
+				'message'   => 'Accessing the database directly should be avoided. Please use the $wpdb object and associated functions instead. Found: %s.',
+				'functions' => array(
+					'mysql_*',
+					'mysqli_*',
+					'mysqlnd_ms_*',
+					'mysqlnd_qc_*',
+					'mysqlnd_uh_*',
+					'mysqlnd_memcache_*',
+					'maxdb_*',
+				),
+				'whitelist' => array(
+					'mysql_to_rfc3339' => true,
+				),
+			),
+
+		);
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Files/FileNameSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Files/FileNameSniff.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Files;
+
+use WordPress\Sniff;
+
+/**
+ * Ensures filenames do not contain underscores.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.1.0
+ * @since   0.11.0 - This sniff will now also check for all lowercase file names.
+ *                 - This sniff will now also verify that files containing a class start with `class-`.
+ *                 - This sniff will now also verify that files in `wp-includes` containing
+ *                   template tags end in `-template`. Based on @subpackage file DocBlock tag.
+ *                 - This sniff will now allow for underscores in file names for certain theme
+ *                   specific exceptions if the `$is_theme` property is set to `true`.
+ * @since   0.12.0 Now extends the `WordPress_Sniff` class.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @uses    \WordPress\Sniff::$custom_test_class_whitelist
+ */
+class FileNameSniff extends Sniff {
+
+	/**
+	 * Regex for the theme specific exceptions.
+	 *
+	 * N.B. This regex currently does not allow for mimetype sublevel only file names,
+	 * such as `plain.php`.
+	 *
+	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
+	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#custom-taxonomies
+	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#custom-post-types
+	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#embeds
+	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#attachment
+	 * @link https://developer.wordpress.org/themes/template-files-section/partial-and-miscellaneous-template-files/#content-slug-php
+	 * @link https://wphierarchy.com/
+	 * @link https://en.wikipedia.org/wiki/Media_type#Naming
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string
+	 */
+	const THEME_EXCEPTIONS_REGEX = '`
+		^                    # Anchor to the beginning of the string.
+		(?:
+							 # Template prefixes which can have exceptions.
+			(?:archive|category|content|embed|page|single|tag|taxonomy)
+			-[^\.]+          # These need to be followed by a dash and some chars.
+		|
+			(?:application|audio|example|image|message|model|multipart|text|video) #Top-level mime-types
+			(?:_[^\.]+)?     # Optionally followed by an underscore and a sub-type.
+		)\.(?:php|inc)$      # End in .php (or .inc for the test files) and anchor to the end of the string.
+	`Dx';
+
+	/**
+	 * Whether the codebase being sniffed is a theme.
+	 *
+	 * If true, it will allow for certain typical theme specific exceptions to the filename rules.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var bool
+	 */
+	public $is_theme = false;
+
+	/**
+	 * Whether to apply strict class file name rules.
+	 *
+	 * If true, it demands that classes are prefixed with `class-` and that the rest of the
+	 * file name reflects the class name.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var bool
+	 */
+	public $strict_class_file_names = true;
+
+	/**
+	 * Historical exceptions in WP core to the class name rule.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	private $class_exceptions = array(
+		'class.wp-dependencies.php' => true,
+		'class.wp-scripts.php'      => true,
+		'class.wp-styles.php'       => true,
+	);
+
+	/**
+	 * Unit test version of the historical exceptions in WP core.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	private $unittest_class_exceptions = array(
+		'class.wp-dependencies.inc' => true,
+		'class.wp-scripts.inc'      => true,
+		'class.wp-styles.inc'       => true,
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		if ( defined( '\PHP_CODESNIFFER_IN_TESTS' ) ) {
+			$this->class_exceptions = array_merge( $this->class_exceptions, $this->unittest_class_exceptions );
+		}
+
+		return array( T_OPEN_TAG );
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+
+		// Usage of `strip_quotes` is to ensure `stdin_path` passed by IDEs does not include quotes.
+		$file = $this->strip_quotes( $this->phpcsFile->getFileName() );
+		if ( 'STDIN' === $file ) {
+			return;
+		}
+
+		$fileName = basename( $file );
+		$expected = strtolower( str_replace( '_', '-', $fileName ) );
+
+		/*
+		 * Generic check for lowercase hyphenated file names.
+		 */
+		if ( $fileName !== $expected && ( false === $this->is_theme || 1 !== preg_match( self::THEME_EXCEPTIONS_REGEX, $fileName ) ) ) {
+			$this->phpcsFile->addError(
+				'Filenames should be all lowercase with hyphens as word separators. Expected %s, but found %s.',
+				0,
+				'NotHyphenatedLowercase',
+				array( $expected, $fileName )
+			);
+		}
+		unset( $expected );
+
+		/*
+		 * Check files containing a class for the "class-" prefix and that the rest of
+		 * the file name reflects the class name.
+		 */
+		if ( true === $this->strict_class_file_names ) {
+			$has_class = $this->phpcsFile->findNext( T_CLASS, $stackPtr );
+			if ( false !== $has_class && false === $this->is_test_class( $has_class ) ) {
+				$class_name = $this->phpcsFile->getDeclarationName( $has_class );
+				$expected   = 'class-' . strtolower( str_replace( '_', '-', $class_name ) );
+
+				if ( substr( $fileName, 0, -4 ) !== $expected && ! isset( $this->class_exceptions[ $fileName ] ) ) {
+					$this->phpcsFile->addError(
+						'Class file names should be based on the class name with "class-" prepended. Expected %s, but found %s.',
+						0,
+						'InvalidClassFileName',
+						array(
+							$expected . '.php',
+							$fileName,
+						)
+					);
+				}
+				unset( $expected );
+			}
+		}
+
+		/*
+		 * Check non-class files in "wp-includes" with a "@subpackage Template" tag for a "-template" suffix.
+		 */
+		if ( false !== strpos( $file, DIRECTORY_SEPARATOR . 'wp-includes' . DIRECTORY_SEPARATOR ) ) {
+			$subpackage_tag = $this->phpcsFile->findNext( T_DOC_COMMENT_TAG, $stackPtr, null, false, '@subpackage' );
+			if ( false !== $subpackage_tag ) {
+				$subpackage = $this->phpcsFile->findNext( T_DOC_COMMENT_STRING, $subpackage_tag );
+				if ( false !== $subpackage ) {
+					$fileName_end = substr( $fileName, -13 );
+					$has_class    = $this->phpcsFile->findNext( T_CLASS, $stackPtr );
+
+					if ( ( 'Template' === trim( $this->tokens[ $subpackage ]['content'] )
+						&& $this->tokens[ $subpackage_tag ]['line'] === $this->tokens[ $subpackage ]['line'] )
+						&& ( ( ! defined( '\PHP_CODESNIFFER_IN_TESTS' ) && '-template.php' !== $fileName_end )
+						|| ( defined( '\PHP_CODESNIFFER_IN_TESTS' ) && '-template.inc' !== $fileName_end ) )
+						&& false === $has_class
+					) {
+						$this->phpcsFile->addError(
+							'Files containing template tags should have "-template" appended to the end of the file name. Expected %s, but found %s.',
+							0,
+							'InvalidTemplateTagFileName',
+							array(
+								substr( $fileName, 0, -4 ) . '-template.php',
+								$fileName,
+							)
+						);
+					}
+				}
+			}
+		}
+
+		// Only run this sniff once per file, no need to run it again.
+		return ( $this->phpcsFile->numTokens + 1 );
+
+	} // End process_token().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Functions/DontExtractSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Functions/DontExtractSniff.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Functions;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Restricts the usage of extract().
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#dont-extract
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.10.0 Previously this check was contained within WordPress_Sniffs_VIP_RestrictedFunctionsSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class DontExtractSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+
+			'extract' => array(
+				'type'      => 'error',
+				'message'   => '%s() usage is highly discouraged, due to the complexity and unintended issues it might cause.',
+				'functions' => array(
+					'extract',
+				),
+			),
+
+		);
+	} // End getGroups().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Functions/FunctionCallSignatureNoParamsSniff.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Functions;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Enforces no whitespace between the parenthesis of a function call without parameters.
+ *
+ * @link    https://make.wordpress.org/core/handbook/coding-standards/php/#space-usage
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class FunctionCallSignatureNoParamsSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return Tokens::$functionNameTokens;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int Integer stack pointer to skip the rest of the file.
+	 */
+	public function process_token( $stackPtr ) {
+
+		// Find the next non-empty token.
+		$openParenthesis = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+		if ( T_OPEN_PARENTHESIS !== $this->tokens[ $openParenthesis ]['code'] ) {
+			// Not a function call.
+			return;
+		}
+
+		if ( ! isset( $this->tokens[ $openParenthesis ]['parenthesis_closer'] ) ) {
+			// Not a function call.
+			return;
+		}
+
+		// Find the previous non-empty token.
+		$search   = Tokens::$emptyTokens;
+		$search[] = T_BITWISE_AND;
+		$previous = $this->phpcsFile->findPrevious( $search, ( $stackPtr - 1 ), null, true );
+		if ( T_FUNCTION === $this->tokens[ $previous ]['code'] ) {
+			// It's a function definition, not a function call.
+			return;
+		}
+
+		$closer = $this->tokens[ $openParenthesis ]['parenthesis_closer'];
+
+		if ( ( $closer - 1 ) === $openParenthesis ) {
+			return;
+		}
+
+		$nextNonWhitespace = $this->phpcsFile->findNext( T_WHITESPACE, ( $openParenthesis + 1 ), null, true );
+
+		if ( $nextNonWhitespace !== $closer ) {
+			// Function has params or comment between parenthesis.
+			return;
+		}
+
+		$fix = $this->phpcsFile->addFixableError(
+			'Function calls without parameters should have no spaces between the parenthesis.',
+			( $openParenthesis + 1 ),
+			'WhitespaceFound'
+		);
+		if ( true === $fix ) {
+			// If there is only whitespace between the parenthesis, it will just be the one token.
+			$this->phpcsFile->fixer->replaceToken( ( $openParenthesis + 1 ), '' );
+		}
+
+	} // End process_token().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Functions/FunctionRestrictionsSniff.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Functions;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Restricts usage of some functions.
+ *
+ * @package    WPCS\WordPressCodingStandards
+ *
+ * @since      0.3.0
+ * @since      0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @deprecated 0.10.0 The functionality which used to be contained in this class has been moved to
+ *                    the WordPress_AbstractFunctionRestrictionsSniff class.
+ *                    This class is left here to prevent backward-compatibility breaks for
+ *                    custom sniffs extending the old class and references to this
+ *                    sniff from custom phpcs.xml files.
+ * @see        \WordPress\AbstractFunctionRestrictionsSniff
+ */
+class FunctionRestrictionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array();
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/NamingConventions/PrefixAllGlobalsSniff.php
@@ -1,0 +1,771 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\NamingConventions;
+
+use WordPress\AbstractFunctionParameterSniff;
+use WordPress\PHPCSHelper;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Verify that everything defined in the global namespace is prefixed with a theme/plugin specific prefix.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @uses    \WordPress\Sniff::$custom_test_class_whitelist
+ */
+class PrefixAllGlobalsSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * Error message template.
+	 *
+	 * @var string
+	 */
+	const ERROR_MSG = '%s by a theme/plugin should start with the theme/plugin prefix. Found: "%s".';
+
+	/**
+	 * Target prefixes.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var string[]|string
+	 */
+	public $prefixes = '';
+
+	/**
+	 * Prefix blacklist.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var string[]
+	 */
+	protected $prefix_blacklist = array(
+		'wp' => true,
+		'_'  => true,
+	);
+
+	/**
+	 * Target prefixes after validation.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var string[]
+	 */
+	private $validated_prefixes = array();
+
+	/**
+	 * Cache of previously set prefixes.
+	 *
+	 * Prevents having to do the same prefix validation over and over again.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var string[]
+	 */
+	private $previous_prefixes = array();
+
+	/**
+	 * A list of all PHP superglobals with the exception of $GLOBALS which is handled separately.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var array
+	 */
+	protected $superglobals = array(
+		'_COOKIE'  => true,
+		'_ENV'     => true,
+		'_GET'     => true,
+		'_FILES'   => true,
+		'_POST'    => true,
+		'_REQUEST' => true,
+		'_SERVER'  => true,
+		'_SESSION' => true,
+	);
+
+	/**
+	 * A list of core hooks that are allowed to be called by plugins and themes.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var array
+	 */
+	protected $whitelisted_core_hooks = array(
+		'widget_title'   => true,
+		'add_meta_boxes' => true,
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		$targets = array(
+			T_FUNCTION  => T_FUNCTION,
+			T_CLASS     => T_CLASS,
+			T_INTERFACE => T_INTERFACE,
+			T_TRAIT     => T_TRAIT,
+			T_CONST     => T_CONST,
+			T_VARIABLE  => T_VARIABLE,
+			T_DOLLAR    => T_DOLLAR, // Variable variables.
+		);
+
+		// Add function call target for hook names and constants defined using define().
+		$parent = parent::register();
+		if ( ! empty( $parent ) ) {
+			$targets[] = T_STRING;
+		}
+
+		return $targets;
+	}
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		$this->target_functions           = $this->hookInvokeFunctions;
+		$this->target_functions['define'] = true;
+
+		return parent::getGroups();
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+		/*
+		 * Allow for whitelisting.
+		 *
+		 * Generally speaking a theme/plugin should *only* execute their own hooks, but there may be a
+		 * good reason to execute a core hook.
+		 *
+		 * Similarly, newer PHP or WP functions or constants may need to be emulated for continued support
+		 * of older PHP and WP versions.
+		 */
+		if ( $this->has_whitelist_comment( 'prefix', $stackPtr ) ) {
+			return;
+		}
+
+		// Allow overruling the prefixes set in a ruleset via the command line.
+		$cl_prefixes = trim( PHPCSHelper::get_config_data( 'prefixes' ) );
+		if ( ! empty( $cl_prefixes ) ) {
+			$this->prefixes = $cl_prefixes;
+		}
+
+		$this->prefixes = $this->merge_custom_array( $this->prefixes, array(), false );
+		if ( empty( $this->prefixes ) ) {
+			// No prefixes passed, nothing to do.
+			return;
+		}
+
+		$this->validate_prefixes();
+		if ( empty( $this->validated_prefixes ) ) {
+			// No _valid_ prefixes passed, nothing to do.
+			return;
+		}
+
+		if ( T_STRING === $this->tokens[ $stackPtr ]['code'] ) {
+			// Disallow excluding function groups for this sniff.
+			$this->exclude = '';
+
+			return parent::process_token( $stackPtr );
+
+		} elseif ( T_DOLLAR === $this->tokens[ $stackPtr ]['code'] ) {
+
+			return $this->process_variable_variable( $stackPtr );
+
+		} elseif ( T_VARIABLE === $this->tokens[ $stackPtr ]['code'] ) {
+
+			return $this->process_variable_assignment( $stackPtr );
+
+		} else {
+
+			// Namespaced methods, classes and constants do not need to be prefixed.
+			$namespace = $this->determine_namespace( $stackPtr );
+			if ( '' !== $namespace && '\\' !== $namespace ) {
+				return;
+			}
+
+			$item_name  = '';
+			$error_text = 'Unknown syntax used by';
+			$error_code = 'NonPrefixedSyntaxFound';
+
+			switch ( $this->tokens[ $stackPtr ]['type'] ) {
+				case 'T_FUNCTION':
+					// Methods in a class do not need to be prefixed.
+					if ( $this->phpcsFile->hasCondition( $stackPtr, array( T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT ) ) === true ) {
+						return;
+					}
+
+					$item_name = $this->phpcsFile->getDeclarationName( $stackPtr );
+					if ( function_exists( '\\' . $item_name ) ) {
+						// Backfill for PHP native function.
+						return;
+					}
+
+					$error_text = 'Functions declared';
+					$error_code = 'NonPrefixedFunctionFound';
+					break;
+
+				case 'T_CLASS':
+				case 'T_INTERFACE':
+				case 'T_TRAIT':
+					// Ignore test classes.
+					if ( true === $this->is_test_class( $stackPtr ) ) {
+						if ( $this->tokens[ $stackPtr ]['scope_condition'] === $stackPtr && isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
+							// Skip forward to end of test class.
+							return $this->tokens[ $stackPtr ]['scope_closer'];
+						}
+						return;
+					}
+
+					$item_name  = $this->phpcsFile->getDeclarationName( $stackPtr );
+					$error_text = 'Classes declared';
+					$error_code = 'NonPrefixedClassFound';
+
+					switch ( $this->tokens[ $stackPtr ]['type'] ) {
+						case 'T_CLASS':
+							if ( class_exists( '\\' . $item_name ) ) {
+								// Backfill for PHP native class.
+								return;
+							}
+							break;
+
+						case 'T_INTERFACE':
+							if ( interface_exists( '\\' . $item_name ) ) {
+								// Backfill for PHP native interface.
+								return;
+							}
+
+							$error_text = 'Interfaces declared';
+							$error_code = 'NonPrefixedInterfaceFound';
+							break;
+
+						case 'T_TRAIT':
+							if ( function_exists( '\trait_exists' ) && trait_exists( '\\' . $item_name ) ) {
+								// Backfill for PHP native trait.
+								return;
+							}
+
+							$error_text = 'Traits declared';
+							$error_code = 'NonPrefixedTraitFound';
+							break;
+
+						default:
+							// Left empty on purpose.
+							break;
+					}
+
+					break;
+
+				case 'T_CONST':
+					// Constants in a class do not need to be prefixed.
+					if ( true === $this->is_class_constant( $stackPtr ) ) {
+						return;
+					}
+
+					$constant_name_ptr = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+					if ( false === $constant_name_ptr ) {
+						// Live coding.
+						return;
+					}
+
+					$item_name = $this->tokens[ $constant_name_ptr ]['content'];
+					if ( defined( '\\' . $item_name ) ) {
+						// Backfill for PHP native constant.
+						return;
+					}
+
+					$error_text = 'Global constants defined';
+					$error_code = 'NonPrefixedConstantFound';
+					break;
+
+				default:
+					// Left empty on purpose.
+					break;
+
+			}
+
+			if ( empty( $item_name ) || $this->is_prefixed( $item_name ) === true ) {
+				return;
+			}
+
+			$this->phpcsFile->addError(
+				self::ERROR_MSG,
+				$stackPtr,
+				$error_code,
+				array(
+					$error_text,
+					$item_name,
+				)
+			);
+		}
+
+	} // End process_token().
+
+	/**
+	 * Handle variable variable defined in the global namespace.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	protected function process_variable_variable( $stackPtr ) {
+		static $indicators = array(
+			T_OPEN_CURLY_BRACKET => true,
+			T_VARIABLE           => true,
+		);
+
+		// Is this a variable variable ?
+		// Not concerned with nested ones as those will be recognized on their own token.
+		$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+		if ( false === $next_non_empty || ! isset( $indicators[ $this->tokens[ $next_non_empty ]['code'] ] ) ) {
+			return;
+		}
+
+		if ( T_OPEN_CURLY_BRACKET === $this->tokens[ $next_non_empty ]['code']
+			&& isset( $this->tokens[ $next_non_empty ]['bracket_closer'] )
+		) {
+			// Skip over the variable part.
+			$next_non_empty = $this->tokens[ $next_non_empty ]['bracket_closer'];
+		}
+
+		$maybe_assignment = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true, null, true );
+
+		while ( false !== $maybe_assignment
+			&& T_OPEN_SQUARE_BRACKET === $this->tokens[ $maybe_assignment ]['code']
+			&& isset( $this->tokens[ $maybe_assignment ]['bracket_closer'] )
+		) {
+			$maybe_assignment = $this->phpcsFile->findNext(
+				Tokens::$emptyTokens,
+				( $this->tokens[ $maybe_assignment ]['bracket_closer'] + 1 ),
+				null,
+				true,
+				null,
+				true
+			);
+		}
+
+		if ( false === $maybe_assignment ) {
+			return;
+		}
+
+		if ( ! isset( Tokens::$assignmentTokens[ $this->tokens[ $maybe_assignment ]['code'] ] ) ) {
+			// Not an assignment.
+			return;
+		}
+
+		$error = self::ERROR_MSG;
+
+		/*
+		 * Local variable variables in a function do not need to be prefixed.
+		 * But a variable variable could evaluate to the name of an imported global
+		 * variable.
+		 * Not concerned with imported variable variables (global.. ) as that has been
+		 * forbidden since PHP 7.0. Presuming cross-version code and if not, that
+		 * is for the PHPCompatibility standard to detect.
+		 */
+		if ( $this->phpcsFile->hasCondition( $stackPtr, array( T_FUNCTION, T_CLOSURE ) ) === true ) {
+			$condition = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+			if ( false === $condition ) {
+				$condition = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+			}
+
+			$has_global = $this->phpcsFile->findPrevious( T_GLOBAL, ( $stackPtr - 1 ), $this->tokens[ $condition ]['scope_opener'] );
+			if ( false === $has_global ) {
+				// No variable import happening.
+				return;
+			}
+
+			$error = 'Variable variable which could potentially override an imported global variable detected. ' . $error;
+		}
+
+		$variable_name = $this->phpcsFile->getTokensAsString( $stackPtr, ( ( $next_non_empty - $stackPtr ) + 1 ) );
+
+		// Still here ? In that case, the variable name should be prefixed.
+		$this->phpcsFile->addWarning(
+			$error,
+			$stackPtr,
+			'NonPrefixedVariableFound',
+			array(
+				'Variables defined',
+				$variable_name,
+			)
+		);
+
+		// Skip over the variable part of the variable.
+		return ( $next_non_empty + 1 );
+	}
+
+	/**
+	 * Check that defined global variables are prefixed.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	protected function process_variable_assignment( $stackPtr ) {
+
+		// We're only concerned with variables which are being defined.
+		// `is_assigment()` will not recognize property assignments, which is good in this case.
+		if ( false === $this->is_assignment( $stackPtr ) ) {
+			return;
+		}
+
+		$is_error      = true;
+		$variable_name = substr( $this->tokens[ $stackPtr ]['content'], 1 ); // Strip the dollar sign.
+
+		// Bow out early if we know for certain no prefix is needed.
+		if ( $this->variable_prefixed_or_whitelisted( $variable_name ) === true ) {
+			return;
+		}
+
+		if ( 'GLOBALS' === $variable_name ) {
+			$array_open = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+			if ( false === $array_open || T_OPEN_SQUARE_BRACKET !== $this->tokens[ $array_open ]['code'] ) {
+				// Live coding or something very silly.
+				return;
+			}
+
+			$array_key = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $array_open + 1 ), null, true, null, true );
+			if ( false === $array_key ) {
+				// No key found, nothing to do.
+				return;
+			}
+
+			$stackPtr      = $array_key;
+			$variable_name = $this->strip_quotes( $this->tokens[ $array_key ]['content'] );
+
+			// Check whether a prefix is needed.
+			if ( isset( Tokens::$stringTokens[ $this->tokens[ $array_key ]['code'] ] )
+				&& $this->variable_prefixed_or_whitelisted( $variable_name ) === true
+			) {
+				return;
+			}
+
+			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $array_key ]['code'] ) {
+				// If the array key is a double quoted string, try again with only
+				// the part before the first variable (if any).
+				$exploded = explode( '$', $variable_name );
+				$first    = rtrim( $exploded[0], '{' );
+				if ( '' !== $first ) {
+					if ( $this->variable_prefixed_or_whitelisted( $first ) === true ) {
+						return;
+					}
+				} else {
+					// If the first part was dynamic, throw a warning.
+					$is_error = false;
+				}
+			} elseif ( ! isset( Tokens::$stringTokens[ $this->tokens[ $array_key ]['code'] ] ) ) {
+				// Dynamic array key, throw a warning.
+				$is_error = false;
+			}
+		} else {
+			// Function parameters do not need to be prefixed.
+			if ( isset( $this->tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+				foreach ( $this->tokens[ $stackPtr ]['nested_parenthesis'] as $opener => $closer ) {
+					if ( isset( $this->tokens[ $opener ]['parenthesis_owner'] ) && T_FUNCTION === $this->tokens[ $this->tokens[ $opener ]['parenthesis_owner'] ]['code'] ) {
+						return;
+					}
+				}
+				unset( $opener, $closer );
+			}
+
+			// Properties in a class do not need to be prefixed.
+			if ( true === $this->is_class_property( $stackPtr ) ) {
+				return;
+			}
+
+			// Local variables in a function do not need to be prefixed unless they are being imported.
+			if ( $this->phpcsFile->hasCondition( $stackPtr, array( T_FUNCTION, T_CLOSURE ) ) === true ) {
+				$condition = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+				if ( false === $condition ) {
+					$condition = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+				}
+
+				$has_global = $this->phpcsFile->findPrevious( T_GLOBAL, ( $stackPtr - 1 ), $this->tokens[ $condition ]['scope_opener'] );
+				if ( false === $has_global ) {
+					// No variable import happening.
+					return;
+				}
+
+				// Ok, this may be an imported global variable.
+				$end_of_statement = $this->phpcsFile->findNext( T_SEMICOLON, ( $has_global + 1 ) );
+				if ( false === $end_of_statement ) {
+					// No semi-colon - live coding.
+					return;
+				}
+
+				for ( $ptr = ( $has_global + 1 ); $ptr <= $end_of_statement; $ptr++ ) {
+					// Move the stack pointer to the next variable.
+					$ptr = $this->phpcsFile->findNext( T_VARIABLE, $ptr, $end_of_statement, false, null, true );
+
+					if ( false === $ptr ) {
+						// Reached the end of the global statement without finding the variable,
+						// so this must be a local variable.
+						return;
+					}
+
+					if ( substr( $this->tokens[ $ptr ]['content'], 1 ) === $variable_name ) {
+						break;
+					}
+				}
+
+				unset( $condition, $has_global, $end_of_statement, $ptr, $imported );
+
+			}
+		}
+
+		// Still here ? In that case, the variable name should be prefixed.
+		$this->addMessage(
+			self::ERROR_MSG,
+			$stackPtr,
+			$is_error,
+			'NonPrefixedVariableFound',
+			array(
+				'Variables defined',
+				'$' . $variable_name,
+			)
+		);
+
+	} // End process_variable_assignment().
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+
+		// Ignore deprecated hook names.
+		if ( strpos( $matched_content, '_deprecated' ) > 0 ) {
+			return;
+		}
+
+		// No matter whether it is a constant definition or a hook call, both use the first parameter.
+		if ( ! isset( $parameters[1] ) ) {
+			return;
+		}
+
+		$is_error    = true;
+		$raw_content = $this->strip_quotes( $parameters[1]['raw'] );
+
+		if (
+			'define' !== $matched_content
+			&& isset( $this->whitelisted_core_hooks[ $raw_content ] )
+		) {
+			return;
+		}
+
+		if ( $this->is_prefixed( $raw_content ) === true ) {
+			return;
+		} else {
+			// This may be a dynamic hook/constant name.
+			$first_non_empty = $this->phpcsFile->findNext(
+				Tokens::$emptyTokens,
+				$parameters[1]['start'],
+				( $parameters[1]['end'] + 1 ),
+				true
+			);
+
+			if ( false === $first_non_empty ) {
+				return;
+			}
+
+			$first_non_empty_content = $this->strip_quotes( $this->tokens[ $first_non_empty ]['content'] );
+
+			// Try again with just the first token if it's a text string.
+			if ( isset( Tokens::$stringTokens[ $this->tokens[ $first_non_empty ]['code'] ] )
+				&& $this->is_prefixed( $first_non_empty_content ) === true
+			) {
+				return;
+			}
+
+			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $first_non_empty ]['code'] ) {
+				// If the first part of the parameter is a double quoted string, try again with only
+				// the part before the first variable (if any).
+				$exploded = explode( '$', $first_non_empty_content );
+				$first    = rtrim( $exploded[0], '{' );
+				if ( '' !== $first ) {
+					if ( $this->is_prefixed( $first ) === true ) {
+						return;
+					}
+				} else {
+					// Start of hook/constant name is dynamic, throw a warning.
+					$is_error = false;
+				}
+			} elseif ( ! isset( Tokens::$stringTokens[ $this->tokens[ $first_non_empty ]['code'] ] ) ) {
+				// Dynamic hook/constant name, throw a warning.
+				$is_error = false;
+			}
+		}
+
+		if ( 'define' === $matched_content ) {
+			if ( defined( '\\' . $raw_content ) ) {
+				// Backfill for PHP native constant.
+				return;
+			}
+
+			if ( strpos( $raw_content, '\\' ) !== false ) {
+				// Namespaced or unreachable constant.
+				return;
+			}
+
+			$data       = array( 'Global constants defined' );
+			$error_code = 'NonPrefixedConstantFound';
+		} else {
+			$data       = array( 'Hook names invoked' );
+			$error_code = 'NonPrefixedHooknameFound';
+		}
+
+		$data[] = $raw_content;
+
+		$this->addMessage( self::ERROR_MSG, $parameters[1]['start'], $is_error, $error_code, $data );
+
+	} // End process_parameters().
+
+	/**
+	 * Check if a function/class/constant/variable name is prefixed with one of the expected prefixes.
+	 *
+	 * @since 0.12.0
+	 * @since 0.14.0 Allows for other non-word characters as well as underscores to better support hook names.
+	 *
+	 * @param string $name Name to check for a prefix.
+	 *
+	 * @return bool True when the name is the prefix or starts with the prefix + a separator.
+	 *              False otherwise.
+	 */
+	private function is_prefixed( $name ) {
+
+		foreach ( $this->validated_prefixes as $prefix ) {
+			if ( strtolower( $name ) === $prefix ) {
+				// Ok, prefix *is* the hook/constant name.
+				return true;
+
+			} else {
+				$prefix_found = stripos( $name, $prefix . '_' );
+
+				if ( 0 === $prefix_found ) {
+					// Ok, prefix found at start of hook/constant name.
+					return true;
+				}
+
+				if ( preg_match( '`^' . preg_quote( $prefix, '`' ) . '\W`i', $name ) === 1 ) {
+					// Ok, prefix with other non-word character found at start of hook/constant name.
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if a variable name might need a prefix.
+	 *
+	 * Prefix is not needed for:
+	 * - superglobals,
+	 * - WP native globals,
+	 * - variables which are already prefixed.
+	 *
+	 * @param string $name Variable name without the dollar sign.
+	 * @return bool True if the variable name is whitelisted or already prefixed.
+	 *              False otherwise.
+	 */
+	private function variable_prefixed_or_whitelisted( $name ) {
+		// Ignore superglobals and WP global variables.
+		if ( isset( $this->superglobals[ $name ] ) || isset( $this->wp_globals[ $name ] ) ) {
+			return true;
+		}
+
+		return $this->is_prefixed( $name );
+	}
+
+	/**
+	 * Validate an array of prefixes as passed through a custom property or via the command line.
+	 *
+	 * Checks that the prefix:
+	 * - is not one of the blacklisted ones.
+	 * - complies with the PHP rules for valid function, class, variable, constant names.
+	 *
+	 * @since 0.12.0
+	 */
+	private function validate_prefixes() {
+		if ( $this->previous_prefixes === $this->prefixes ) {
+			return;
+		}
+
+		// Set the cache *before* validation so as to not break the above compare.
+		$this->previous_prefixes = $this->prefixes;
+
+		// Validate the passed prefix(es).
+		foreach ( $this->prefixes as $key => $prefix ) {
+			$prefixLC = strtolower( $prefix );
+
+			if ( isset( $this->prefix_blacklist[ $prefixLC ] ) ) {
+				$this->phpcsFile->addError(
+					'The "%s" prefix is not allowed.',
+					0,
+					'ForbiddenPrefixPassed',
+					array( $prefix )
+				);
+				unset( $this->prefixes[ $key ] );
+				continue;
+			}
+
+			// Validate the prefix against characters allowed for function, class, constant names etc.
+			if ( preg_match( '`^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$`', $prefix ) !== 1 ) {
+				$this->phpcsFile->addError(
+					'The "%s" prefix is not a valid function/class/variable/constant prefix in PHP.',
+					0,
+					'InvalidPrefixPassed',
+					array( $prefix )
+				);
+				unset( $this->prefixes[ $key ] );
+			}
+
+			// Lowercase the prefix to allow for direct compare.
+			$this->prefixes[ $key ] = $prefixLC;
+		}
+
+		// Set the validated prefixes cache.
+		$this->validated_prefixes = $this->prefixes;
+
+	} // End validate_prefixes().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\NamingConventions;
+
+use PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff as PHPCS_PEAR_ValidFunctionNameSniff;
+use PHP_CodeSniffer_File as File;
+
+/**
+ * Enforces WordPress function name and method name format, based upon Squiz code.
+ *
+ * @link    https://make.wordpress.org/core/handbook/coding-standards/php/#naming-conventions
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.1.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * Last synced with parent class July 2016 up to commit 4fea2e651109e41066a81e22e004d851fb1287f6.
+ * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/PEAR/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+ *
+ * {@internal While this class extends the PEAR parent, it does not actually use the checks
+ * contained in the parent. It only uses the properties and the token registration from the parent.}}
+ */
+class ValidFunctionNameSniff extends PHPCS_PEAR_ValidFunctionNameSniff {
+
+	/**
+	 * Additional double underscore prefixed methods specific to certain PHP native extensions.
+	 *
+	 * Currently only handles the SoapClient Extension.
+	 *
+	 * @link http://php.net/manual/en/class.soapclient.php
+	 *
+	 * @var array <string method name> => <string class name>
+	 */
+	private $methodsDoubleUnderscore = array(
+		'doRequest'              => 'SoapClient',
+		'getFunctions'           => 'SoapClient',
+		'getLastRequest'         => 'SoapClient',
+		'getLastRequestHeaders'  => 'SoapClient',
+		'getLastResponse'        => 'SoapClient',
+		'getLastResponseHeaders' => 'SoapClient',
+		'getTypes'               => 'SoapClient',
+		'setCookie'              => 'SoapClient',
+		'setLocation'            => 'SoapClient',
+		'setSoapHeaders'         => 'SoapClient',
+		'soapCall'               => 'SoapClient',
+	);
+
+	/**
+	 * Processes the tokens outside the scope.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being processed.
+	 * @param int                         $stackPtr  The position where this token was
+	 *                                               found.
+	 *
+	 * @return void
+	 */
+	protected function processTokenOutsideScope( File $phpcsFile, $stackPtr ) {
+		$functionName = $phpcsFile->getDeclarationName( $stackPtr );
+
+		if ( ! isset( $functionName ) ) {
+			// Ignore closures.
+			return;
+		}
+
+		if ( '' === ltrim( $functionName, '_' ) ) {
+			// Ignore special functions.
+			return;
+		}
+
+		// Is this a magic function ? I.e., it is prefixed with "__" ?
+		// Outside class scope this basically just means __autoload().
+		if ( 0 === strpos( $functionName, '__' ) ) {
+			$magicPart = strtolower( substr( $functionName, 2 ) );
+			if ( ! isset( $this->magicFunctions[ $magicPart ] ) ) {
+				$error     = 'Function name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
+				$errorData = array( $functionName );
+				$phpcsFile->addError( $error, $stackPtr, 'FunctionDoubleUnderscore', $errorData );
+			}
+
+			return;
+		}
+
+		if ( strtolower( $functionName ) !== $functionName ) {
+			$error     = 'Function name "%s" is not in snake case format, try "%s"';
+			$errorData = array(
+				$functionName,
+				$this->get_name_suggestion( $functionName ),
+			);
+			$phpcsFile->addError( $error, $stackPtr, 'FunctionNameInvalid', $errorData );
+		}
+
+	} // End processTokenOutsideScope().
+
+	/**
+	 * Processes the tokens within the scope.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being processed.
+	 * @param int                         $stackPtr  The position where this token was
+	 *                                               found.
+	 * @param int                         $currScope The position of the current scope.
+	 *
+	 * @return void
+	 */
+	protected function processTokenWithinScope( File $phpcsFile, $stackPtr, $currScope ) {
+		$methodName = $phpcsFile->getDeclarationName( $stackPtr );
+
+		if ( ! isset( $methodName ) ) {
+			// Ignore closures.
+			return;
+		}
+
+		$className = $phpcsFile->getDeclarationName( $currScope );
+
+		// Ignore special functions.
+		if ( '' === ltrim( $methodName, '_' ) ) {
+			return;
+		}
+
+		// PHP4 constructors are allowed to break our rules.
+		if ( $methodName === $className ) {
+			return;
+		}
+
+		// PHP4 destructors are allowed to break our rules.
+		if ( '_' . $className === $methodName ) {
+			return;
+		}
+
+		$extended   = $phpcsFile->findExtendedClassName( $currScope );
+		$interfaces = $phpcsFile->findImplementedInterfaceNames( $currScope );
+
+		// If this is a child class or interface implementation, it may have to use camelCase or double underscores.
+		if ( ! empty( $extended ) || ! empty( $interfaces ) ) {
+			return;
+		}
+
+		// Is this a magic method ? I.e. is it prefixed with "__" ?
+		if ( 0 === strpos( $methodName, '__' ) ) {
+			$magicPart = strtolower( substr( $methodName, 2 ) );
+			if ( ! isset( $this->magicMethods[ $magicPart ] ) && ! isset( $this->methodsDoubleUnderscore[ $magicPart ] ) ) {
+				$error     = 'Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore';
+				$errorData = array( $className . '::' . $methodName );
+				$phpcsFile->addError( $error, $stackPtr, 'MethodDoubleUnderscore', $errorData );
+			}
+
+			return;
+		}
+
+		// Check for all lowercase.
+		if ( strtolower( $methodName ) !== $methodName ) {
+			$error     = 'Method name "%s" in class %s is not in snake case format, try "%s"';
+			$errorData = array(
+				$methodName,
+				$className,
+				$this->get_name_suggestion( $methodName ),
+			);
+			$phpcsFile->addError( $error, $stackPtr, 'MethodNameInvalid', $errorData );
+		}
+
+	} // End processTokenWithinScope().
+
+	/**
+	 * Transform the existing function/method name to one which complies with the naming conventions.
+	 *
+	 * @param string $name The function/method name.
+	 * @return string
+	 */
+	protected function get_name_suggestion( $name ) {
+		$suggested = preg_replace( '/([A-Z])/', '_$1', $name );
+		$suggested = strtolower( $suggested );
+		$suggested = str_replace( '__', '_', $suggested );
+		$suggested = trim( $suggested, '_' );
+		return $suggested;
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/NamingConventions/ValidHookNameSniff.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\NamingConventions;
+
+use WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * Use lowercase letters in action and filter names. Separate words via underscores.
+ *
+ * This sniff is only testing the hook invoke functions as when using 'add_action'/'add_filter'
+ * you can't influence the hook name.
+ *
+ * Hook names invoked with `do_action_deprecated()` and `apply_filters_deprecated()` are ignored.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.10.0
+ * @since   0.11.0 Extends the WordPress_AbstractFunctionParameterSniff class.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class ValidHookNameSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * Additional word separators.
+	 *
+	 * This public variable allows providing additional word separators which
+	 * will be allowed in hook names via a property in the phpcs.xml config file.
+	 *
+	 * Example usage:
+	 * <rule ref="WordPress.NamingConventions.ValidHookName">
+	 *   <properties>
+	 *     <property name="additionalWordDelimiters" value="-"/>
+	 *   </properties>
+	 * </rule>
+	 *
+	 * Provide several extra delimiters as one string:
+	 * <rule ref="WordPress.NamingConventions.ValidHookName">
+	 *   <properties>
+	 *     <property name="additionalWordDelimiters" value="-/."/>
+	 *   </properties>
+	 * </rule>
+	 *
+	 * @var string
+	 */
+	public $additionalWordDelimiters = '';
+
+	/**
+	 * Regular expression to test for correct punctuation of a hook name.
+	 *
+	 * The placeholder will be replaced by potentially provided additional
+	 * word delimiters in the `prepare_regex()` method.
+	 *
+	 * @var string
+	 */
+	protected $punctuation_regex = '`[^\w%s]`';
+
+	/**
+	 * Groups of function to restrict.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		$this->target_functions = $this->hookInvokeFunctions;
+		return parent::getGroups();
+	}
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		// Ignore deprecated hook names.
+		if ( strpos( $matched_content, '_deprecated' ) > 0 ) {
+			return;
+		}
+
+		if ( ! isset( $parameters[1] ) ) {
+			return;
+		}
+
+		$regex = $this->prepare_regex();
+
+		$case_errors = 0;
+		$underscores = 0;
+		$content     = array();
+		$expected    = array();
+
+		for ( $i = $parameters[1]['start']; $i <= $parameters[1]['end']; $i++ ) {
+			$content[ $i ]  = $this->tokens[ $i ]['content'];
+			$expected[ $i ] = $this->tokens[ $i ]['content'];
+
+			if ( in_array( $this->tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+				$string = $this->strip_quotes( $this->tokens[ $i ]['content'] );
+
+				/*
+				 * Here be dragons - a double quoted string can contain extrapolated variables
+				 * which don't have to comply with these rules.
+				 */
+				if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $i ]['code'] ) {
+					$transform       = $this->transform_complex_string( $string, $regex );
+					$case_transform  = $this->transform_complex_string( $string, $regex, 'case' );
+					$punct_transform = $this->transform_complex_string( $string, $regex, 'punctuation' );
+				} else {
+					$transform       = $this->transform( $string, $regex );
+					$case_transform  = $this->transform( $string, $regex, 'case' );
+					$punct_transform = $this->transform( $string, $regex, 'punctuation' );
+				}
+
+				if ( $string === $transform ) {
+					continue;
+				}
+
+				if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $i ]['code'] ) {
+					$expected[ $i ] = '"' . $transform . '"';
+				} else {
+					$expected[ $i ] = '\'' . $transform . '\'';
+				}
+
+				if ( $string !== $case_transform ) {
+					$case_errors++;
+				}
+				if ( $string !== $punct_transform ) {
+					$underscores++;
+				}
+			}
+		}
+
+		$data = array(
+			implode( '', $expected ),
+			implode( '', $content ),
+		);
+
+		if ( $case_errors > 0 ) {
+			$error = 'Hook names should be lowercase. Expected: %s, but found: %s.';
+			$this->phpcsFile->addError( $error, $stackPtr, 'NotLowercase', $data );
+		}
+		if ( $underscores > 0 ) {
+			$error = 'Words in hook names should be separated using underscores. Expected: %s, but found: %s.';
+			$this->phpcsFile->addWarning( $error, $stackPtr, 'UseUnderscores', $data );
+		}
+
+	} // End process_parameters().
+
+	/**
+	 * Prepare the punctuation regular expression.
+	 *
+	 * Merges the existing regular expression with potentially provided extra word delimiters to allow.
+	 * This is done 'late' and for each found token as otherwise inline `@codingStandardsChangeSetting`
+	 * directives would be ignored.
+	 *
+	 * @return string
+	 */
+	protected function prepare_regex() {
+		$extra = '';
+		if ( '' !== $this->additionalWordDelimiters && is_string( $this->additionalWordDelimiters ) ) {
+			$extra = preg_quote( $this->additionalWordDelimiters, '`' );
+		}
+
+		return sprintf( $this->punctuation_regex, $extra );
+
+	} // End prepare_regex().
+
+	/**
+	 * Transform an arbitrary string to lowercase and replace punctuation and spaces with underscores.
+	 *
+	 * @param string $string         The target string.
+	 * @param string $regex          The punctuation regular expression to use.
+	 * @param string $transform_type Whether to a partial or complete transform.
+	 *                               Valid values are: 'full', 'case', 'punctuation'.
+	 * @return string
+	 */
+	protected function transform( $string, $regex, $transform_type = 'full' ) {
+
+		switch ( $transform_type ) {
+			case 'case':
+				return strtolower( $string );
+
+			case 'punctuation':
+				return preg_replace( $regex, '_', $string );
+
+			case 'full':
+			default:
+				return preg_replace( $regex, '_', strtolower( $string ) );
+		}
+	} // End transform().
+
+	/**
+	 * Transform a complex string which may contain variable extrapolation.
+	 *
+	 * @param string $string         The target string.
+	 * @param string $regex          The punctuation regular expression to use.
+	 * @param string $transform_type Whether to a partial or complete transform.
+	 *                               Valid values are: 'full', 'case', 'punctuation'.
+	 * @return string
+	 */
+	protected function transform_complex_string( $string, $regex, $transform_type = 'full' ) {
+		$output = preg_split( '`([\{\}\$\[\] ])`', $string, -1, PREG_SPLIT_DELIM_CAPTURE );
+
+		$is_variable = false;
+		$has_braces  = false;
+		$braces      = 0;
+
+		foreach ( $output as $i => $part ) {
+			if ( in_array( $part, array( '$', '{' ), true ) ) {
+				$is_variable = true;
+				if ( '{' === $part ) {
+					$has_braces = true;
+					$braces++;
+				}
+				continue;
+			}
+
+			if ( true === $is_variable ) {
+				if ( '[' === $part ) {
+					$has_braces = true;
+					$braces++;
+				}
+				if ( in_array( $part, array( '}', ']' ), true ) ) {
+					$braces--;
+				}
+				if ( false === $has_braces && ' ' === $part ) {
+					$is_variable  = false;
+					$output[ $i ] = $this->transform( $part, $regex, $transform_type );
+				}
+
+				if ( ( true === $has_braces && 0 === $braces ) && false === in_array( $output[ ( $i + 1 ) ], array( '{', '[' ), true ) ) {
+					$has_braces  = false;
+					$is_variable = false;
+				}
+				continue;
+			}
+
+			$output[ $i ] = $this->transform( $part, $regex, $transform_type );
+		}
+
+		return implode( '', $output );
+	} // End transform_complex_string().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -1,0 +1,336 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer_Standards_AbstractVariableSniff as PHPCS_AbstractVariableSniff;
+use PHP_CodeSniffer_File as File;
+use WordPress\Sniff;
+
+/**
+ * Checks the naming of variables and member variables.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#naming-conventions
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.9.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * Last synced with base class July 2014 at commit ed257ca0e56ad86cd2a4d6fa38ce0b95141c824f.
+ * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/NamingConventions/ValidVariableNameSniff.php
+ */
+class ValidVariableNameSniff extends PHPCS_AbstractVariableSniff {
+
+	/**
+	 * PHP Reserved Vars.
+	 *
+	 * @since 0.9.0
+	 * @since 0.11.0 Changed visibility from public to protected.
+	 *
+	 * @var array
+	 */
+	protected $php_reserved_vars = array(
+		'_SERVER'              => true,
+		'_GET'                 => true,
+		'_POST'                => true,
+		'_REQUEST'             => true,
+		'_SESSION'             => true,
+		'_ENV'                 => true,
+		'_COOKIE'              => true,
+		'_FILES'               => true,
+		'GLOBALS'              => true,
+		'http_response_header' => true,
+		'HTTP_RAW_POST_DATA'   => true,
+		'php_errormsg'         => true,
+	);
+
+	/**
+	 * Mixed-case variables used by WordPress.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	protected $wordpress_mixed_case_vars = array(
+		'EZSQL_ERROR'       => true,
+		'GETID3_ERRORARRAY' => true,
+		'is_IE'             => true,
+		'is_IIS'            => true,
+		'is_macIE'          => true,
+		'is_NS4'            => true,
+		'is_winIE'          => true,
+		'PHP_SELF'          => true,
+		'post_ID'           => true,
+		'user_ID'           => true,
+	);
+
+	/**
+	 * List of member variables that can have mixed case.
+	 *
+	 * @since 0.9.0
+	 * @since 0.11.0 Changed from public to protected.
+	 *
+	 * @var array
+	 */
+	protected $whitelisted_mixed_case_member_var_names = array(
+		'ID'                => true,
+		'comment_ID'        => true,
+		'comment_post_ID'   => true,
+		'post_ID'           => true,
+		'comment_author_IP' => true,
+		'cat_ID'            => true,
+	);
+
+	/**
+	 * Custom list of properties which can have mixed case.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customPropertiesWhitelist = array();
+
+	/**
+	 * Cache of previously added custom functions.
+	 *
+	 * Prevents having to do the same merges over and over again.
+	 *
+	 * @since 0.10.0
+	 * @since 0.11.0 - Name changed from $addedCustomVariables.
+	 *               - Changed the format from simple bool to array.
+	 *
+	 * @var array
+	 */
+	protected $addedCustomProperties = array(
+		'properties' => null,
+		'variables'  => null,
+	);
+
+	/**
+	 * Custom list of properties which can have mixed case.
+	 *
+	 * @since 0.10.0
+	 * @deprecated 0.11.0 Use $customPropertiesWhitelist instead.
+	 *
+	 * @var string|string[]
+	 */
+	public $customVariablesWhitelist = array();
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
+	 * @param int                         $stack_ptr  The position of the current token in the
+	 *                                                stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	protected function processVariable( File $phpcs_file, $stack_ptr ) {
+
+		$tokens   = $phpcs_file->getTokens();
+		$var_name = ltrim( $tokens[ $stack_ptr ]['content'], '$' );
+
+		// If it's a php reserved var, then its ok.
+		if ( isset( $this->php_reserved_vars[ $var_name ] ) ) {
+			return;
+		}
+
+		// Merge any custom variables with the defaults.
+		$this->mergeWhiteList( $phpcs_file );
+
+		// Likewise if it is a mixed-case var used by WordPress core.
+		if ( isset( $this->wordpress_mixed_case_vars[ $var_name ] ) ) {
+			return;
+		}
+
+		$obj_operator = $phpcs_file->findNext( array( T_WHITESPACE ), ( $stack_ptr + 1 ), null, true );
+		if ( T_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code'] ) {
+			// Check to see if we are using a variable from an object.
+			$var = $phpcs_file->findNext( array( T_WHITESPACE ), ( $obj_operator + 1 ), null, true );
+			if ( T_STRING === $tokens[ $var ]['code'] ) {
+				$bracket = $phpcs_file->findNext( array( T_WHITESPACE ), ( $var + 1 ), null, true );
+				if ( T_OPEN_PARENTHESIS !== $tokens[ $bracket ]['code'] ) {
+					$obj_var_name = $tokens[ $var ]['content'];
+
+					// There is no way for us to know if the var is public or
+					// private, so we have to ignore a leading underscore if there is
+					// one and just check the main part of the variable name.
+					$original_var_name = $obj_var_name;
+					if ( '_' === substr( $obj_var_name, 0, 1 ) ) {
+						$obj_var_name = substr( $obj_var_name, 1 );
+					}
+
+					if ( ! isset( $this->whitelisted_mixed_case_member_var_names[ $obj_var_name ] ) && self::isSnakeCase( $obj_var_name ) === false ) {
+						$error = 'Object property "%s" is not in valid snake_case format';
+						$data  = array( $original_var_name );
+						$phpcs_file->addError( $error, $var, 'NotSnakeCaseMemberVar', $data );
+					}
+				}
+			}
+		}
+
+		$in_class     = false;
+		$obj_operator = $phpcs_file->findPrevious( array( T_WHITESPACE ), ( $stack_ptr - 1 ), null, true );
+		if ( T_DOUBLE_COLON === $tokens[ $obj_operator ]['code'] || T_OBJECT_OPERATOR === $tokens[ $obj_operator ]['code'] ) {
+			// The variable lives within a class, and is referenced like
+			// this: MyClass::$_variable or $class->variable.
+			$in_class = true;
+		}
+
+		// There is no way for us to know if the var is public or private,
+		// so we have to ignore a leading underscore if there is one and just
+		// check the main part of the variable name.
+		$original_var_name = $var_name;
+		if ( '_' === substr( $var_name, 0, 1 ) && true === $in_class ) {
+			$var_name = substr( $var_name, 1 );
+		}
+
+		if ( self::isSnakeCase( $var_name ) === false ) {
+			if ( $in_class && ! isset( $this->whitelisted_mixed_case_member_var_names[ $var_name ] ) ) {
+				$error      = 'Object property "%s" is not in valid snake_case format';
+				$error_name = 'NotSnakeCaseMemberVar';
+			} elseif ( ! $in_class ) {
+				$error      = 'Variable "%s" is not in valid snake_case format';
+				$error_name = 'NotSnakeCase';
+			}
+
+			if ( isset( $error, $error_name ) ) {
+				$data = array( $original_var_name );
+				$phpcs_file->addError( $error, $stack_ptr, $error_name, $data );
+			}
+		}
+
+	}
+
+	/**
+	 * Processes class member variables.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
+	 * @param int                         $stack_ptr  The position of the current token in the
+	 *                                                stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	protected function processMemberVar( File $phpcs_file, $stack_ptr ) {
+
+		$tokens = $phpcs_file->getTokens();
+
+		$var_name     = ltrim( $tokens[ $stack_ptr ]['content'], '$' );
+		$member_props = $phpcs_file->getMemberProperties( $stack_ptr );
+		if ( empty( $member_props ) ) {
+			// Couldn't get any info about this variable, which
+			// generally means it is invalid or possibly has a parse
+			// error. Any errors will be reported by the core, so
+			// we can ignore it.
+			return;
+		}
+
+		// Merge any custom variables with the defaults.
+		$this->mergeWhiteList( $phpcs_file );
+
+		$error_data = array( $var_name );
+		if ( ! isset( $this->whitelisted_mixed_case_member_var_names[ $var_name ] ) && false === self::isSnakeCase( $var_name ) ) {
+			$error = 'Member variable "%s" is not in valid snake_case format.';
+			$phpcs_file->addError( $error, $stack_ptr, 'MemberNotSnakeCase', $error_data );
+		}
+
+	}
+
+	/**
+	 * Processes the variable found within a double quoted string.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
+	 * @param int                         $stack_ptr  The position of the double quoted
+	 *                                                string.
+	 *
+	 * @return void
+	 */
+	protected function processVariableInString( File $phpcs_file, $stack_ptr ) {
+
+		$tokens = $phpcs_file->getTokens();
+
+		if ( preg_match_all( '|[^\\\]\${?([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)|', $tokens[ $stack_ptr ]['content'], $matches ) > 0 ) {
+
+			// Merge any custom variables with the defaults.
+			$this->mergeWhiteList( $phpcs_file );
+
+			foreach ( $matches[1] as $var_name ) {
+				// If it's a php reserved var, then its ok.
+				if ( isset( $this->php_reserved_vars[ $var_name ] ) ) {
+					continue;
+				}
+
+				// Likewise if it is a mixed-case var used by WordPress core.
+				if ( isset( $this->wordpress_mixed_case_vars[ $var_name ] ) ) {
+					return;
+				}
+
+				if ( false === self::isSnakeCase( $var_name ) ) {
+					$error = 'Variable "%s" is not in valid snake_case format';
+					$data  = array( $var_name );
+					$phpcs_file->addError( $error, $stack_ptr, 'StringNotSnakeCase', $data );
+				}
+			}
+		}
+
+	}
+
+	/**
+	 * Return whether the variable is in snake_case.
+	 *
+	 * @param string $var_name Variable name.
+	 * @return bool
+	 */
+	public static function isSnakeCase( $var_name ) {
+		return (bool) preg_match( '/^[a-z0-9_]+$/', $var_name );
+	}
+
+	/**
+	 * Merge a custom whitelist provided via a custom ruleset with the predefined whitelist,
+	 * if we haven't already.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcs_file The file being scanned.
+	 *
+	 * @return void
+	 */
+	protected function mergeWhiteList( File $phpcs_file ) {
+		if ( $this->customPropertiesWhitelist !== $this->addedCustomProperties['properties']
+			|| $this->customVariablesWhitelist !== $this->addedCustomProperties['variables']
+		) {
+			// Fix property potentially passed as comma-delimited string.
+			$customProperties = Sniff::merge_custom_array( $this->customPropertiesWhitelist, array(), false );
+
+			if ( ! empty( $this->customVariablesWhitelist ) ) {
+				$customProperties = Sniff::merge_custom_array(
+					$this->customVariablesWhitelist,
+					$customProperties,
+					false
+				);
+
+				$phpcs_file->addWarning(
+					'The customVariablesWhitelist property is deprecated in favor of customPropertiesWhitelist.',
+					0,
+					'DeprecatedCustomVariablesWhitelist'
+				);
+			}
+
+			$this->whitelisted_mixed_case_member_var_names = Sniff::merge_custom_array(
+				$customProperties,
+				$this->whitelisted_mixed_case_member_var_names
+			);
+
+			$this->addedCustomProperties['properties'] = $this->customPropertiesWhitelist;
+			$this->addedCustomProperties['variables']  = $this->customVariablesWhitelist;
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/PHP/DevelopmentFunctionsSniff.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Restrict the use of various development functions.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class DevelopmentFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'error_log' => array(
+				'type'      => 'warning',
+				'message'   => '%s() found. Debug code should not normally be used in production.',
+				'functions' => array(
+					'error_log',
+					'var_dump',
+					'var_export',
+					'print_r',
+					'trigger_error',
+					'set_error_handler',
+					'debug_backtrace',
+					'debug_print_backtrace',
+					'wp_debug_backtrace_summary',
+				),
+			),
+
+			'prevent_path_disclosure' => array(
+				'type'      => 'warning',
+				'message'   => '%s() can lead to full path disclosure.',
+				'functions' => array(
+					'error_reporting',
+					'phpinfo',
+				),
+			),
+
+		);
+	} // end getGroups()
+
+} // end class

--- a/ci/wpcs/WordPress/Sniffs/PHP/DiscourageGotoSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/PHP/DiscourageGotoSniff.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\Sniff;
+
+/**
+ * Discourage the use of the PHP `goto` language construct.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ *
+ * {@internal This sniff is a duplicate of an upstream PR. Once the minimum PHPCS
+ * requirement for WPCS goes up beyond the version in which the upstream PR
+ * is merged, this sniff can be safely removed.
+ * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1664} }}
+ */
+class DiscourageGotoSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_GOTO,
+			T_GOTO_LABEL,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 */
+	public function process_token( $stackPtr ) {
+
+		$this->phpcsFile->addWarning( 'Using the "goto" language construct is discouraged', $stackPtr, 'Found' );
+	}
+
+}//end class

--- a/ci/wpcs/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use PHP_CodeSniffer_File as File;
+
+/**
+ * Discourages the use of various native PHP functions and suggests alternatives.
+ *
+ * @package    WPCS\WordPressCodingStandards
+ *
+ * @since      0.1.0
+ * @since      0.10.0 The checks for the POSIX functions have been replaced by the stand-alone
+ *                    sniff WordPress_Sniffs_PHP_POSIXFunctionsSniff.
+ * @since      0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @deprecated 0.11.0 The checks for the PHP development functions have been replaced by the
+ *                    stand-alone sniff WordPress_Sniffs_PHP_DevelopmentFunctionsSniff.
+ *                    The checks for the WP deprecated functions have been replaced by the
+ *                    stand-alone sniff WordPress_Sniffs_WP_DeprecatedFunctionsSniff.
+ *                    The checks for the PHP functions which have a WP alternative has been replaced
+ *                    by the stand-alone sniff WordPress_Sniffs_WP_AlternativeFunctionsSniff.
+ *                    The checks for the WP discouraged functions have been replaced by the
+ *                    stand-alone sniff WordPress_Sniffs_WP_DiscouragedFunctionsSniff.
+ *                    The checks for the PHP discouraged functions have been replaced by the
+ *                    stand-alone sniff WordPress_Sniffs_WP_DiscouragedPHPFunctionsSniff.
+ *                    The check for the `register_globals` has been removed as there is no such
+ *                    function. To check for `register_globals` ini directive use
+ *                    PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff from wimg/PHPCompatibility.
+ */
+class DiscouragedFunctionsSniff {
+
+	/**
+	 * Don't use.
+	 *
+	 * @deprecated 0.11.0
+	 *
+	 * @return int[]
+	 */
+	public function register() {
+		return array();
+	}
+
+	/**
+	 * Don't use.
+	 *
+	 * @deprecated 0.11.0
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile A PHP_CodeSniffer file.
+	 * @param int                         $stackPtr  The position of the token.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {}
+
+}

--- a/ci/wpcs/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/PHP/DiscouragedPHPFunctionsSniff.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Discourages the use of various native PHP functions and suggests alternatives.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 `create_function` was moved to the PHP.RestrictedFunctions sniff.
+ */
+class DiscouragedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to discourage.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'serialize' => array(
+				'type'      => 'warning',
+				'message'   => '%s() found. Serialized data has known vulnerability problems with Object Injection. JSON is generally a better approach for serializing data. See https://www.owasp.org/index.php/PHP_Object_Injection',
+				'functions' => array(
+					'serialize',
+					'unserialize',
+				),
+			),
+
+			'urlencode' => array(
+				'type'      => 'warning',
+				'message'   => '%s() should only be used when dealing with legacy applications rawurlencode() should now be used instead. See http://php.net/manual/en/function.rawurlencode.php and http://www.faqs.org/rfcs/rfc3986.html',
+				'functions' => array(
+					'urlencode',
+				),
+			),
+
+			'runtime_configuration' => array(
+				'type'      => 'warning',
+				'message'   => '%s() found. Changing configuration at runtime is rarely necessary.',
+				'functions' => array(
+					'error_reporting',
+					'ini_alter',
+					'ini_restore',
+					'ini_set',
+					'apache_setenv',
+					'putenv',
+					'set_include_path',
+					'restore_include_path',
+					// This alias was DEPRECATED in PHP 5.3.0, and REMOVED as of PHP 7.0.0.
+					'magic_quotes_runtime',
+					// Warning This function was DEPRECATED in PHP 5.3.0, and REMOVED as of PHP 7.0.0.
+					'set_magic_quotes_runtime',
+					// Warning This function was removed from most SAPIs in PHP 5.3.0, and was removed from PHP-FPM in PHP 7.0.0.
+					'dl',
+				),
+			),
+
+			'system_calls' => array(
+				'type'      => 'warning',
+				'message'   => '%s() found. PHP system calls are often disabled by server admins.',
+				'functions' => array(
+					'exec',
+					'passthru',
+					'proc_open',
+					'shell_exec',
+					'system',
+					'popen',
+				),
+			),
+
+			'obfuscation' => array(
+				'type'      => 'warning',
+				'message'   => '%s() can be used to obfuscate code which is strongly discouraged. Please verify that the function is used for benign reasons.',
+				'functions' => array(
+					'base64_decode',
+					'base64_encode',
+					'convert_uudecode',
+					'convert_uuencode',
+					'str_rot13',
+				),
+			),
+
+		);
+	} // end getGroups()
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/PHP/POSIXFunctionsSniff.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Perl compatible regular expressions (PCRE, preg_ functions) should be used in preference
+ * to their POSIX counterparts.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#regular-expressions
+ * @link    http://php.net/manual/en/ref.regex.php
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.10.0 Previously this check was contained within WordPress_Sniffs_VIP_RestrictedFunctionsSniff
+ *                 and the WordPress_Sniffs_PHP_DiscouragedPHPFunctionsSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class POSIXFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'ereg' => array(
+				'type'      => 'error',
+				'message'   => '%s() has been deprecated since PHP 5.3 and removed in PHP 7.0, please use preg_match() instead.',
+				'functions' => array(
+					'ereg',
+					'eregi',
+					'sql_regcase',
+				),
+			),
+
+			'ereg_replace' => array(
+				'type'      => 'error',
+				'message'   => '%s() has been deprecated since PHP 5.3 and removed in PHP 7.0, please use preg_replace() instead.',
+				'functions' => array(
+					'ereg_replace',
+					'eregi_replace',
+				),
+			),
+
+			'split' => array(
+				'type'      => 'error',
+				'message'   => '%s() has been deprecated since PHP 5.3 and removed in PHP 7.0, please use explode(), str_split() or preg_split() instead.',
+				'functions' => array(
+					'split',
+					'spliti',
+				),
+			),
+
+		);
+	} // End getGroups().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/PHP/RestrictedPHPFunctionsSniff.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Forbids the use of various native PHP functions and suggests alternatives.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class RestrictedPHPFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to forbid.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'create_function' => array(
+				'type'      => 'error',
+				'message'   => '%s() is deprecated as of PHP 7.2, please use full fledged functions or anonymous functions instead.',
+				'functions' => array(
+					'create_function',
+				),
+			),
+
+		);
+	} // end getGroups()
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/PHP/StrictComparisonsSniff.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\Sniff;
+
+/**
+ * Enforces Strict Comparison checks, based upon Squiz code.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.4.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * Last synced with base class ?[unknown date]? at commit ?[unknown commit]?.
+ * It is currently unclear whether this sniff is actually based on Squiz code on whether the above
+ * reference to it is a copy/paste oversight.
+ * @link    Possibly: https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/Operators/ComparisonOperatorUsageSniff.php
+ */
+class StrictComparisonsSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_IS_EQUAL,
+			T_IS_NOT_EQUAL,
+		);
+
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		if ( ! $this->has_whitelist_comment( 'loose comparison', $stackPtr ) ) {
+			$error = 'Found: ' . $this->tokens[ $stackPtr ]['content'] . '. Use strict comparisons (=== or !==).';
+			$this->phpcsFile->addWarning( $error, $stackPtr, 'LooseComparison' );
+		}
+
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/PHP/StrictInArraySniff.php
+++ b/ci/wpcs/WordPress/Sniffs/PHP/StrictInArraySniff.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * Flag calling in_array(), array_search() and array_keys() without true as the third parameter.
+ *
+ * @link    https://vip.wordpress.com/documentation/code-review-what-we-look-for/#using-in_array-without-strict-parameter
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.9.0
+ * @since   0.10.0 This sniff not only checks for `in_array()`, but also `array_search()` and `array_keys()`.
+ *                 The sniff no longer needlessly extends the WordPress_Sniffs_Arrays_ArrayAssignmentRestrictionsSniff
+ *                 which it didn't use.
+ * @since   0.11.0 Refactored to extend the new WordPress_AbstractFunctionParameterSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class StrictInArraySniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'strict';
+
+	/**
+	 * List of array functions to which a $strict parameter can be passed.
+	 *
+	 * The $strict parameter is the third and last parameter for each of these functions.
+	 *
+	 * The array_keys() function only requires the $strict parameter when the optional
+	 * second parameter $search has been set.
+	 *
+	 * @link http://php.net/in-array
+	 * @link http://php.net/array-search
+	 * @link http://php.net/array-keys
+	 *
+	 * @since 0.10.0
+	 * @since 0.11.0 Renamed from $array_functions to $target_functions.
+	 *
+	 * @var array <string function_name> => <bool always needed ?>
+	 */
+	protected $target_functions = array(
+		'in_array'     => true,
+		'array_search' => true,
+		'array_keys'   => false,
+	);
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		// Check if the strict check is actually needed.
+		if ( false === $this->target_functions[ $matched_content ] ) {
+			if ( count( $parameters ) === 1 ) {
+				return;
+			}
+		}
+
+		// We're only interested in the third parameter.
+		if ( false === isset( $parameters[3] ) || 'true' !== strtolower( $parameters[3]['raw'] ) ) {
+			$errorcode = 'MissingTrueStrict';
+
+			/*
+			 * Use a different error code when `false` is found to allow for excluding
+			 * the warning as this will be a conscious choice made by the dev.
+			 */
+			if ( isset( $parameters[3] ) && 'false' === strtolower( $parameters[3]['raw'] ) ) {
+				$errorcode = 'FoundNonStrictFalse';
+			}
+
+			$this->phpcsFile->addWarning(
+				'Not using strict comparison for %s; supply true for third argument.',
+				( isset( $parameters[3]['start'] ) ? $parameters[3]['start'] : $parameters[1]['start'] ),
+				$errorcode,
+				array( $matched_content )
+			);
+			return;
+		}
+	}
+
+	/**
+	 * Process the function if no parameters were found.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return void
+	 */
+	public function process_no_parameters( $stackPtr, $group_name, $matched_content ) {
+		$this->phpcsFile->addError( 'Missing arguments to %s.', $stackPtr, 'MissingArguments', array( $matched_content ) );
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/PHP/YodaConditionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/PHP/YodaConditionsSniff.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\PHP;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Enforces Yoda conditional statements.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#yoda-conditions
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class YodaConditionsSniff extends Sniff {
+
+	/**
+	 * The tokens that indicate the start of a condition.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var array
+	 */
+	protected $condition_start_tokens;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+
+		$starters                       = Tokens::$booleanOperators;
+		$starters                      += Tokens::$assignmentTokens;
+		$starters[ T_CASE ]             = T_CASE;
+		$starters[ T_RETURN ]           = T_RETURN;
+		$starters[ T_INLINE_THEN ]      = T_INLINE_THEN;
+		$starters[ T_INLINE_ELSE ]      = T_INLINE_ELSE;
+		$starters[ T_SEMICOLON ]        = T_SEMICOLON;
+		$starters[ T_OPEN_PARENTHESIS ] = T_OPEN_PARENTHESIS;
+
+		$this->condition_start_tokens = $starters;
+
+		return array(
+			T_IS_EQUAL,
+			T_IS_NOT_EQUAL,
+			T_IS_IDENTICAL,
+			T_IS_NOT_IDENTICAL,
+		);
+
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		$start = $this->phpcsFile->findPrevious( $this->condition_start_tokens, $stackPtr, null, false, null, true );
+
+		$needs_yoda = false;
+
+		// Note: going backwards!
+		for ( $i = $stackPtr; $i > $start; $i-- ) {
+
+			// Ignore whitespace.
+			if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+				continue;
+			}
+
+			// If this is a variable or array, we've seen all we need to see.
+			if ( T_VARIABLE === $this->tokens[ $i ]['code']
+				|| T_CLOSE_SQUARE_BRACKET === $this->tokens[ $i ]['code']
+			) {
+				$needs_yoda = true;
+				break;
+			}
+
+			// If this is a function call or something, we are OK.
+			if ( T_CLOSE_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
+				return;
+			}
+		}
+
+		if ( ! $needs_yoda ) {
+			return;
+		}
+
+		// Check if this is a var to var comparison, e.g.: if ( $var1 == $var2 ).
+		$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+		if ( isset( Tokens::$castTokens[ $this->tokens[ $next_non_empty ]['code'] ] ) ) {
+			$next_non_empty = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $next_non_empty + 1 ), null, true );
+		}
+
+		if ( in_array( $this->tokens[ $next_non_empty ]['code'], array( T_SELF, T_PARENT, T_STATIC ), true ) ) {
+			$next_non_empty = $this->phpcsFile->findNext(
+				array_merge( Tokens::$emptyTokens, array( T_DOUBLE_COLON ) ),
+				( $next_non_empty + 1 ),
+				null,
+				true
+			);
+		}
+
+		if ( T_VARIABLE === $this->tokens[ $next_non_empty ]['code'] ) {
+			return;
+		}
+
+		$this->phpcsFile->addError( 'Use Yoda Condition checks, you must.', $stackPtr, 'NotYoda' );
+
+	} // End process().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/AdminBarRemovalSniff.php
@@ -1,0 +1,431 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionParameterSniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Discourages removal of the admin bar.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#removing-the-admin-bar
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.11.0 - Extends the WordPress_AbstractFunctionParameterSniff class.
+ *                 - Added the $remove_only property.
+ *                 - Now also sniffs for manipulation of the admin bar visibility through CSS.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class AdminBarRemovalSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array( 'PHP', 'CSS' );
+
+	/**
+	 * Whether or not the sniff only checks for removal of the admin bar
+	 * or any manipulation to the visibility of the admin bar.
+	 *
+	 * Defaults to true: only check for removal of the admin bar.
+	 * Set to false to check for any form of manipulation of the visibility
+	 * of the admin bar.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var bool
+	 */
+	public $remove_only = true;
+
+	/**
+	 * Functions this sniff is looking for.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	protected $target_functions = array(
+		'show_admin_bar' => true,
+		'add_filter'     => true,
+	);
+
+	/**
+	 * CSS properties this sniff is looking for.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	protected $target_css_properties = array(
+		'visibility' => array(
+			'type'  => '!=',
+			'value' => 'hidden',
+		),
+		'display' => array(
+			'type'  => '!=',
+			'value' => 'none',
+		),
+		'opacity' => array(
+			'type'  => '>',
+			'value' => 0.3,
+		),
+	);
+
+	/**
+	 * CSS selectors this sniff is looking for.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	protected $target_css_selectors = array(
+		'.show-admin-bar',
+		'#wpadminbar',
+	);
+
+	/**
+	 * String tokens within PHP files we want to deal with.
+	 *
+	 * Set from the register() method.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	private $string_tokens = array();
+
+	/**
+	 * Regex template for use with the CSS selectors in combination with PHP text strings.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string
+	 */
+	private $target_css_selectors_regex = '`(?:%s).*?\{(.*)$`';
+
+	/**
+	 * Property to keep track of whether a <style> open tag has been encountered.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	private $in_style;
+
+	/**
+	 * Property to keep track of whether a one of the target selectors has been encountered.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	private $in_target_selector;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		// Set up all string targets.
+		$this->string_tokens = Tokens::$textStringTokens;
+
+		$targets = $this->string_tokens;
+
+		// Add CSS style target.
+		$targets[] = T_STYLE;
+
+		// Set the target selectors regex only once.
+		$selectors = array_map(
+			'preg_quote',
+			$this->target_css_selectors,
+			array_fill( 0, count( $this->target_css_selectors ), '`' )
+		);
+		// Parse the selectors array into the regex string.
+		$this->target_css_selectors_regex = sprintf( $this->target_css_selectors_regex, implode( '|', $selectors ) );
+
+		// Add function call targets.
+		$parent = parent::register();
+		if ( ! empty( $parent ) ) {
+			$targets[] = T_STRING;
+		}
+
+		return $targets;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+
+		$file_name      = $this->phpcsFile->getFileName();
+		$file_extension = substr( strrchr( $file_name, '.' ), 1 );
+
+		if ( 'css' === $file_extension ) {
+			if ( T_STYLE === $this->tokens[ $stackPtr ]['code'] ) {
+				return $this->process_css_style( $stackPtr );
+			}
+		} elseif ( isset( $this->string_tokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
+			/*
+			 * Set $in_style && $in_target_selector to false if it is the first time
+			 * this sniff is run on a file.
+			 */
+			if ( ! isset( $this->in_style[ $file_name ] ) ) {
+				$this->in_style[ $file_name ] = false;
+			}
+			if ( ! isset( $this->in_target_selector[ $file_name ] ) ) {
+				$this->in_target_selector[ $file_name ] = false;
+			}
+
+			return $this->process_text_for_style( $stackPtr, $file_name );
+
+		} else {
+			return parent::process_token( $stackPtr );
+		}
+
+	} // End process_token().
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		$error = false;
+		switch ( $matched_content ) {
+			case 'show_admin_bar':
+				$error = true;
+				if ( true === $this->remove_only ) {
+					if ( 'true' === $parameters[1]['raw'] ) {
+						$error = false;
+					}
+				}
+				break;
+
+			case 'add_filter':
+				$filter_name = $this->strip_quotes( $parameters[1]['raw'] );
+				if ( 'show_admin_bar' !== $filter_name ) {
+					break;
+				}
+
+				$error = true;
+				if ( true === $this->remove_only && isset( $parameters[2]['raw'] ) ) {
+					if ( '__return_true' === $this->strip_quotes( $parameters[2]['raw'] ) ) {
+						$error = false;
+					}
+				}
+				break;
+
+			default:
+				// Left empty on purpose.
+				break;
+		}
+
+		if ( true === $error ) {
+			$this->phpcsFile->addError( 'Removal of admin bar is prohibited.', $stackPtr, 'RemovalDetected' );
+		}
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int    $stackPtr  The position of the current token in the stack.
+	 * @param string $file_name The file name of the current file being processed.
+	 *
+	 * @return void
+	 */
+	public function process_text_for_style( $stackPtr, $file_name ) {
+		$content = trim( $this->tokens[ $stackPtr ]['content'] );
+
+		// No need to check an empty string.
+		if ( '' === $content ) {
+			return;
+		}
+
+		// Are we in a <style> tag ?
+		if ( true === $this->in_style[ $file_name ] ) {
+			if ( false !== strpos( $content, '</style>' ) ) {
+				// Make sure we check any content on this line before the closing style tag.
+				$this->in_style[ $file_name ] = false;
+				$content                      = trim( substr( $content, 0, strpos( $content, '</style>' ) ) );
+			}
+		} elseif ( true === $this->has_html_open_tag( 'style', $stackPtr, $content ) ) {
+			// Ok, found a <style> open tag.
+			if ( false === strpos( $content, '</style>' ) ) {
+				// Make sure we check any content on this line after the opening style tag.
+				$this->in_style[ $file_name ] = true;
+				$content                      = trim( substr( $content, ( strpos( $content, '<style' ) + 6 ) ) );
+			} else {
+				// Ok, we have open and close style tag on the same line with possibly content within.
+				$start   = ( strpos( $content, '<style' ) + 6 );
+				$end     = strpos( $content, '</style>' );
+				$content = trim( substr( $content, $start, ( $end - $start ) ) );
+				unset( $start, $end );
+			}
+		} else {
+			return;
+		}
+
+		// Are we in one of the target selectors ?
+		if ( true === $this->in_target_selector[ $file_name ] ) {
+			if ( false !== strpos( $content, '}' ) ) {
+				// Make sure we check any content on this line before the selector closing brace.
+				$this->in_target_selector[ $file_name ] = false;
+				$content                                = trim( substr( $content, 0, strpos( $content, '}' ) ) );
+			}
+		} elseif ( preg_match( $this->target_css_selectors_regex, $content, $matches ) > 0 ) {
+			// Ok, found a new target selector.
+			$content = '';
+
+			if ( isset( $matches[1] ) && '' !== $matches[1] ) {
+				if ( false === strpos( $matches[1], '}' ) ) {
+					// Make sure we check any content on this line before the closing brace.
+					$this->in_target_selector[ $file_name ] = true;
+					$content                                = trim( $matches[1] );
+				} else {
+					// Ok, we have the selector open and close brace on the same line.
+					$content = trim( substr( $matches[1], 0, strpos( $matches[1], '}' ) ) );
+				}
+			} else {
+				$this->in_target_selector[ $file_name ] = true;
+			}
+		} else {
+			return;
+		}
+		unset( $matches );
+
+		// Now let's do the check for the CSS properties.
+		if ( ! empty( $content ) ) {
+			foreach ( $this->target_css_properties as $property => $requirements ) {
+				if ( false !== strpos( $content, $property ) ) {
+					$error = true;
+
+					if ( true === $this->remove_only ) {
+						// Check the value of the CSS property.
+						if ( preg_match( '`' . preg_quote( $property, '`' ) . '\s*:\s*(.+?)\s*(?:!important)?;`', $content, $matches ) > 0 ) {
+							$value = trim( $matches[1] );
+							$valid = $this->validate_css_property_value( $value, $requirements['type'], $requirements['value'] );
+							if ( true === $valid ) {
+								$error = false;
+							}
+						}
+					}
+
+					if ( true === $error ) {
+						$this->phpcsFile->addError( 'Hiding of the admin bar is not allowed.', $stackPtr, 'HidingDetected' );
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Processes this test for T_STYLE tokens in CSS files.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int $stackPtr  The position of the current token in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	protected function process_css_style( $stackPtr ) {
+		if ( ! isset( $this->target_css_properties[ $this->tokens[ $stackPtr ]['content'] ] ) ) {
+			// Not one of the CSS properties we're interested in.
+			return;
+		}
+
+		$css_property = $this->target_css_properties[ $this->tokens[ $stackPtr ]['content'] ];
+
+		// Check if the CSS selector matches.
+		$opener = $this->phpcsFile->findPrevious( T_OPEN_CURLY_BRACKET, $stackPtr );
+		if ( false !== $opener ) {
+			for ( $i = ( $opener - 1 ); $i >= 0; $i-- ) {
+				if ( isset( Tokens::$commentTokens[ $this->tokens[ $i ]['code'] ] )
+					|| T_CLOSE_CURLY_BRACKET === $this->tokens[ $i ]['code']
+				) {
+					break;
+				}
+			}
+			$start    = ( $i + 1 );
+			$selector = trim( $this->phpcsFile->getTokensAsString( $start, ( $opener - $start ) ) );
+			unset( $i );
+
+			foreach ( $this->target_css_selectors as $target_selector ) {
+				if ( false !== strpos( $selector, $target_selector ) ) {
+					$error = true;
+
+					if ( true === $this->remove_only ) {
+						// Check the value of the CSS property.
+						$valuePtr = $this->phpcsFile->findNext( array( T_COLON, T_WHITESPACE ), ( $stackPtr + 1 ), null, true );
+						$value    = $this->tokens[ $valuePtr ]['content'];
+						$valid    = $this->validate_css_property_value( $value, $css_property['type'], $css_property['value'] );
+						if ( true === $valid ) {
+							$error = false;
+						}
+					}
+
+					if ( true === $error ) {
+						$this->phpcsFile->addError( 'Hiding of the admin bar is not allowed.', $stackPtr, 'HidingDetected' );
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Verify if a CSS property value complies with an expected value.
+	 *
+	 * {@internal This is a method stub, doing only what is needed for this sniff.
+	 * If at some point in the future other sniff would need similar functionality,
+	 * this method should be moved to the WordPress_Sniff class and expanded to cover
+	 * all types of comparisons.}}
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param mixed  $value         The value of CSS property.
+	 * @param string $compare_type  The type of comparison to use for the validation.
+	 * @param string $compare_value The value to compare against.
+	 *
+	 * @return bool True if the property value complies, false otherwise.
+	 */
+	protected function validate_css_property_value( $value, $compare_type, $compare_value ) {
+		switch ( $compare_type ) {
+			case '!=':
+				return $value !== $compare_value;
+
+			case '>':
+				return $value > $compare_value;
+
+			default:
+				return false;
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/CronIntervalSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/CronIntervalSniff.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Flag cron schedules less than 15 minutes.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#cron-schedules-less-than-15-minutes-or-expensive-events
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.11.0 - Extends the WordPress_Sniff class.
+ *                 - Now deals correctly with WP time constants.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 The minimum cron interval tested against is now configurable.
+ */
+class CronIntervalSniff extends Sniff {
+
+	/**
+	 * Minimum allowed cron interval in seconds.
+	 *
+	 * Defaults to 900 (= 15 minutes), which is the requirement for the VIP platform.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var int
+	 */
+	public $min_interval = 900;
+
+	/**
+	 * Known WP Time constant names and their value.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	protected $wp_time_constants = array(
+		'MINUTE_IN_SECONDS' => 60,
+		'HOUR_IN_SECONDS'   => 3600,
+		'DAY_IN_SECONDS'    => 86400,
+		'WEEK_IN_SECONDS'   => 604800,
+		'MONTH_IN_SECONDS'  => 2592000,
+		'YEAR_IN_SECONDS'   => 31536000,
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_CONSTANT_ENCAPSED_STRING,
+			T_DOUBLE_QUOTED_STRING,
+		);
+
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		$token = $this->tokens[ $stackPtr ];
+
+		if ( 'cron_schedules' !== $this->strip_quotes( $token['content'] ) ) {
+			return;
+		}
+
+		// If within add_filter.
+		$functionPtr = $this->phpcsFile->findPrevious( T_STRING, key( $token['nested_parenthesis'] ) );
+		if ( false === $functionPtr || 'add_filter' !== $this->tokens[ $functionPtr ]['content'] ) {
+			return;
+		}
+
+		$callback = $this->get_function_call_parameter( $functionPtr, 2 );
+		if ( false === $callback ) {
+			return;
+		}
+
+		// Detect callback function name.
+		$callbackArrayPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, $callback['start'], ( $callback['end'] + 1 ), true );
+
+		// If callback is array, get second element.
+		if ( false !== $callbackArrayPtr
+			&& ( T_ARRAY === $this->tokens[ $callbackArrayPtr ]['code']
+				|| T_OPEN_SHORT_ARRAY === $this->tokens[ $callbackArrayPtr ]['code'] )
+		) {
+			$callback = $this->get_function_call_parameter( $callbackArrayPtr, 2 );
+
+			if ( false === $callback ) {
+				$this->confused( $stackPtr );
+				return;
+			}
+		}
+
+		unset( $functionPtr );
+
+		// Search for the function in tokens.
+		$callbackFunctionPtr = $this->phpcsFile->findNext( array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING, T_CLOSURE ), $callback['start'], ( $callback['end'] + 1 ) );
+
+		if ( false === $callbackFunctionPtr ) {
+			$this->confused( $stackPtr );
+			return;
+		}
+
+		if ( T_CLOSURE === $this->tokens[ $callbackFunctionPtr ]['code'] ) {
+			$functionPtr = $callbackFunctionPtr;
+		} else {
+			$functionName = $this->strip_quotes( $this->tokens[ $callbackFunctionPtr ]['content'] );
+
+			for ( $ptr = 0; $ptr < $this->phpcsFile->numTokens; $ptr++ ) {
+				if ( T_FUNCTION === $this->tokens[ $ptr ]['code'] ) {
+					$foundName = $this->phpcsFile->getDeclarationName( $ptr );
+					if ( $foundName === $functionName ) {
+						$functionPtr = $ptr;
+						break;
+					} elseif ( isset( $this->tokens[ $ptr ]['scope_closer'] ) ) {
+						// Skip to the end of the function definition.
+						$ptr = $this->tokens[ $ptr ]['scope_closer'];
+					}
+				}
+			}
+		}
+
+		if ( ! isset( $functionPtr ) ) {
+			$this->confused( $stackPtr );
+			return;
+		}
+
+		if ( ! isset( $this->tokens[ $functionPtr ]['scope_opener'], $this->tokens[ $functionPtr ]['scope_closer'] ) ) {
+			return;
+		}
+
+		$opening = $this->tokens[ $functionPtr ]['scope_opener'];
+		$closing = $this->tokens[ $functionPtr ]['scope_closer'];
+		for ( $i = $opening; $i <= $closing; $i++ ) {
+
+			if ( in_array( $this->tokens[ $i ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+				if ( 'interval' === $this->strip_quotes( $this->tokens[ $i ]['content'] ) ) {
+					$operator = $this->phpcsFile->findNext( T_DOUBLE_ARROW, $i, null, false, null, true );
+					if ( false === $operator ) {
+						$this->confused( $stackPtr );
+						return;
+					}
+
+					$valueStart = $this->phpcsFile->findNext( T_WHITESPACE, ( $operator + 1 ), null, true, null, true );
+					$valueEnd   = $this->phpcsFile->findNext( array( T_COMMA, T_CLOSE_PARENTHESIS ), ( $valueStart + 1 ) );
+					$value      = $this->phpcsFile->getTokensAsString( $valueStart, ( $valueEnd - $valueStart ) );
+
+					if ( is_numeric( $value ) ) {
+						$interval = $value;
+						break;
+					}
+
+					// Deal correctly with WP time constants.
+					$value = str_replace( array_keys( $this->wp_time_constants ), array_values( $this->wp_time_constants ), $value );
+
+					// If all digits and operators, eval!
+					if ( preg_match( '#^[\s\d+*/-]+$#', $value ) > 0 ) {
+						$interval = eval( "return ( $value );" ); // @codingStandardsIgnoreLine - No harm here.
+						break;
+					}
+
+					$this->confused( $stackPtr );
+					return;
+				}
+			}
+		}
+
+		$this->min_interval = (int) $this->min_interval;
+
+		if ( isset( $interval ) && $interval < $this->min_interval ) {
+			$minutes = round( ( $this->min_interval / 60 ), 1 );
+			$this->phpcsFile->addError(
+				'Scheduling crons at %s sec ( less than %s minutes ) is prohibited.',
+				$stackPtr,
+				'CronSchedulesInterval',
+				array(
+					$interval,
+					$minutes,
+				)
+			);
+			return;
+		}
+
+	} // End process_token().
+
+	/**
+	 * Add warning about unclear cron schedule change.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 */
+	public function confused( $stackPtr ) {
+		$this->phpcsFile->addWarning(
+			'Detected changing of cron_schedules, but could not detect the interval value.',
+			$stackPtr,
+			'ChangeDetected'
+		);
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/DirectDatabaseQuerySniff.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Flag Database direct queries.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#direct-database-queries
+ * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#database-alteration
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.6.0  Removed the add_unique_message() function as it is no longer needed.
+ * @since   0.11.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class DirectDatabaseQuerySniff extends Sniff {
+
+	/**
+	 * List of custom cache get functions.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customCacheGetFunctions = array();
+
+	/**
+	 * List of custom cache set functions.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customCacheSetFunctions = array();
+
+	/**
+	 * List of custom cache delete functions.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customCacheDeleteFunctions = array();
+
+	/**
+	 * Cache of previously added custom functions.
+	 *
+	 * Prevents having to do the same merges over and over again.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	protected $addedCustomFunctions = array(
+		'cacheget'    => null,
+		'cacheset'    => null,
+		'cachedelete' => null,
+	);
+
+	/**
+	 * The lists of $wpdb methods.
+	 *
+	 * @since 0.6.0
+	 * @since 0.11.0 Changed from static to non-static.
+	 *
+	 * @var array[]
+	 */
+	protected $methods = array(
+		'cachable' => array(
+			'delete'      => true,
+			'get_var'     => true,
+			'get_col'     => true,
+			'get_row'     => true,
+			'get_results' => true,
+			'query'       => true,
+			'replace'     => true,
+			'update'      => true,
+		),
+		'noncachable' => array(
+			'insert' => true,
+		),
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_VARIABLE,
+		);
+
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		// Check for $wpdb variable.
+		if ( '$wpdb' !== $this->tokens[ $stackPtr ]['content'] ) {
+			return;
+		}
+
+		$is_object_call = $this->phpcsFile->findNext( T_OBJECT_OPERATOR, ( $stackPtr + 1 ), null, false, null, true );
+		if ( false === $is_object_call ) {
+			return; // This is not a call to the wpdb object.
+		}
+
+		$methodPtr = $this->phpcsFile->findNext( array( T_WHITESPACE ), ( $is_object_call + 1 ), null, true, null, true );
+		$method    = $this->tokens[ $methodPtr ]['content'];
+
+		$this->mergeFunctionLists();
+
+		if ( ! isset( $this->methods['all'][ $method ] ) ) {
+			return;
+		}
+
+		$endOfStatement   = $this->phpcsFile->findNext( T_SEMICOLON, ( $stackPtr + 1 ), null, false, null, true );
+		$endOfLineComment = '';
+		for ( $i = ( $endOfStatement + 1 ); $i < $this->phpcsFile->numTokens; $i++ ) {
+
+			if ( $this->tokens[ $i ]['line'] !== $this->tokens[ $endOfStatement ]['line'] ) {
+				break;
+			}
+
+			if ( T_COMMENT === $this->tokens[ $i ]['code'] ) {
+				$endOfLineComment .= $this->tokens[ $i ]['content'];
+			}
+		}
+
+		$whitelisted_db_call = false;
+		if ( preg_match( '/db call\W*(?:ok|pass|clear|whitelist)/i', $endOfLineComment ) ) {
+			$whitelisted_db_call = true;
+		}
+
+		// Check for Database Schema Changes.
+		for ( $_pos = ( $stackPtr + 1 ); $_pos < $endOfStatement; $_pos++ ) {
+			$_pos = $this->phpcsFile->findNext( Tokens::$textStringTokens, $_pos, $endOfStatement, false, null, true );
+			if ( false === $_pos ) {
+				break;
+			}
+
+			if ( preg_match( '#\b(?:ALTER|CREATE|DROP)\b#i', $this->tokens[ $_pos ]['content'] ) > 0 ) {
+				$this->phpcsFile->addError( 'Attempting a database schema change is highly discouraged.', $_pos, 'SchemaChange' );
+			}
+		}
+
+		// Flag instance if not whitelisted.
+		if ( ! $whitelisted_db_call ) {
+			$this->phpcsFile->addWarning( 'Usage of a direct database call is discouraged.', $stackPtr, 'DirectQuery' );
+		}
+
+		if ( ! isset( $this->methods['cachable'][ $method ] ) ) {
+			return $endOfStatement;
+		}
+
+		$whitelisted_cache = false;
+		$cached            = false;
+		$wp_cache_get      = false;
+		if ( preg_match( '/cache\s+(?:ok|pass|clear|whitelist)/i', $endOfLineComment ) ) {
+			$whitelisted_cache = true;
+		}
+		if ( ! $whitelisted_cache && ! empty( $this->tokens[ $stackPtr ]['conditions'] ) ) {
+			$scope_function = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+
+			if ( false === $scope_function ) {
+				$scope_function = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+			}
+
+			if ( false !== $scope_function ) {
+				$scopeStart = $this->tokens[ $scope_function ]['scope_opener'];
+				$scopeEnd   = $this->tokens[ $scope_function ]['scope_closer'];
+
+				for ( $i = ( $scopeStart + 1 ); $i < $scopeEnd; $i++ ) {
+					if ( T_STRING === $this->tokens[ $i ]['code'] ) {
+
+						if ( isset( $this->cacheDeleteFunctions[ $this->tokens[ $i ]['content'] ] ) ) {
+
+							if ( in_array( $method, array( 'query', 'update', 'replace', 'delete' ), true ) ) {
+								$cached = true;
+								break;
+							}
+						} elseif ( isset( $this->cacheGetFunctions[ $this->tokens[ $i ]['content'] ] ) ) {
+
+							$wp_cache_get = true;
+
+						} elseif ( isset( $this->cacheSetFunctions[ $this->tokens[ $i ]['content'] ] ) ) {
+
+							if ( $wp_cache_get ) {
+								$cached = true;
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if ( ! $cached && ! $whitelisted_cache ) {
+			$message = 'Usage of a direct database call without caching is prohibited. Use wp_cache_get / wp_cache_set or wp_cache_delete.';
+			$this->phpcsFile->addError( $message, $stackPtr, 'NoCaching' );
+		}
+
+		return $endOfStatement;
+
+	} // End process_token().
+
+	/**
+	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.
+	 *
+	 * @since 0.11.0 Split out from the `process()` method.
+	 *
+	 * @return void
+	 */
+	protected function mergeFunctionLists() {
+		if ( ! isset( $this->methods['all'] ) ) {
+			$this->methods['all'] = array_merge( $this->methods['cachable'], $this->methods['noncachable'] );
+		}
+
+		if ( $this->customCacheGetFunctions !== $this->addedCustomFunctions['cacheget'] ) {
+			$this->cacheGetFunctions = $this->merge_custom_array(
+				$this->customCacheGetFunctions,
+				$this->cacheGetFunctions
+			);
+
+			$this->addedCustomFunctions['cacheget'] = $this->customCacheGetFunctions;
+		}
+
+		if ( $this->customCacheSetFunctions !== $this->addedCustomFunctions['cacheset'] ) {
+			$this->cacheSetFunctions = $this->merge_custom_array(
+				$this->customCacheSetFunctions,
+				$this->cacheSetFunctions
+			);
+
+			$this->addedCustomFunctions['cacheset'] = $this->customCacheSetFunctions;
+		}
+
+		if ( $this->customCacheDeleteFunctions !== $this->addedCustomFunctions['cachedelete'] ) {
+			$this->cacheDeleteFunctions = $this->merge_custom_array(
+				$this->customCacheDeleteFunctions,
+				$this->cacheDeleteFunctions
+			);
+
+			$this->addedCustomFunctions['cachedelete'] = $this->customCacheDeleteFunctions;
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Disallow Filesystem writes.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#filesystem-writes
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.11.0 Extends the WordPress_AbstractFunctionRestrictionsSniff instead of the
+ *                 Generic_Sniffs_PHP_ForbiddenFunctionsSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class FileSystemWritesDisallowSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * If true, an error will be thrown; otherwise a warning.
+	 *
+	 * @var bool
+	 */
+	public $error = true;
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		$groups = array(
+			'file_ops' => array(
+				'type'      => 'error',
+				'message'   => 'Filesystem writes are forbidden, you should not be using %s()',
+				'functions' => array(
+					'delete',
+					'file_put_contents',
+					'flock',
+					'fputcsv',
+					'fputs',
+					'fwrite',
+					'ftruncate',
+					'is_writable',
+					'is_writeable',
+					'link',
+					'rename',
+					'symlink',
+					'tempnam',
+					'touch',
+					'unlink',
+				),
+			),
+			'directory' => array(
+				'type'      => 'error',
+				'message'   => 'Filesystem writes are forbidden, you should not be using %s()',
+				'functions' => array(
+					'mkdir',
+					'rmdir',
+				),
+			),
+			'chmod' => array(
+				'type'      => 'error',
+				'message'   => 'Filesystem writes are forbidden, you should not be using %s()',
+				'functions' => array(
+					'chgrp',
+					'chown',
+					'chmod',
+					'lchgrp',
+					'lchown',
+				),
+			),
+		);
+
+		/*
+		 * Maintain old behaviour - allow for changing the error type from the ruleset
+		 * using the `error` property.
+		 */
+		if ( false === $this->error ) {
+			foreach ( $groups as $group_name => $details ) {
+				$groups[ $group_name ]['type'] = 'warning';
+			}
+		}
+
+		return $groups;
+
+	} // End getGroups().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/OrderByRandSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/OrderByRandSniff.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
+/**
+ * Flag using orderby => rand.
+ *
+ * @link    https://vip.wordpress.com/documentation/code-review-what-we-look-for/#order-by-rand
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.9.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class OrderByRandSniff extends AbstractArrayAssignmentRestrictionsSniff {
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'orderby' => array(
+				'type' => 'error',
+				'keys' => array(
+					'orderby',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Callback to process each confirmed key, to check value
+	 * This must be extended to add the logic to check assignment value
+	 *
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches with custom error message passed to ->process().
+	 */
+	public function callback( $key, $val, $line, $group ) {
+		if ( 'rand' === strtolower( $val ) ) {
+			return 'Detected forbidden query_var "%s" of "%s". Use vip_get_random_posts() instead.';
+		} else {
+			return false;
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/PluginMenuSlugSniff.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * Warn about __FILE__ for page registration.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#using-__file__-for-page-registration
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.11.0 Refactored to extend the new WordPress_AbstractFunctionParameterSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class PluginMenuSlugSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'add_menu_functions';
+
+	/**
+	 * Functions which can be used to add pages to the WP Admin menu.
+	 *
+	 * @since 0.3.0
+	 * @since 0.11.0 Renamed from $add_menu_functions to $target_functions
+	 *               and changed visibility to protected.
+	 *
+	 * @var array <string function name> => <array target parameter positions>
+	 */
+	protected $target_functions = array(
+		'add_menu_page'       => array( 4 ),
+		'add_object_page'     => array( 4 ),
+		'add_utility_page'    => array( 4 ),
+		'add_submenu_page'    => array( 1, 5 ),
+		'add_dashboard_page'  => array( 4 ),
+		'add_posts_page'      => array( 4 ),
+		'add_media_page'      => array( 4 ),
+		'add_links_page'      => array( 4 ),
+		'add_pages_page'      => array( 4 ),
+		'add_comments_page'   => array( 4 ),
+		'add_theme_page'      => array( 4 ),
+		'add_plugins_page'    => array( 4 ),
+		'add_users_page'      => array( 4 ),
+		'add_management_page' => array( 4 ),
+		'add_options_page'    => array( 4 ),
+	);
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		foreach ( $this->target_functions[ $matched_content ] as $position ) {
+			if ( isset( $parameters[ $position ] ) ) {
+				$file_constant = $this->phpcsFile->findNext( T_FILE, $parameters[ $position ]['start'], ( $parameters[ $position ]['end'] + 1 ) );
+
+				if ( false !== $file_constant ) {
+					$this->phpcsFile->addError( 'Using __FILE__ for menu slugs risks exposing filesystem structure.', $stackPtr, 'Using__FILE__' );
+				}
+			}
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/PostsPerPageSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/PostsPerPageSniff.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
+/**
+ * Flag returning high or infinite posts_per_page.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#no-limit-queries
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 Added the posts_per_page property.
+ */
+class PostsPerPageSniff extends AbstractArrayAssignmentRestrictionsSniff {
+
+	/**
+	 * Posts per page property
+	 *
+	 * Posts per page limit to check against.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var int
+	 */
+	public $posts_per_page = 100;
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'posts_per_page' => array(
+				'type' => 'error',
+				'keys' => array(
+					'posts_per_page',
+					'nopaging',
+					'numberposts',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Callback to process each confirmed key, to check value.
+	 * This must be extended to add the logic to check assignment value.
+	 *
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
+	 *                       with custom error message passed to ->process().
+	 */
+	public function callback( $key, $val, $line, $group ) {
+		$key                  = strtolower( $key );
+		$this->posts_per_page = (int) $this->posts_per_page;
+
+		if (
+			( 'nopaging' === $key && ( 'true' === $val || 1 === $val ) )
+			||
+			( in_array( $key, array( 'numberposts', 'posts_per_page' ), true ) && '-1' === $val )
+			) {
+
+			return 'Disabling pagination is prohibited in VIP context, do not set `%s` to `%s` ever.';
+
+		} elseif ( in_array( $key, array( 'posts_per_page', 'numberposts' ), true ) ) {
+
+			if ( $val > $this->posts_per_page ) {
+				return 'Detected high pagination limit, `%s` is set to `%s`';
+			}
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/RestrictedFunctionsSniff.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Restricts usage of some functions in VIP context.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.10.0 The checks for `extract()` and the POSIX functions have been replaced by
+ *                 the stand-alone sniffs WordPress_Sniffs_Functions_DontExtractSniff and
+ *                 WordPress_Sniffs_PHP_POSIXFunctionsSniff respectively.
+ * @since   0.11.0 The checks for `create_function()`, `serialize()`/`unserialize()` and
+ *                 `urlencode` have been moved to the stand-alone sniff
+ *                 WordPress_Sniffs_PHP_DiscouragedPHPFunctionsSniff.
+ *                 The checks for PHP developer functions, `error_reporting` and `phpinfo`have been
+ *                 moved to the stand-alone sniff WordPress_Sniffs_PHP_DevelopmentFunctionsSniff.
+ *                 The check for `parse_url()` and `curl_*` have been moved to the stand-alone sniff
+ *                 WordPress_Sniffs_WP_AlternativeFunctionsSniff.
+ *                 The check for `eval()` now defers to the upstream Squiz.PHP.Eval sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class RestrictedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#switch_to_blog
+			'switch_to_blog' => array(
+				'type'      => 'error',
+				'message'   => '%s() is not something you should ever need to do in a VIP theme context. Instead use an API (XML-RPC, REST) to interact with other sites if needed.',
+				'functions' => array( 'switch_to_blog' ),
+			),
+
+			'file_get_contents' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is highly discouraged, please use wpcom_vip_file_get_contents() instead.',
+				'functions' => array(
+					'file_get_contents',
+					'vip_wp_file_get_contents',
+				),
+			),
+
+			'wpcom_vip_get_term_link' => array(
+				'type'      => 'error',
+				'message'   => '%s() is deprecated, please use get_term_link(), get_tag_link(), or get_category_link() instead.',
+				'functions' => array(
+					'wpcom_vip_get_term_link',
+				),
+			),
+
+			'get_page_by_path' => array(
+				'type'      => 'error',
+				'message'   => '%s() is prohibited, please use wpcom_vip_get_page_by_path() instead.',
+				'functions' => array(
+					'get_page_by_path',
+				),
+			),
+
+			'get_page_by_title' => array(
+				'type'      => 'error',
+				'message'   => '%s() is prohibited, please use wpcom_vip_get_page_by_title() instead.',
+				'functions' => array(
+					'get_page_by_title',
+				),
+			),
+
+			'wpcom_vip_get_term_by' => array(
+				'type'      => 'error',
+				'message'   => '%s() is deprecated, please use get_term_by() or get_cat_ID() instead.',
+				'functions' => array(
+					'wpcom_vip_get_term_by',
+				),
+			),
+
+			'wpcom_vip_get_category_by_slug' => array(
+				'type'      => 'error',
+				'message'   => '%s() is deprecated, please use get_category_by_slug() instead.',
+				'functions' => array(
+					'wpcom_vip_get_category_by_slug',
+				),
+			),
+
+			'url_to_postid' => array(
+				'type'      => 'error',
+				'message'   => '%s() is prohibited, please use wpcom_vip_url_to_postid() instead.',
+				'functions' => array(
+					'url_to_postid',
+					'url_to_post_id',
+				),
+			),
+
+			'attachment_url_to_postid' => array(
+				'type'      => 'error',
+				'message'   => '%s() is prohibited, please use wpcom_vip_attachment_url_to_postid() instead.',
+				'functions' => array(
+					'attachment_url_to_postid',
+				),
+			),
+
+			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#remote-calls
+			'wp_remote_get' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is highly discouraged, please use vip_safe_wp_remote_get() instead.',
+				'functions' => array(
+					'wp_remote_get',
+				),
+			),
+
+			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#custom-roles
+			'custom_role' => array(
+				'type'      => 'error',
+				'message'   => 'Use wpcom_vip_add_role() instead of %s()',
+				'functions' => array(
+					'add_role',
+				),
+			),
+
+			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#caching-constraints
+			'cookies' => array(
+				'type'      => 'warning',
+				'message'   => 'Due to using Batcache, server side based client related logic will not work, use JS instead.',
+				'functions' => array(
+					'setcookie',
+				),
+			),
+
+			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#working-with-wp_users-and-user_meta
+			'user_meta' => array(
+				'type'      => 'error',
+				'message'   => '%s() usage is highly discouraged, check VIP documentation on "Working with wp_users"',
+				'functions' => array(
+					'get_user_meta',
+					'update_user_meta',
+					'delete_user_meta',
+					'add_user_meta',
+				),
+			),
+
+			// @todo Introduce a sniff specific to get_posts() that checks for suppress_filters=>false being supplied.
+			'get_posts' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is discouraged in favor of creating a new WP_Query() so that Advanced Post Cache will cache the query, unless you explicitly supply suppress_filters => false.',
+				'functions' => array(
+					'get_posts',
+					'wp_get_recent_posts',
+					'get_children',
+				),
+			),
+
+			'term_exists' => array(
+				'type'      => 'error',
+				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_term_exists() instead.',
+				'functions' => array(
+					'term_exists',
+				),
+			),
+
+			'count_user_posts' => array(
+				'type'      => 'error',
+				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_count_user_posts() instead.',
+				'functions' => array(
+					'count_user_posts',
+				),
+			),
+
+			'wp_old_slug_redirect' => array(
+				'type'      => 'error',
+				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_old_slug_redirect() instead.',
+				'functions' => array(
+					'wp_old_slug_redirect',
+				),
+			),
+
+			'get_adjacent_post' => array(
+				'type'      => 'error',
+				'message'   => '%s() is highly discouraged due to not being cached; please use wpcom_vip_get_adjacent_post() instead.',
+				'functions' => array(
+					'get_adjacent_post',
+					'get_previous_post',
+					'get_previous_post_link',
+					'get_next_post',
+					'get_next_post_link',
+				),
+			),
+
+			'get_intermediate_image_sizes' => array(
+				'type'      => 'error',
+				'message'   => 'Intermediate images do not exist on the VIP platform, and thus get_intermediate_image_sizes() returns an empty array() on the platform. This behavior is intentional to prevent WordPress from generating multiple thumbnails when images are uploaded.',
+				'functions' => array(
+					'get_intermediate_image_sizes',
+				),
+			),
+
+			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#use-wp_safe_redirect-instead-of-wp_redirect
+			'wp_redirect' => array(
+				'type'      => 'warning',
+				'message'   => '%s() found. Using wp_safe_redirect(), along with the allowed_redirect_hosts filter, can help avoid any chances of malicious redirects within code. It is also important to remember to call exit() after a redirect so that no other unwanted code is executed.',
+				'functions' => array(
+					'wp_redirect',
+				),
+			),
+
+			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#mobile-detection
+			'wp_is_mobile' => array(
+				'type'      => 'error',
+				'message'   => '%s() found. When targeting mobile visitors, jetpack_is_mobile() should be used instead of wp_is_mobile. It is more robust and works better with full page caching.',
+				'functions' => array(
+					'wp_is_mobile',
+				),
+			),
+
+		);
+	} // End getGroups().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/RestrictedVariablesSniff.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractVariableRestrictionsSniff;
+
+/**
+ * Restricts usage of some variables in VIP context.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class RestrictedVariablesSniff extends AbstractVariableRestrictionsSniff {
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'wpdb' => array(
+	 *      'type'          => 'error' | 'warning',
+	 *      'message'       => 'Dont use this one please!',
+	 *      'variables'     => array( '$val', '$var' ),
+	 *      'object_vars'   => array( '$foo->bar', .. ),
+	 *      'array_members' => array( '$foo['bar']', .. ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#working-with-wp_users-and-user_meta
+			'user_meta' => array(
+				'type'        => 'error',
+				'message'     => 'Usage of users/usermeta tables is highly discouraged in VIP context, For storing user additional user metadata, you should look at User Attributes.',
+				'object_vars' => array(
+					'$wpdb->users',
+					'$wpdb->usermeta',
+				),
+			),
+
+			// @link https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#caching-constraints
+			'cache_constraints' => array(
+				'type'          => 'warning',
+				'message'       => 'Due to using Batcache, server side based client related logic will not work, use JS instead.',
+				'variables'     => array(
+					'$_COOKIE',
+				),
+				'array_members' => array(
+					'$_SERVER[\'HTTP_USER_AGENT\']',
+					'$_SERVER[\'REMOTE_ADDR\']',
+				),
+			),
+		);
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Discourages the use of session functions.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#session_start-and-other-session-related-functions
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.11.0 Extends the WordPress_AbstractFunctionRestrictionsSniff instead of the
+ *                 Generic_Sniffs_PHP_ForbiddenFunctionsSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class SessionFunctionsUsageSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'session' => array(
+				'type'      => 'error',
+				'message'   => 'The use of PHP session function %s() is prohibited.',
+				'functions' => array(
+					'session_abort',
+					'session_cache_expire',
+					'session_cache_limiter',
+					'session_commit',
+					'session_create_id',
+					'session_decode',
+					'session_destroy',
+					'session_encode',
+					'session_gc',
+					'session_get_cookie_params',
+					'session_id',
+					'session_is_registered',
+					'session_module_name',
+					'session_name',
+					'session_regenerate_id',
+					'session_register_shutdown',
+					'session_register',
+					'session_reset',
+					'session_save_path',
+					'session_set_cookie_params',
+					'session_set_save_handler',
+					'session_start',
+					'session_status',
+					'session_unregister',
+					'session_unset',
+					'session_write_close',
+				),
+			),
+		);
+	} // End getGroups().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/SessionVariableUsageSniff.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\Sniff;
+
+/**
+ * Discourages the use of the session variable.
+ * Creating a session writes a file to the server and is unreliable in a multi-server environment.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#session_start-and-other-session-related-functions
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.10.0 The sniff no longer needlessly extends the Generic_Sniffs_PHP_ForbiddenFunctionsSniff
+ *                 which it didn't use.
+ * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class SessionVariableUsageSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_VARIABLE,
+		);
+
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		if ( '$_SESSION' === $this->tokens[ $stackPtr ]['content'] ) {
+			$this->phpcsFile->addError(
+				'Usage of $_SESSION variable is prohibited.',
+				$stackPtr,
+				'SessionVarsProhibited'
+			);
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/SlowDBQuerySniff.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractArrayAssignmentRestrictionsSniff;
+
+/**
+ * Flag potentially slow queries.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip/code-review-what-we-look-for/#uncached-pageload
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.12.0 Introduced new and more intuitively named 'slow query' whitelist
+ *                 comment, replacing the 'tax_query' whitelist comment which is now
+ *                 deprecated.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class SlowDBQuerySniff extends AbstractArrayAssignmentRestrictionsSniff {
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'slow_db_query' => array(
+				'type'    => 'warning',
+				'message' => 'Detected usage of %s, possible slow query.',
+				'keys'    => array(
+					'tax_query',
+					'meta_query',
+					'meta_key',
+					'meta_value',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+
+		if ( $this->has_whitelist_comment( 'slow query', $stackPtr ) ) {
+			return;
+		}
+
+		if ( $this->has_whitelist_comment( 'tax_query', $stackPtr ) ) {
+			/*
+			 * Only throw the warning about a deprecated comment when the sniff would otherwise
+			 * have been triggered on the array key.
+			 */
+			if ( in_array( $this->tokens[ $stackPtr ]['code'], array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING ), true ) ) {
+				$this->phpcsFile->addWarning(
+					'The "tax_query" whitelist comment is deprecated in favor of the "slow query" whitelist comment.',
+					$stackPtr,
+					'DeprecatedWhitelistFlagFound'
+				);
+			}
+
+			return;
+		}
+
+		return parent::process_token( $stackPtr );
+	}
+
+	/**
+	 * Callback to process each confirmed key, to check value.
+	 * This must be extended to add the logic to check assignment value.
+	 *
+	 * @param  string $key   Array index / key.
+	 * @param  mixed  $val   Assigned value.
+	 * @param  int    $line  Token line.
+	 * @param  array  $group Group definition.
+	 * @return mixed         FALSE if no match, TRUE if matches, STRING if matches
+	 *                       with custom error message passed to ->process().
+	 */
+	public function callback( $key, $val, $line, $group ) {
+		return true;
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/SuperGlobalInputUsageSniff.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\Sniff;
+
+/**
+ * Flag any usage of super global input var ( _GET / _POST / etc. ).
+ *
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/79
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.4.0  This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class SuperGlobalInputUsageSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_VARIABLE,
+		);
+
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		// Check for global input variable.
+		if ( ! in_array( $this->tokens[ $stackPtr ]['content'], $this->input_superglobals, true ) ) {
+			return;
+		}
+
+		$varName = $this->tokens[ $stackPtr ]['content'];
+
+		// If we're overriding a superglobal with an assignment, no need to test.
+		if ( $this->is_assignment( $stackPtr ) ) {
+			return;
+		}
+
+		// Check for whitelisting comment.
+		if ( ! $this->has_whitelist_comment( 'input var', $stackPtr ) ) {
+			$this->phpcsFile->addWarning( 'Detected access of super global var %s, probably needs manual inspection.', $stackPtr, 'AccessDetected', array( $varName ) );
+		}
+
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Disallow the changing of timezone.
+ *
+ * @link    http://vip.wordpress.com/documentation/use-current_time-not-date_default_timezone_set/
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.11.0 Extends the WordPress_AbstractFunctionRestrictionsSniff instead of the
+ *                 Generic_Sniffs_PHP_ForbiddenFunctionsSniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class TimezoneChangeSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'timezone_change' => array(
+				'type'      => 'error',
+				'message'   => 'Using %s() and similar isn\'t allowed, instead use WP internal timezone support.',
+				'functions' => array(
+					'date_default_timezone_set',
+				),
+			),
+		);
+	} // End getGroups().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/VIP/ValidatedSanitizedInputSniff.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\VIP;
+
+use WordPress\Sniff;
+
+/**
+ * Flag any non-validated/sanitized input ( _GET / _POST / etc. ).
+ *
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/69
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.4.0  This class now extends WordPress_Sniff.
+ * @since   0.5.0  Method getArrayIndexKey() has been moved to WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class ValidatedSanitizedInputSniff extends Sniff {
+
+	/**
+	 * Check for validation functions for a variable within its own parenthesis only.
+	 *
+	 * @var boolean
+	 */
+	public $check_validation_in_scope_only = false;
+
+	/**
+	 * Custom list of functions that sanitize the values passed to them.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customSanitizingFunctions = array();
+
+	/**
+	 * Custom sanitizing functions that implicitly unslash the values passed to them.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customUnslashingSanitizingFunctions = array();
+
+	/**
+	 * Cache of previously added custom functions.
+	 *
+	 * Prevents having to do the same merges over and over again.
+	 *
+	 * @since 0.5.0
+	 * @since 0.11.0 - Changed from static to non-static.
+	 *               - Changed the format from simple bool to array.
+	 *
+	 * @var array
+	 */
+	protected $addedCustomFunctions = array(
+		'sanitize'        => null,
+		'unslashsanitize' => null,
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_VARIABLE,
+			T_DOUBLE_QUOTED_STRING,
+			T_HEREDOC,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		$superglobals = $this->input_superglobals;
+
+		// Handling string interpolation.
+		if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $stackPtr ]['code']
+			|| T_HEREDOC === $this->tokens[ $stackPtr ]['code']
+		) {
+			$interpolated_variables = array_map(
+				function ( $symbol ) {
+					return '$' . $symbol;
+				},
+				$this->get_interpolated_variables( $this->tokens[ $stackPtr ]['content'] )
+			);
+			foreach ( array_intersect( $interpolated_variables, $superglobals ) as $bad_variable ) {
+				$this->phpcsFile->addError( 'Detected usage of a non-sanitized, non-validated input variable %s: %s', $stackPtr, 'InputNotValidatedNotSanitized', array( $bad_variable, $this->tokens[ $stackPtr ]['content'] ) );
+			}
+
+			return;
+		}
+
+		// Check if this is a superglobal.
+		if ( ! in_array( $this->tokens[ $stackPtr ]['content'], $superglobals, true ) ) {
+			return;
+		}
+
+		// If we're overriding a superglobal with an assignment, no need to test.
+		if ( $this->is_assignment( $stackPtr ) ) {
+			return;
+		}
+
+		// This superglobal is being validated.
+		if ( $this->is_in_isset_or_empty( $stackPtr ) ) {
+			return;
+		}
+
+		$array_key = $this->get_array_access_key( $stackPtr );
+
+		if ( empty( $array_key ) ) {
+			return;
+		}
+
+		$error_data = array( $this->tokens[ $stackPtr ]['content'] );
+
+		// Check for validation first.
+		if ( ! $this->is_validated( $stackPtr, $array_key, $this->check_validation_in_scope_only ) ) {
+			$this->phpcsFile->addError( 'Detected usage of a non-validated input variable: %s', $stackPtr, 'InputNotValidated', $error_data );
+			// return; // Should we just return and not look for sanitizing functions ?
+		}
+
+		if ( $this->has_whitelist_comment( 'sanitization', $stackPtr ) ) {
+			return;
+		}
+
+		// If this is a comparison ('a' == $_POST['foo']), sanitization isn't needed.
+		if ( $this->is_comparison( $stackPtr ) ) {
+			return;
+		}
+
+		$this->mergeFunctionLists();
+
+		// Now look for sanitizing functions.
+		if ( ! $this->is_sanitized( $stackPtr, true ) ) {
+			$this->phpcsFile->addError( 'Detected usage of a non-sanitized input variable: %s', $stackPtr, 'InputNotSanitized', $error_data );
+		}
+
+	} // End process_token().
+
+	/**
+	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.
+	 *
+	 * @since 0.11.0 Split out from the `process()` method.
+	 *
+	 * @return void
+	 */
+	protected function mergeFunctionLists() {
+		if ( $this->customSanitizingFunctions !== $this->addedCustomFunctions['sanitize'] ) {
+			$this->sanitizingFunctions = $this->merge_custom_array(
+				$this->customSanitizingFunctions,
+				$this->sanitizingFunctions
+			);
+
+			$this->addedCustomFunctions['sanitize'] = $this->customSanitizingFunctions;
+		}
+
+		if ( $this->customUnslashingSanitizingFunctions !== $this->addedCustomFunctions['unslashsanitize'] ) {
+			$this->unslashingSanitizingFunctions = $this->merge_custom_array(
+				$this->customUnslashingSanitizingFunctions,
+				$this->unslashingSanitizingFunctions
+			);
+
+			$this->addedCustomFunctions['unslashsanitize'] = $this->customUnslashingSanitizingFunctions;
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Variables/GlobalVariablesSniff.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Variables;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Warns about overwriting WordPress native global variables.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.4.0  This class now extends WordPress_Sniff.
+ * @since   0.12.0 The $wp_globals property has been moved to the WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @uses    \WordPress\Sniff::$custom_test_class_whitelist
+ */
+class GlobalVariablesSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_GLOBAL,
+			T_VARIABLE,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		$token = $this->tokens[ $stackPtr ];
+
+		if ( T_VARIABLE === $token['code'] && '$GLOBALS' === $token['content'] ) {
+			$bracketPtr = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+			if ( false === $bracketPtr || T_OPEN_SQUARE_BRACKET !== $this->tokens[ $bracketPtr ]['code'] || ! isset( $this->tokens[ $bracketPtr ]['bracket_closer'] ) ) {
+				return;
+			}
+
+			// Bow out if the array key contains a variable.
+			$has_variable = $this->phpcsFile->findNext( T_VARIABLE, ( $bracketPtr + 1 ), $this->tokens[ $bracketPtr ]['bracket_closer'] );
+			if ( false !== $has_variable ) {
+				return;
+			}
+
+			// Retrieve the array key and avoid getting tripped up by some simple obfuscation.
+			$var_name = '';
+			$start    = ( $bracketPtr + 1 );
+			for ( $ptr = $start; $ptr < $this->tokens[ $bracketPtr ]['bracket_closer']; $ptr++ ) {
+				if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $ptr ]['code'] ) {
+					$var_name .= $this->strip_quotes( $this->tokens[ $ptr ]['content'] );
+				}
+			}
+
+			if ( ! isset( $this->wp_globals[ $var_name ] ) ) {
+				return;
+			}
+
+			if ( true === $this->is_assignment( $this->tokens[ $bracketPtr ]['bracket_closer'] ) ) {
+				$this->maybe_add_error( $stackPtr );
+			}
+		} elseif ( T_GLOBAL === $token['code'] ) {
+			$search = array(); // Array of globals to watch for.
+			$ptr    = ( $stackPtr + 1 );
+			while ( $ptr ) {
+				if ( ! isset( $this->tokens[ $ptr ] ) ) {
+					break;
+				}
+
+				$var = $this->tokens[ $ptr ];
+
+				// Halt the loop at end of statement.
+				if ( T_SEMICOLON === $var['code'] ) {
+					break;
+				}
+
+				if ( T_VARIABLE === $var['code'] ) {
+					if ( isset( $this->wp_globals[ substr( $var['content'], 1 ) ] ) ) {
+						$search[] = $var['content'];
+					}
+				}
+
+				$ptr++;
+			}
+			unset( $var );
+
+			if ( empty( $search ) ) {
+				return;
+			}
+
+			// Only search from the end of the "global ...;" statement onwards.
+			$start        = ( $this->phpcsFile->findEndOfStatement( $stackPtr ) + 1 );
+			$end          = $this->phpcsFile->numTokens;
+			$global_scope = true;
+
+			// Is the global statement within a function call or closure ?
+			// If so, limit the token walking to the function scope.
+			$function_token = $this->phpcsFile->getCondition( $stackPtr, T_FUNCTION );
+			if ( false === $function_token ) {
+				$function_token = $this->phpcsFile->getCondition( $stackPtr, T_CLOSURE );
+			}
+
+			if ( false !== $function_token ) {
+				if ( ! isset( $this->tokens[ $function_token ]['scope_closer'] ) ) {
+					// Live coding, unfinished function.
+					return;
+				}
+
+				$end          = $this->tokens[ $function_token ]['scope_closer'];
+				$global_scope = false;
+			}
+
+			// Check for assignments to collected global vars.
+			for ( $ptr = $start; $ptr < $end; $ptr++ ) {
+
+				// If the global statement was in the global scope, skip over functions, classes and the likes.
+				if ( true === $global_scope && in_array( $this->tokens[ $ptr ]['code'], array( T_FUNCTION, T_CLOSURE, T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
+					if ( ! isset( $this->tokens[ $ptr ]['scope_closer'] ) ) {
+						// Live coding, skip the rest of the file.
+						return;
+					}
+
+					$ptr = $this->tokens[ $ptr ]['scope_closer'];
+					continue;
+				}
+
+				if ( T_VARIABLE === $this->tokens[ $ptr ]['code']
+					&& in_array( $this->tokens[ $ptr ]['content'], $search, true )
+				) {
+					// Don't throw false positives for static class properties.
+					$previous = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $ptr - 1 ), null, true, null, true );
+					if ( false !== $previous && T_DOUBLE_COLON === $this->tokens[ $previous ]['code'] ) {
+						continue;
+					}
+
+					if ( true === $this->is_assignment( $ptr ) ) {
+						$this->maybe_add_error( $ptr );
+					}
+				}
+			}
+		}
+
+	} // End process_token().
+
+	/**
+	 * Add the error if there is no whitelist comment present and the assignment
+	 * is not done from within a test method.
+	 *
+	 * @param int $stackPtr The position of the token to throw the error for.
+	 *
+	 * @return void
+	 */
+	public function maybe_add_error( $stackPtr ) {
+		if ( ! $this->is_token_in_test_method( $stackPtr ) && ! $this->has_whitelist_comment( 'override', $stackPtr ) ) {
+			$this->phpcsFile->addError( 'Overriding WordPress globals is prohibited', $stackPtr, 'OverrideProhibited' );
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/Variables/VariableRestrictionsSniff.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\Variables;
+
+use WordPress\AbstractVariableRestrictionsSniff;
+
+/**
+ * Restricts usage of some variables.
+ *
+ * @package    WPCS\WordPressCodingStandards
+ *
+ * @since      0.3.0
+ * @since      0.13.0 Class name changed: this class is now namespaced.
+ *
+ * @deprecated 0.10.0 The functionality which used to be contained in this class has been moved to
+ *                    the WordPress_AbstractVariableRestrictionsSniff class.
+ *                    This class is left here to prevent backward-compatibility breaks for
+ *                    custom sniffs extending the old class and references to this
+ *                    sniff from custom phpcs.xml files.
+ *                    This file is also still used to unit test the abstract class.
+ * @see        \WordPress\AbstractVariableRestrictionsSniff
+ */
+class VariableRestrictionsSniff extends AbstractVariableRestrictionsSniff {
+
+	/**
+	 * Groups of variables to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'wpdb' => array(
+	 *      'type'          => 'error' | 'warning',
+	 *      'message'       => 'Dont use this one please!',
+	 *      'variables'     => array( '$val', '$var' ),
+	 *      'object_vars'   => array( '$foo->bar', .. ),
+	 *      'array_members' => array( '$foo['bar']', .. ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array();
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WP/AlternativeFunctionsSniff.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Discourages the use of various functions and suggests (WordPress) alternatives.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class AlternativeFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'curl' => array(
+				'type'      => 'warning',
+				'message'   => 'Using cURL functions is highly discouraged. Use wp_remote_get() instead.',
+				'functions' => array(
+					'curl_*',
+				),
+			),
+
+			'parse_url' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is discouraged because of inconsistency in the output across PHP versions; use wp_parse_url() instead.',
+				'functions' => array(
+					'parse_url',
+				),
+			),
+
+			'json_encode' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is discouraged. Use wp_json_encode() instead.',
+				'functions' => array(
+					'json_encode',
+				),
+			),
+
+			'file_get_contents' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is discouraged. Use wp_remote_get() instead.',
+				'functions' => array(
+					'file_get_contents',
+				),
+			),
+
+			'file_system_read' => array(
+				'type'      => 'warning',
+				'message'   => 'File operations should use WP_Filesystem methods instead of direct PHP filesystem calls. Found: %s()',
+				'functions' => array(
+					'readfile',
+					'fopen',
+					'fsockopen',
+					'pfsockopen',
+					'fclose',
+					'fread',
+					'fwrite',
+					'file_put_contents',
+					'file_get_contents',
+				),
+			),
+
+		);
+	} // End getGroups().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WP/CapitalPDangitSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WP/CapitalPDangitSniff.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WP;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Capital P Dangit!
+ *
+ * Verify the correct spelling of `WordPress` in text strings, comments and class names.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class CapitalPDangitSniff extends Sniff {
+
+	/**
+	 * Regex to match a large number or spelling variations of WordPress in text strings.
+	 *
+	 * Prevents matches on:
+	 * - URLs for wordpress.org/com/net/tv.
+	 * - `@...` usernames starting with `wordpress`
+	 * - email addresses with a domain starting with `wordpress`
+	 * - email addresses with a user name ending with `wordpress`
+	 * - (most) variable names.
+	 * - directory paths containing a folder starting or ending with `wordpress`.
+	 * - file names containing `wordpress` for a limited set of extensions.
+	 * - `wordpress` prefixed or suffixed with dashes as those are indicators that the
+	 *   term is probably used as part of a CSS class, such as `fa-wordpress`
+	 *   or filename/path like `class-wordpress-importer.php`.
+	 * - back-tick quoted `wordpress`.
+	 *
+	 * @var string
+	 */
+	const WP_REGEX = '#(?<![\\\\/\$@`-])\b(Word[ _-]*Pres+)\b(?![@/`-]|\.(?:org|com|net|tv)|[^\s<>\'"()]*?\.(?:php|js|css|png|j[e]?pg|gif|pot))#i';
+
+	/**
+	 * Regex to match a large number or spelling variations of WordPress in class names.
+	 *
+	 * @var string
+	 */
+	const WP_CLASSNAME_REGEX = '`(?:^|_)(Word[_]*Pres+)(?:_|$)`i';
+
+	/**
+	 * String tokens we want to listen for.
+	 *
+	 * @var array
+	 */
+	private $text_string_tokens = array(
+		T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
+		T_DOUBLE_QUOTED_STRING     => T_DOUBLE_QUOTED_STRING,
+		T_HEREDOC                  => T_HEREDOC,
+		T_NOWDOC                   => T_NOWDOC,
+		T_INLINE_HTML              => T_INLINE_HTML,
+	);
+
+	/**
+	 * Comment tokens we want to listen for as they contain text strings.
+	 *
+	 * @var array
+	 */
+	private $comment_text_tokens = array(
+		T_DOC_COMMENT        => T_DOC_COMMENT,
+		T_DOC_COMMENT_STRING => T_DOC_COMMENT_STRING,
+		T_COMMENT            => T_COMMENT,
+	);
+
+	/**
+	 * Class-like structure tokens to listen for.
+	 *
+	 * Using proper spelling in class, interface and trait names does not conflict with the naming conventions.
+	 *
+	 * @var array
+	 */
+	private $class_tokens = array(
+		T_CLASS     => T_CLASS,
+		T_INTERFACE => T_INTERFACE,
+		T_TRAIT     => T_TRAIT,
+	);
+
+	/**
+	 * Combined text string and comment tokens array.
+	 *
+	 * This property is set in the register() method and used for lookups.
+	 *
+	 * @var array
+	 */
+	private $text_and_comment_tokens = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+		// Union the arrays - keeps the array keys.
+		$this->text_and_comment_tokens = ( $this->text_string_tokens + $this->comment_text_tokens );
+
+		$targets = ( $this->text_and_comment_tokens + $this->class_tokens );
+
+		// Also sniff for array tokens to make skipping anything within those more efficient.
+		$targets[ T_ARRAY ]            = T_ARRAY;
+		$targets[ T_OPEN_SHORT_ARRAY ] = T_OPEN_SHORT_ARRAY;
+
+		return $targets;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+
+		if ( $this->has_whitelist_comment( 'spelling', $stackPtr ) ) {
+			return;
+		}
+
+		/*
+		 * Ignore tokens within an array definition as this is a false positive in 80% of all cases.
+		 *
+		 * The return values skip to the end of the array.
+		 * This prevents the sniff "hanging" on very long configuration arrays.
+		 */
+		if ( T_OPEN_SHORT_ARRAY === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr ]['bracket_closer'] ) ) {
+			return $this->tokens[ $stackPtr ]['bracket_closer'];
+		} elseif ( T_ARRAY === $this->tokens[ $stackPtr ]['code'] && isset( $this->tokens[ $stackPtr ]['parenthesis_closer'] ) ) {
+			return $this->tokens[ $stackPtr ]['parenthesis_closer'];
+		}
+
+		/*
+		 * Deal with misspellings in class/interface/trait names.
+		 * These are not auto-fixable, but need the attention of a developer.
+		 */
+		if ( isset( $this->class_tokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
+			$classname = $this->phpcsFile->getDeclarationName( $stackPtr );
+			if ( empty( $classname ) ) {
+				return;
+			}
+
+			if ( preg_match_all( self::WP_CLASSNAME_REGEX, $classname, $matches, PREG_PATTERN_ORDER ) > 0 ) {
+				$mispelled = $this->retrieve_misspellings( $matches[1] );
+
+				if ( ! empty( $mispelled ) ) {
+					$this->phpcsFile->addWarning(
+						'Please spell "WordPress" correctly. Found: "%s" as part of the class/interface/trait name.',
+						$stackPtr,
+						'MisspelledClassName',
+						array( implode( ', ', $mispelled ) )
+					);
+				}
+			}
+
+			return;
+		}
+
+		/*
+		 * Deal with misspellings in text strings and documentation.
+		 */
+
+		// Ignore content of docblock @link tags.
+		if ( T_DOC_COMMENT_STRING === $this->tokens[ $stackPtr ]['code']
+			|| T_DOC_COMMENT === $this->tokens[ $stackPtr ]['code']
+		) {
+
+			$comment_start = $this->phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, ( $stackPtr - 1 ) );
+			if ( false !== $comment_start ) {
+				$comment_tag = $this->phpcsFile->findPrevious( T_DOC_COMMENT_TAG, ( $stackPtr - 1 ), $comment_start );
+				if ( false !== $comment_tag && '@link' === $this->tokens[ $comment_tag ]['content'] ) {
+					// @link tag, so ignore.
+					return;
+				}
+			}
+		}
+
+		// Ignore any text strings which are array keys `$var['key']` as this is a false positive in 80% of all cases.
+		if ( T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $stackPtr ]['code'] ) {
+			$prevToken = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true, null, true );
+			if ( false !== $prevToken && T_OPEN_SQUARE_BRACKET === $this->tokens[ $prevToken ]['code'] ) {
+				$nextToken = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true, null, true );
+				if ( false !== $nextToken && T_CLOSE_SQUARE_BRACKET === $this->tokens[ $nextToken ]['code'] ) {
+					return;
+				}
+			}
+		}
+
+		$content = $this->tokens[ $stackPtr ]['content'];
+
+		if ( preg_match_all( self::WP_REGEX, $content, $matches, ( PREG_PATTERN_ORDER | PREG_OFFSET_CAPTURE ) ) > 0 ) {
+			/*
+			 * Prevent some typical false positives.
+			 */
+			if ( isset( $this->text_and_comment_tokens[ $this->tokens[ $stackPtr ]['code'] ] ) ) {
+				$offset = 0;
+				foreach ( $matches[1] as $key => $match_data ) {
+					$next_offset = ( $match_data[1] + strlen( $match_data[0] ) );
+
+					// Prevent matches on part of a URL.
+					if ( preg_match( '`http[s]?://[^\s<>\'"()]*' . preg_quote( $match_data[0], '`' ) . '`', $content, $discard, 0, $offset ) === 1 ) {
+						unset( $matches[1][ $key ] );
+					} elseif ( preg_match( '`[a-z]+=(["\'])' . preg_quote( $match_data[0], '`' ) . '\1`', $content, $discard, 0, $offset ) === 1 ) {
+						// Prevent matches on html attributes like: `value="wordpress"`.
+						unset( $matches[1][ $key ] );
+					} elseif ( preg_match( '`\\\\\'' . preg_quote( $match_data[0], '`' ) . '\\\\\'`', $content, $discard, 0, $offset ) === 1 ) {
+						// Prevent matches on xpath queries and such: `\'wordpress\'`.
+						unset( $matches[1][ $key ] );
+					} elseif ( preg_match( '`(?:\?|&amp;|&)[a-z0-9_]+=' . preg_quote( $match_data[0], '`' ) . '(?:&|$)`', $content, $discard, 0, $offset ) === 1 ) {
+						// Prevent matches on url query strings: `?something=wordpress`.
+						unset( $matches[1][ $key ] );
+					}
+
+					$offset = $next_offset;
+				}
+
+				if ( empty( $matches[1] ) ) {
+					return;
+				}
+			}
+
+			$mispelled = $this->retrieve_misspellings( $matches[1] );
+
+			if ( empty( $mispelled ) ) {
+				return;
+			}
+
+			$fix = $this->phpcsFile->addFixableWarning(
+				'Please spell "WordPress" correctly. Found %s misspelling(s): %s',
+				$stackPtr,
+				'Misspelled',
+				array(
+					count( $mispelled ),
+					implode( ', ', $mispelled ),
+				)
+			);
+
+			if ( true === $fix ) {
+				// Apply fixes based on offset to ensure we don't replace false positives.
+				$replacement = $content;
+				foreach ( $matches[1] as $match ) {
+					$replacement = substr_replace( $replacement, 'WordPress', $match[1], strlen( $match[0] ) );
+				}
+
+				$this->phpcsFile->fixer->replaceToken( $stackPtr, $replacement );
+			}
+		}
+
+	} // End process_token().
+
+	/**
+	 * Retrieve a list of misspellings based on an array of matched variations on the target word.
+	 *
+	 * @param array $match_stack Array of matched variations of the target word.
+	 * @return array Array containing only the misspelled variants.
+	 */
+	protected function retrieve_misspellings( $match_stack ) {
+		$mispelled = array();
+		foreach ( $match_stack as $match ) {
+			// Deal with multi-dimensional arrays when capturing offset.
+			if ( is_array( $match ) ) {
+				$match = $match[0];
+			}
+
+			if ( 'WordPress' !== $match ) {
+				$mispelled[] = $match;
+			}
+		}
+
+		return $mispelled;
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WP/DeprecatedClassesSniff.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WP;
+
+use WordPress\AbstractClassRestrictionsSniff;
+
+/**
+ * Restricts the use of deprecated WordPress classes and suggests alternatives.
+ *
+ * This sniff will throw an error when usage of a deprecated class is detected
+ * if the class was deprecated before the minimum supported WP version;
+ * a warning otherwise.
+ * By default, it is set to presume that a project will support the current
+ * WP version and up to three releases before.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 Now has the ability to handle minimum supported WP version
+ *                 being provided via the command-line or as as <config> value
+ *                 in a custom ruleset.
+ *
+ * @uses    \WordPress\Sniff::$minimum_supported_version
+ */
+class DeprecatedClassesSniff extends AbstractClassRestrictionsSniff {
+
+	/**
+	 * List of deprecated classes with alternative when available.
+	 *
+	 * To be updated after every major release.
+	 *
+	 * Version numbers should be fully qualified.
+	 *
+	 * @var array
+	 */
+	private $deprecated_classes = array(
+
+		// WP 3.1.0.
+		'WP_User_Search' => array(
+			'alt'     => 'WP_User_Query',
+			'version' => '3.1.0',
+		),
+	);
+
+
+	/**
+	 * Groups of classes to restrict.
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		// Make sure all array keys are lowercase.
+		$keys                     = array_keys( $this->deprecated_classes );
+		$keys                     = array_map( 'strtolower', $keys );
+		$this->deprecated_classes = array_combine( $keys, $this->deprecated_classes );
+
+		return array(
+			'deprecated_classes' => array(
+				'classes' => $keys,
+			),
+		);
+
+	} // End getGroups().
+
+	/**
+	 * Process a matched token.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched. Will
+	 *                                always be 'deprecated_functions'.
+	 * @param string $matched_content The token content (class name) which was matched.
+	 *
+	 * @return void
+	 */
+	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
+
+		$this->get_wp_version_from_cl();
+
+		$class_name = ltrim( strtolower( $matched_content ), '\\' );
+
+		$message = 'The %s class has been deprecated since WordPress version %s.';
+		$data    = array(
+			ltrim( $matched_content, '\\' ),
+			$this->deprecated_classes[ $class_name ]['version'],
+		);
+
+		if ( ! empty( $this->deprecated_classes[ $class_name ]['alt'] ) ) {
+			$message .= ' Use %s instead.';
+			$data[]   = $this->deprecated_classes[ $class_name ]['alt'];
+		}
+
+		$this->addMessage(
+			$message,
+			$stackPtr,
+			( version_compare( $this->deprecated_classes[ $class_name ]['version'], $this->minimum_supported_version, '<' ) ),
+			$this->string_to_errorcode( $matched_content . 'Found' ),
+			$data
+		);
+
+	} // End process_matched_token().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WP/DeprecatedFunctionsSniff.php
@@ -1,0 +1,1359 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Restricts the use of various deprecated WordPress functions and suggests alternatives.
+ *
+ * This sniff will throw an error when usage of deprecated functions is detected
+ * if the function was deprecated before the minimum supported WP version;
+ * a warning otherwise.
+ * By default, it is set to presume that a project will support the current
+ * WP version and up to three releases before.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 Now has the ability to handle minimum supported WP version
+ *                 being provided via the command-line or as as <config> value
+ *                 in a custom ruleset.
+ *
+ * @uses    \WordPress\Sniff::$minimum_supported_version
+ */
+class DeprecatedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * List of deprecated functions with alternative when available.
+	 *
+	 * To be updated after every major release.
+	 * Last updated for WordPress 4.8.
+	 *
+	 * Version numbers should be fully qualified.
+	 * Replacement functions should have parentheses.
+	 *
+	 * To retrieve a function list for comparison, the following tool is available:
+	 * https://github.com/JDGrimes/wp-deprecated-code-scanner
+	 *
+	 * @var array
+	 */
+	private $deprecated_functions = array(
+
+		// WP 0.71.
+		'the_category_head' => array(
+			'alt'     => 'get_the_category_by_ID()',
+			'version' => '0.71',
+		),
+		'the_category_ID' => array(
+			'alt'     => 'get_the_category()',
+			'version' => '0.71',
+		),
+
+		// WP 1.2.0.
+		'permalink_link' => array(
+			'alt'     => 'the_permalink()',
+			'version' => '1.2.0',
+		),
+
+		// WP 1.5.0.
+		'start_wp' => array(
+			// Verified correct alternative.
+			'alt'     => 'the Loop',
+			'version' => '1.5.0',
+		),
+
+		// WP 1.5.1.
+		'get_postdata' => array(
+			'alt'     => 'get_post()',
+			'version' => '1.5.1',
+		),
+
+		// WP 2.0.0.
+		'create_user' => array(
+			'alt'     => 'wp_create_user()',
+			'version' => '2.0.0',
+		),
+		'next_post' => array(
+			'alt'     => 'next_post_link()',
+			'version' => '2.0.0',
+		),
+		'previous_post' => array(
+			'alt'     => 'previous_post_link()',
+			'version' => '2.0.0',
+		),
+		'user_can_create_draft' => array(
+			'alt'     => 'current_user_can()',
+			'version' => '2.0.0',
+		),
+		'user_can_create_post' => array(
+			'alt'     => 'current_user_can()',
+			'version' => '2.0.0',
+		),
+		'user_can_delete_post' => array(
+			'alt'     => 'current_user_can()',
+			'version' => '2.0.0',
+		),
+		'user_can_delete_post_comments' => array(
+			'alt'     => 'current_user_can()',
+			'version' => '2.0.0',
+		),
+		'user_can_edit_post' => array(
+			'alt'     => 'current_user_can()',
+			'version' => '2.0.0',
+		),
+		'user_can_edit_post_comments' => array(
+			'alt'     => 'current_user_can()',
+			'version' => '2.0.0',
+		),
+		'user_can_edit_post_date' => array(
+			'alt'     => 'current_user_can()',
+			'version' => '2.0.0',
+		),
+		'user_can_edit_user' => array(
+			'alt'     => 'current_user_can()',
+			'version' => '2.0.0',
+		),
+		'user_can_set_post_date' => array(
+			'alt'     => 'current_user_can()',
+			'version' => '2.0.0',
+		),
+
+		// WP 2.1.0.
+		'dropdown_cats' => array(
+			'alt'     => 'wp_dropdown_categories()',
+			'version' => '2.1.0',
+		),
+		'get_archives' => array(
+			'alt'     => 'wp_get_archives()',
+			'version' => '2.1.0',
+		),
+		'get_author_link' => array(
+			'alt'     => 'get_author_posts_url()',
+			'version' => '2.1.0',
+		),
+		'get_autotoggle' => array(
+			'alt'     => '',
+			'version' => '2.1.0',
+		),
+		'get_link' => array(
+			'alt'     => 'get_bookmark()',
+			'version' => '2.1.0',
+		),
+		'get_linkcatname' => array(
+			'alt'     => 'get_category()',
+			'version' => '2.1.0',
+		),
+		'get_linkobjects' => array(
+			'alt'     => 'get_bookmarks()',
+			'version' => '2.1.0',
+		),
+		'get_linkobjectsbyname' => array(
+			'alt'     => 'get_bookmarks()',
+			'version' => '2.1.0',
+		),
+		'get_linkrating' => array(
+			'alt'     => 'sanitize_bookmark_field()',
+			'version' => '2.1.0',
+		),
+		'get_links' => array(
+			'alt'     => 'get_bookmarks()',
+			'version' => '2.1.0',
+		),
+		'get_links_list' => array(
+			'alt'     => 'wp_list_bookmarks()',
+			'version' => '2.1.0',
+		),
+		'get_links_withrating' => array(
+			'alt'     => 'get_bookmarks()',
+			'version' => '2.1.0',
+		),
+		'get_linksbyname' => array(
+			'alt'     => 'get_bookmarks()',
+			'version' => '2.1.0',
+		),
+		'get_linksbyname_withrating' => array(
+			'alt'     => 'get_bookmarks()',
+			'version' => '2.1.0',
+		),
+		'get_settings' => array(
+			'alt'     => 'get_option()',
+			'version' => '2.1.0',
+		),
+		'link_pages' => array(
+			'alt'     => 'wp_link_pages()',
+			'version' => '2.1.0',
+		),
+		'links_popup_script' => array(
+			'alt'     => '',
+			'version' => '2.1.0',
+		),
+		'list_authors' => array(
+			'alt'     => 'wp_list_authors()',
+			'version' => '2.1.0',
+		),
+		'list_cats' => array(
+			'alt'     => 'wp_list_categories()',
+			'version' => '2.1.0',
+		),
+		'tinymce_include' => array(
+			'alt'     => 'wp_editor()',
+			'version' => '2.1.0',
+		),
+		'wp_get_links' => array(
+			'alt'     => 'wp_list_bookmarks()',
+			'version' => '2.1.0',
+		),
+		'wp_get_linksbyname' => array(
+			'alt'     => 'wp_list_bookmarks()',
+			'version' => '2.1.0',
+		),
+		'wp_get_post_cats' => array(
+			'alt'     => 'wp_get_post_categories()',
+			'version' => '2.1.0',
+		),
+		'wp_list_cats' => array(
+			'alt'     => 'wp_list_categories()',
+			'version' => '2.1.0',
+		),
+		'wp_set_post_cats' => array(
+			'alt'     => 'wp_set_post_categories()',
+			'version' => '2.1.0',
+		),
+
+		// WP 2.2.0.
+		'comments_rss' => array(
+			'alt'     => 'get_post_comments_feed_link()',
+			'version' => '2.2.0',
+		),
+
+		// WP 2.3.0.
+		'permalink_single_rss' => array(
+			'alt'     => 'the_permalink_rss()',
+			'version' => '2.3.0',
+		),
+
+		// WP 2.5.0.
+		'comments_rss_link' => array(
+			'alt'     => 'post_comments_feed_link()',
+			'version' => '2.5.0',
+		),
+		'documentation_link' => array(
+			'alt'     => '',
+			'version' => '2.5.0',
+		),
+		'get_attachment_icon' => array(
+			'alt'     => 'wp_get_attachment_image()',
+			'version' => '2.5.0',
+		),
+		'get_attachment_icon_src' => array(
+			'alt'     => 'wp_get_attachment_image_src()',
+			'version' => '2.5.0',
+		),
+		'get_attachment_innerHTML' => array(
+			'alt'     => 'wp_get_attachment_image()',
+			'version' => '2.5.0',
+		),
+		'get_author_rss_link' => array(
+			'alt'     => 'get_author_feed_link()',
+			'version' => '2.5.0',
+		),
+		'get_category_rss_link' => array(
+			'alt'     => 'get_category_feed_link()',
+			'version' => '2.5.0',
+		),
+		'get_the_attachment_link' => array(
+			'alt'     => 'wp_get_attachment_link()',
+			'version' => '2.5.0',
+		),
+		'gzip_compression' => array(
+			'alt'     => '',
+			'version' => '2.5.0',
+		),
+		'wp_clearcookie' => array(
+			'alt'     => 'wp_clear_auth_cookie()',
+			'version' => '2.5.0',
+		),
+		'wp_get_cookie_login' => array(
+			'alt'     => '',
+			'version' => '2.5.0',
+		),
+		'wp_login' => array(
+			'alt'     => 'wp_signon()',
+			'version' => '2.5.0',
+		),
+		'wp_setcookie' => array(
+			'alt'     => 'wp_set_auth_cookie()',
+			'version' => '2.5.0',
+		),
+
+		// WP 2.6.0.
+		'dropdown_categories' => array(
+			'alt'     => 'wp_category_checklist()',
+			'version' => '2.6.0',
+		),
+		'dropdown_link_categories' => array(
+			'alt'     => 'wp_link_category_checklist()',
+			'version' => '2.6.0',
+		),
+
+		// WP 2.7.0.
+		'get_commentdata' => array(
+			'alt'     => 'get_comment()',
+			'version' => '2.7.0',
+		),
+		// This is a method i.e. WP_Filesystem_Base::find_base_dir() See #731.
+		'find_base_dir' => array(
+			'alt'     => 'WP_Filesystem::abspath()',
+			'version' => '2.7.0',
+		),
+		// This is a method i.e. WP_Filesystem_Base::get_base_dir() See #731.
+		'get_base_dir' => array(
+			'alt'     => 'WP_Filesystem::abspath()',
+			'version' => '2.7.0',
+		),
+
+		// WP 2.8.0.
+		'__ngettext' => array(
+			'alt'     => '_n()',
+			'version' => '2.8.0',
+		),
+		'__ngettext_noop' => array(
+			'alt'     => '_n_noop()',
+			'version' => '2.8.0',
+		),
+		'attribute_escape' => array(
+			'alt'     => 'esc_attr()',
+			'version' => '2.8.0',
+		),
+		'get_author_name' => array(
+			'alt'     => 'get_the_author_meta(\'display_name\')',
+			'version' => '2.8.0',
+		),
+		'get_category_children' => array(
+			'alt'     => 'get_term_children()',
+			'version' => '2.8.0',
+		),
+		'get_catname' => array(
+			'alt'     => 'get_cat_name()',
+			'version' => '2.8.0',
+		),
+		'get_the_author_aim' => array(
+			'alt'     => 'get_the_author_meta(\'aim\')',
+			'version' => '2.8.0',
+		),
+		'get_the_author_description' => array(
+			'alt'     => 'get_the_author_meta(\'description\')',
+			'version' => '2.8.0',
+		),
+		'get_the_author_email' => array(
+			'alt'     => 'get_the_author_meta(\'email\')',
+			'version' => '2.8.0',
+		),
+		'get_the_author_firstname' => array(
+			'alt'     => 'get_the_author_meta(\'first_name\')',
+			'version' => '2.8.0',
+		),
+		'get_the_author_icq' => array(
+			'alt'     => 'get_the_author_meta(\'icq\')',
+			'version' => '2.8.0',
+		),
+		'get_the_author_ID' => array(
+			'alt'     => 'get_the_author_meta(\'ID\')',
+			'version' => '2.8.0',
+		),
+		'get_the_author_lastname' => array(
+			'alt'     => 'get_the_author_meta(\'last_name\')',
+			'version' => '2.8.0',
+		),
+		'get_the_author_login' => array(
+			'alt'     => 'get_the_author_meta(\'login\')',
+			'version' => '2.8.0',
+		),
+		'get_the_author_msn' => array(
+			'alt'     => 'get_the_author_meta(\'msn\')',
+			'version' => '2.8.0',
+		),
+		'get_the_author_nickname' => array(
+			'alt'     => 'get_the_author_meta(\'nickname\')',
+			'version' => '2.8.0',
+		),
+		'get_the_author_url' => array(
+			'alt'     => 'get_the_author_meta(\'url\')',
+			'version' => '2.8.0',
+		),
+		'get_the_author_yim' => array(
+			'alt'     => 'get_the_author_meta(\'yim\')',
+			'version' => '2.8.0',
+		),
+		'js_escape' => array(
+			'alt'     => 'esc_js()',
+			'version' => '2.8.0',
+		),
+		'register_sidebar_widget' => array(
+			'alt'     => 'wp_register_sidebar_widget()',
+			'version' => '2.8.0',
+		),
+		'register_widget_control' => array(
+			'alt'     => 'wp_register_widget_control()',
+			'version' => '2.8.0',
+		),
+		'sanitize_url' => array(
+			'alt'     => 'esc_url_raw()',
+			'version' => '2.8.0',
+		),
+		'the_author_aim' => array(
+			'alt'     => 'the_author_meta(\'aim\')',
+			'version' => '2.8.0',
+		),
+		'the_author_description' => array(
+			'alt'     => 'the_author_meta(\'description\')',
+			'version' => '2.8.0',
+		),
+		'the_author_email' => array(
+			'alt'     => 'the_author_meta(\'email\')',
+			'version' => '2.8.0',
+		),
+		'the_author_firstname' => array(
+			'alt'     => 'the_author_meta(\'first_name\')',
+			'version' => '2.8.0',
+		),
+		'the_author_icq' => array(
+			'alt'     => 'the_author_meta(\'icq\')',
+			'version' => '2.8.0',
+		),
+		'the_author_ID' => array(
+			'alt'     => 'the_author_meta(\'ID\')',
+			'version' => '2.8.0',
+		),
+		'the_author_lastname' => array(
+			'alt'     => 'the_author_meta(\'last_name\')',
+			'version' => '2.8.0',
+		),
+		'the_author_login' => array(
+			'alt'     => 'the_author_meta(\'login\')',
+			'version' => '2.8.0',
+		),
+		'the_author_msn' => array(
+			'alt'     => 'the_author_meta(\'msn\')',
+			'version' => '2.8.0',
+		),
+		'the_author_nickname' => array(
+			'alt'     => 'the_author_meta(\'nickname\')',
+			'version' => '2.8.0',
+		),
+		'the_author_url' => array(
+			'alt'     => 'the_author_meta(\'url\')',
+			'version' => '2.8.0',
+		),
+		'the_author_yim' => array(
+			'alt'     => 'the_author_meta(\'yim\')',
+			'version' => '2.8.0',
+		),
+		'unregister_sidebar_widget' => array(
+			'alt'     => 'wp_unregister_sidebar_widget()',
+			'version' => '2.8.0',
+		),
+		'unregister_widget_control' => array(
+			'alt'     => 'wp_unregister_widget_control()',
+			'version' => '2.8.0',
+		),
+		'wp_specialchars' => array(
+			'alt'     => 'esc_html()',
+			'version' => '2.8.0',
+		),
+
+		// WP 2.9.0.
+		'_c' => array(
+			'alt'     => '_x()',
+			'version' => '2.9.0',
+		),
+		'_nc' => array(
+			'alt'     => '_nx()',
+			'version' => '2.9.0',
+		),
+		'get_real_file_to_edit' => array(
+			'alt'     => '',
+			'version' => '2.9.0',
+		),
+		'make_url_footnote' => array(
+			'alt'     => '',
+			'version' => '2.9.0',
+		),
+		'the_content_rss' => array(
+			'alt'     => 'the_content_feed()',
+			'version' => '2.9.0',
+		),
+		'translate_with_context' => array(
+			'alt'     => '_x()',
+			'version' => '2.9.0',
+		),
+
+		// WP 3.0.0.
+		'activate_sitewide_plugin' => array(
+			'alt'     => 'activate_plugin()',
+			'version' => '3.0.0',
+		),
+		'add_option_update_handler' => array(
+			'alt'     => 'register_setting()',
+			'version' => '3.0.0',
+		),
+		'automatic_feed_links' => array(
+			'alt'     => 'add_theme_support( \'automatic-feed-links\' )',
+			'version' => '3.0.0',
+		),
+		'clean_url' => array(
+			'alt'     => 'esc_url()',
+			'version' => '3.0.0',
+		),
+		'clear_global_post_cache' => array(
+			'alt'     => 'clean_post_cache()',
+			'version' => '3.0.0',
+		),
+		'codepress_footer_js' => array(
+			'alt'     => '',
+			'version' => '3.0.0',
+		),
+		'codepress_get_lang' => array(
+			'alt'     => '',
+			'version' => '3.0.0',
+		),
+		'deactivate_sitewide_plugin' => array(
+			'alt'     => 'deactivate_plugin()',
+			'version' => '3.0.0',
+		),
+		'delete_usermeta' => array(
+			'alt'     => 'delete_user_meta()',
+			'version' => '3.0.0',
+		),
+		'funky_javascript_callback' => array(
+			'alt'     => '',
+			'version' => '3.0.0',
+		),
+		'funky_javascript_fix' => array(
+			'alt'     => '',
+			'version' => '3.0.0',
+		),
+		'generate_random_password' => array(
+			'alt'     => 'wp_generate_password()',
+			'version' => '3.0.0',
+		),
+		'get_alloptions' => array(
+			'alt'     => 'wp_load_alloptions()',
+			'version' => '3.0.0',
+		),
+		'get_blog_list' => array(
+			'alt'     => 'wp_get_sites()',
+			'version' => '3.0.0',
+		),
+		'get_most_active_blogs' => array(
+			'alt'     => '',
+			'version' => '3.0.0',
+		),
+		'get_profile' => array(
+			'alt'     => 'get_the_author_meta()',
+			'version' => '3.0.0',
+		),
+		'get_user_details' => array(
+			'alt'     => 'get_user_by()',
+			'version' => '3.0.0',
+		),
+		'get_usermeta' => array(
+			'alt'     => 'get_user_meta()',
+			'version' => '3.0.0',
+		),
+		'get_usernumposts' => array(
+			'alt'     => 'count_user_posts()',
+			'version' => '3.0.0',
+		),
+		'graceful_fail' => array(
+			'alt'     => 'wp_die()',
+			'version' => '3.0.0',
+		),
+		'is_main_blog' => array(
+			'alt'     => 'is_main_site()',
+			'version' => '3.0.0',
+		),
+		'is_site_admin' => array(
+			'alt'     => 'is_super_admin()',
+			'version' => '3.0.0',
+		),
+		'is_taxonomy' => array(
+			'alt'     => 'taxonomy_exists()',
+			'version' => '3.0.0',
+		),
+		'is_term' => array(
+			'alt'     => 'term_exists()',
+			'version' => '3.0.0',
+		),
+		'is_wpmu_sitewide_plugin' => array(
+			'alt'     => 'is_network_only_plugin()',
+			'version' => '3.0.0',
+		),
+		'mu_options' => array(
+			'alt'     => '',
+			'version' => '3.0.0',
+		),
+		'remove_option_update_handler' => array(
+			'alt'     => 'unregister_setting()',
+			'version' => '3.0.0',
+		),
+		'set_current_user' => array(
+			'alt'     => 'wp_set_current_user()',
+			'version' => '3.0.0',
+		),
+		'update_usermeta' => array(
+			'alt'     => 'update_user_meta()',
+			'version' => '3.0.0',
+		),
+		'use_codepress' => array(
+			'alt'     => '',
+			'version' => '3.0.0',
+		),
+		'validate_email' => array(
+			'alt'     => 'is_email()',
+			'version' => '3.0.0',
+		),
+		'wp_dropdown_cats' => array(
+			'alt'     => 'wp_dropdown_categories()',
+			'version' => '3.0.0',
+		),
+		'wp_shrink_dimensions' => array(
+			'alt'     => 'wp_constrain_dimensions()',
+			'version' => '3.0.0',
+		),
+		'wpmu_checkAvailableSpace' => array(
+			'alt'     => 'is_upload_space_available()',
+			'version' => '3.0.0',
+		),
+		'wpmu_menu' => array(
+			'alt'     => '',
+			'version' => '3.0.0',
+		),
+
+		// WP 3.1.0.
+		'get_author_user_ids' => array(
+			'alt'     => 'get_users()',
+			'version' => '3.1.0',
+		),
+		'get_dashboard_blog' => array(
+			'alt'     => '',
+			'version' => '3.1.0',
+		),
+		'get_editable_authors' => array(
+			'alt'     => 'get_users()',
+			'version' => '3.1.0',
+		),
+		'get_editable_user_ids' => array(
+			'alt'     => 'get_users()',
+			'version' => '3.1.0',
+		),
+		'get_nonauthor_user_ids' => array(
+			'alt'     => 'get_users()',
+			'version' => '3.1.0',
+		),
+		'get_others_drafts' => array(
+			'alt'     => '',
+			'version' => '3.1.0',
+		),
+		'get_others_pending' => array(
+			'alt'     => '',
+			'version' => '3.1.0',
+		),
+		'get_others_unpublished_posts' => array(
+			'alt'     => '',
+			'version' => '3.1.0',
+		),
+		'get_users_of_blog' => array(
+			'alt'     => 'get_users()',
+			'version' => '3.1.0',
+		),
+		'install_themes_feature_list' => array(
+			'alt'     => 'get_theme_feature_list()',
+			'version' => '3.1.0',
+		),
+		'is_plugin_page' => array(
+			// Verified correct alternative.
+			'alt'     => 'global $plugin_page and/or get_plugin_page_hookname() hooks',
+			'version' => '3.1.0',
+		),
+		'update_category_cache' => array(
+			'alt'     => '',
+			'version' => '3.1.0',
+		),
+
+		// WP 3.2.0.
+		'favorite_actions' => array(
+			'alt'     => 'WP_Admin_Bar',
+			'version' => '3.2.0',
+		),
+		'wp_dashboard_quick_press_output' => array(
+			'alt'     => 'wp_dashboard_quick_press()',
+			'version' => '3.2.0',
+		),
+		'wp_timezone_supported' => array(
+			'alt'     => '',
+			'version' => '3.2.0',
+		),
+
+		// WP 3.3.0.
+		'add_contextual_help' => array(
+			'alt'     => 'get_current_screen()->add_help_tab()',
+			'version' => '3.3.0',
+		),
+		'get_boundary_post_rel_link' => array(
+			'alt'     => '',
+			'version' => '3.3.0',
+		),
+		'get_index_rel_link' => array(
+			'alt'     => '',
+			'version' => '3.3.0',
+		),
+		'get_parent_post_rel_link' => array(
+			'alt'     => '',
+			'version' => '3.3.0',
+		),
+		'get_user_by_email' => array(
+			'alt'     => 'get_user_by(\'email\')',
+			'version' => '3.3.0',
+		),
+		'get_user_metavalues' => array(
+			'alt'     => '',
+			'version' => '3.3.0',
+		),
+		'get_userdatabylogin' => array(
+			'alt'     => 'get_user_by(\'login\')',
+			'version' => '3.3.0',
+		),
+		'index_rel_link' => array(
+			'alt'     => '',
+			'version' => '3.3.0',
+		),
+		'is_blog_user' => array(
+			'alt'     => 'is_user_member_of_blog()',
+			'version' => '3.3.0',
+		),
+		'media_upload_audio' => array(
+			'alt'     => 'wp_media_upload_handler()',
+			'version' => '3.3.0',
+		),
+		'media_upload_file' => array(
+			'alt'     => 'wp_media_upload_handler()',
+			'version' => '3.3.0',
+		),
+		'media_upload_image' => array(
+			'alt'     => 'wp_media_upload_handler()',
+			'version' => '3.3.0',
+		),
+		'media_upload_video' => array(
+			'alt'     => 'wp_media_upload_handler()',
+			'version' => '3.3.0',
+		),
+		'parent_post_rel_link' => array(
+			'alt'     => '',
+			'version' => '3.3.0',
+		),
+		'sanitize_user_object' => array(
+			'alt'     => '',
+			'version' => '3.3.0',
+		),
+		'screen_layout' => array(
+			'alt'     => '$current_screen->render_screen_layout()',
+			'version' => '3.3.0',
+		),
+		'screen_meta' => array(
+			'alt'     => '$current_screen->render_screen_meta()',
+			'version' => '3.3.0',
+		),
+		'screen_options' => array(
+			'alt'     => '$current_screen->render_per_page_options()',
+			'version' => '3.3.0',
+		),
+		'start_post_rel_link' => array(
+			'alt'     => '',
+			'version' => '3.3.0',
+		),
+		'the_editor' => array(
+			'alt'     => 'wp_editor()',
+			'version' => '3.3.0',
+		),
+		'type_url_form_audio' => array(
+			'alt'     => 'wp_media_insert_url_form(\'audio\')',
+			'version' => '3.3.0',
+		),
+		'type_url_form_file' => array(
+			'alt'     => 'wp_media_insert_url_form(\'file\')',
+			'version' => '3.3.0',
+		),
+		'type_url_form_image' => array(
+			'alt'     => 'wp_media_insert_url_form(\'image\')',
+			'version' => '3.3.0',
+		),
+		'type_url_form_video' => array(
+			'alt'     => 'wp_media_insert_url_form(\'video\')',
+			'version' => '3.3.0',
+		),
+		'wp_admin_bar_dashboard_view_site_menu' => array(
+			'alt'     => '',
+			'version' => '3.3.0',
+		),
+		'wp_preload_dialogs' => array(
+			'alt'     => 'wp_editor()',
+			'version' => '3.3.0',
+		),
+		'wp_print_editor_js' => array(
+			'alt'     => 'wp_editor()',
+			'version' => '3.3.0',
+		),
+		'wp_quicktags' => array(
+			'alt'     => 'wp_editor()',
+			'version' => '3.3.0',
+		),
+		'wp_tiny_mce' => array(
+			'alt'     => 'wp_editor()',
+			'version' => '3.3.0',
+		),
+		'wpmu_admin_do_redirect' => array(
+			'alt'     => '',
+			'version' => '3.3.0',
+		),
+		'wpmu_admin_redirect_add_updated_param' => array(
+			'alt'     => '',
+			'version' => '3.3.0',
+		),
+
+		// WP 3.4.0.
+		'add_custom_background' => array(
+			'alt'     => 'add_theme_support( \'custom-background\', $args )',
+			'version' => '3.4.0',
+		),
+		'add_custom_image_header' => array(
+			'alt'     => 'add_theme_support( \'custom-header\', $args )',
+			'version' => '3.4.0',
+		),
+		'clean_page_cache' => array(
+			'alt'     => 'clean_post_cache()',
+			'version' => '3.4.0',
+		),
+		'clean_pre' => array(
+			'alt'     => '',
+			'version' => '3.4.0',
+		),
+		'current_theme_info' => array(
+			'alt'     => 'wp_get_theme()',
+			'version' => '3.4.0',
+		),
+		'debug_fclose' => array(
+			'alt'     => 'error_log()',
+			'version' => '3.4.0',
+		),
+		'debug_fopen' => array(
+			'alt'     => 'error_log()',
+			'version' => '3.4.0',
+		),
+		'debug_fwrite' => array(
+			'alt'     => 'error_log()',
+			'version' => '3.4.0',
+		),
+		'display_theme' => array(
+			'alt'     => '',
+			'version' => '3.4.0',
+		),
+		'get_allowed_themes' => array(
+			'alt'     => 'wp_get_themes( array( \'allowed\' => true ) )',
+			'version' => '3.4.0',
+		),
+		'get_broken_themes' => array(
+			'alt'     => 'wp_get_themes( array( \'errors\' => true )',
+			'version' => '3.4.0',
+		),
+		'get_current_theme' => array(
+			'alt'     => 'wp_get_theme()',
+			'version' => '3.4.0',
+		),
+		'get_site_allowed_themes' => array(
+			'alt'     => 'WP_Theme::get_allowed_on_network()',
+			'version' => '3.4.0',
+		),
+		'get_theme' => array(
+			'alt'     => 'wp_get_theme( $stylesheet )',
+			'version' => '3.4.0',
+		),
+		'get_theme_data' => array(
+			'alt'     => 'wp_get_theme()',
+			'version' => '3.4.0',
+		),
+		'get_themes' => array(
+			'alt'     => 'wp_get_themes()',
+			'version' => '3.4.0',
+		),
+		'logIO' => array(
+			'alt'     => 'error_log()',
+			'version' => '3.4.0',
+		),
+		'remove_custom_background' => array(
+			'alt'     => 'remove_theme_support( \'custom-background\' )',
+			'version' => '3.4.0',
+		),
+		'remove_custom_image_header' => array(
+			'alt'     => 'remove_theme_support( \'custom-header\' )',
+			'version' => '3.4.0',
+		),
+		'update_page_cache' => array(
+			'alt'     => 'update_post_cache()',
+			'version' => '3.4.0',
+		),
+		'wpmu_get_blog_allowedthemes' => array(
+			'alt'     => 'WP_Theme::get_allowed_on_site()',
+			'version' => '3.4.0',
+		),
+
+		// WP 3.4.1.
+		'wp_explain_nonce' => array(
+			'alt'     => 'wp_nonce_ays()',
+			'version' => '3.4.1',
+		),
+
+		// WP 3.5.0.
+		'_flip_image_resource' => array(
+			'alt'     => 'WP_Image_Editor::flip()',
+			'version' => '3.5.0',
+		),
+		'_get_post_ancestors' => array(
+			'alt'     => '',
+			'version' => '3.5.0',
+		),
+		'_insert_into_post_button' => array(
+			'alt'     => '',
+			'version' => '3.5.0',
+		),
+		'_media_button' => array(
+			'alt'     => '',
+			'version' => '3.5.0',
+		),
+		'_rotate_image_resource' => array(
+			'alt'     => 'WP_Image_Editor::rotate()',
+			'version' => '3.5.0',
+		),
+		'_save_post_hook' => array(
+			'alt'     => '',
+			'version' => '3.5.0',
+		),
+		'gd_edit_image_support' => array(
+			'alt'     => 'wp_image_editor_supports()',
+			'version' => '3.5.0',
+		),
+		'get_default_page_to_edit' => array(
+			'alt'     => 'get_default_post_to_edit( \'page\' )',
+			'version' => '3.5.0',
+		),
+		'get_post_to_edit' => array(
+			'alt'     => 'get_post()',
+			'version' => '3.5.0',
+		),
+		'get_udims' => array(
+			'alt'     => 'wp_constrain_dimensions()',
+			'version' => '3.5.0',
+		),
+		'image_resize' => array(
+			'alt'     => 'wp_get_image_editor()',
+			'version' => '3.5.0',
+		),
+		'sticky_class' => array(
+			'alt'     => 'post_class()',
+			'version' => '3.5.0',
+		),
+		'user_pass_ok' => array(
+			'alt'     => 'wp_authenticate()',
+			'version' => '3.5.0',
+		),
+		'wp_cache_reset' => array(
+			'alt'     => '',
+			'version' => '3.5.0',
+		),
+		'wp_create_thumbnail' => array(
+			'alt'     => 'image_resize()',
+			'version' => '3.5.0',
+		),
+		'wp_get_single_post' => array(
+			'alt'     => 'get_post()',
+			'version' => '3.5.0',
+		),
+		'wp_load_image' => array(
+			'alt'     => 'wp_get_image_editor()',
+			'version' => '3.5.0',
+		),
+
+		// WP 3.6.0.
+		'get_user_id_from_string' => array(
+			'alt'     => 'get_user_by()',
+			'version' => '3.6.0',
+		),
+		'wp_convert_bytes_to_hr' => array(
+			'alt'     => 'size_format()',
+			'version' => '3.6.0',
+		),
+		'wp_nav_menu_locations_meta_box' => array(
+			'alt'     => '',
+			'version' => '3.6.0',
+		),
+
+		// WP 3.7.0.
+		'_search_terms_tidy' => array(
+			'alt'     => '',
+			'version' => '3.7.0',
+		),
+		'get_blogaddress_by_domain' => array(
+			'alt'     => '',
+			'version' => '3.7.0',
+		),
+		'the_attachment_links' => array(
+			'alt'     => '',
+			'version' => '3.7.0',
+		),
+		'wp_update_core' => array(
+			'alt'     => 'new Core_Upgrader();',
+			'version' => '3.7.0',
+		),
+		'wp_update_plugin' => array(
+			'alt'     => 'new Plugin_Upgrader();',
+			'version' => '3.7.0',
+		),
+		'wp_update_theme' => array(
+			'alt'     => 'new Theme_Upgrader();',
+			'version' => '3.7.0',
+		),
+
+		// WP 3.8.0.
+		'get_screen_icon' => array(
+			'alt'     => '',
+			'version' => '3.8.0',
+		),
+		'screen_icon' => array(
+			'alt'     => '',
+			'version' => '3.8.0',
+		),
+		'wp_dashboard_incoming_links' => array(
+			'alt'     => '',
+			'version' => '3.8.0',
+		),
+		'wp_dashboard_incoming_links_control' => array(
+			'alt'     => '',
+			'version' => '3.8.0',
+		),
+		'wp_dashboard_incoming_links_output' => array(
+			'alt'     => '',
+			'version' => '3.8.0',
+		),
+		'wp_dashboard_plugins' => array(
+			'alt'     => '',
+			'version' => '3.8.0',
+		),
+		'wp_dashboard_primary_control' => array(
+			'alt'     => '',
+			'version' => '3.8.0',
+		),
+		'wp_dashboard_recent_comments_control' => array(
+			'alt'     => '',
+			'version' => '3.8.0',
+		),
+		'wp_dashboard_secondary' => array(
+			'alt'     => '',
+			'version' => '3.8.0',
+		),
+		'wp_dashboard_secondary_control' => array(
+			'alt'     => '',
+			'version' => '3.8.0',
+		),
+		'wp_dashboard_secondary_output' => array(
+			'alt'     => '',
+			'version' => '3.8.0',
+		),
+
+		// WP 3.9.0.
+		'_relocate_children' => array(
+			'alt'     => '',
+			'version' => '3.9.0',
+		),
+		'default_topic_count_text' => array(
+			'alt'     => '',
+			'version' => '3.9.0',
+		),
+		'format_to_post' => array(
+			'alt'     => '',
+			'version' => '3.9.0',
+		),
+		'get_current_site_name' => array(
+			'alt'     => 'get_current_site()',
+			'version' => '3.9.0',
+		),
+		'rich_edit_exists' => array(
+			'alt'     => '',
+			'version' => '3.9.0',
+		),
+		'wpmu_current_site' => array(
+			'alt'     => '',
+			'version' => '3.9.0',
+		),
+
+		// WP 4.0.0.
+		'get_all_category_ids' => array(
+			'alt'     => 'get_terms()',
+			'version' => '4.0.0',
+		),
+		'like_escape' => array(
+			'alt'     => 'wpdb::esc_like()',
+			'version' => '4.0.0',
+		),
+		'url_is_accessable_via_ssl' => array(
+			'alt'     => '',
+			'version' => '4.0.0',
+		),
+
+		// WP 4.1.0.
+		// This is a method from the WP_Customize_Image_Control class. See #731.
+		'add_tab' => array(
+			'alt'     => '',
+			'version' => '4.1.0',
+		),
+		// This is a method from the WP_Customize_Image_Control class. See #731.
+		'prepare_control' => array(
+			'alt'     => '',
+			'version' => '4.1.0',
+		),
+		// This is a method from the WP_Customize_Image_Control class. See #731.
+		'print_tab_image' => array(
+			'alt'     => '',
+			'version' => '4.1.0',
+		),
+		// This is a method from the WP_Customize_Image_Control class. See #731.
+		'remove_tab' => array(
+			'alt'     => '',
+			'version' => '4.1.0',
+		),
+
+		// WP 4.2.0.
+		// This is a method from the WP_Customize_Widgets class. See #731.
+		'prepreview_added_sidebars_widgets' => array(
+			'alt'     => 'the \'customize_dynamic_setting_args\' filter',
+			'version' => '4.2.0',
+		),
+		// This is a method from the WP_Customize_Widgets class. See #731.
+		'prepreview_added_widget_instance' => array(
+			'alt'     => 'the \'customize_dynamic_setting_args\' filter',
+			'version' => '4.2.0',
+		),
+		// This is a method from the WP_Customize_Widgets class. See #731.
+		'remove_prepreview_filters' => array(
+			'alt'     => 'the \'customize_dynamic_setting_args\' filter',
+			'version' => '4.2.0',
+		),
+		// This is a method from the WP_Customize_Widgets class. See #731.
+		'setup_widget_addition_previews' => array(
+			'alt'     => 'the \'customize_dynamic_setting_args\' filter',
+			'version' => '4.2.0',
+		),
+
+		// WP 4.3.0.
+		'_preview_theme_stylesheet_filter' => array(
+			'alt'     => '',
+			'version' => '4.3.0',
+		),
+		'_preview_theme_template_filter' => array(
+			'alt'     => '',
+			'version' => '4.3.0',
+		),
+		'preview_theme' => array(
+			'alt'     => '',
+			'version' => '4.3.0',
+		),
+		'preview_theme_ob_filter' => array(
+			'alt'     => '',
+			'version' => '4.3.0',
+		),
+		'preview_theme_ob_filter_callback' => array(
+			'alt'     => '',
+			'version' => '4.3.0',
+		),
+		'wp_ajax_wp_fullscreen_save_post' => array(
+			'alt'     => '',
+			'version' => '4.3.0',
+		),
+		'wp_htmledit_pre' => array(
+			'alt'     => 'format_for_editor()',
+			'version' => '4.3.0',
+		),
+		'wp_richedit_pre' => array(
+			'alt'     => 'format_for_editor()',
+			'version' => '4.3.0',
+		),
+
+		// WP 4.4.0.
+		'create_empty_blog' => array(
+			'alt'     => '',
+			'version' => '4.4.0',
+		),
+		'force_ssl_login' => array(
+			'alt'     => 'force_ssl_admin()',
+			'version' => '4.4.0',
+		),
+		'get_admin_users_for_domain' => array(
+			'alt'     => '',
+			'version' => '4.4.0',
+		),
+		'post_permalink' => array(
+			'alt'     => 'get_permalink()',
+			'version' => '4.4.0',
+		),
+		'wp_get_http' => array(
+			'alt'     => 'the WP_Http class',
+			'version' => '4.4.0',
+		),
+		// This is a method i.e. WP_Widget_Recent_Comments::flush_widget_cache() See #731.
+		'flush_widget_cache' => array(
+			'alt'     => '',
+			'version' => '4.4.0',
+		),
+
+		// WP 4.5.0.
+		'add_object_page' => array(
+			'alt'     => 'add_menu_page()',
+			'version' => '4.5.0',
+		),
+		'add_utility_page' => array(
+			'alt'     => 'add_menu_page()',
+			'version' => '4.5.0',
+		),
+		'comments_popup_script' => array(
+			'alt'     => '',
+			'version' => '4.5.0',
+		),
+		'get_comments_popup_template' => array(
+			'alt'     => '',
+			'version' => '4.5.0',
+		),
+		'get_currentuserinfo' => array(
+			'alt'     => 'wp_get_current_user()',
+			'version' => '4.5.0',
+		),
+		'is_comments_popup' => array(
+			'alt'     => '',
+			'version' => '4.5.0',
+		),
+		'popuplinks' => array(
+			'alt'     => '',
+			'version' => '4.5.0',
+		),
+
+		// WP 4.6.0.
+		'post_form_autocomplete_off' => array(
+			'alt'     => '',
+			'version' => '4.6.0',
+		),
+		'wp_embed_handler_googlevideo' => array(
+			'alt'     => '',
+			'version' => '4.6.0',
+		),
+		'wp_get_sites' => array(
+			'alt'     => 'get_sites()',
+			'version' => '4.6.0',
+		),
+
+		// WP 4.7.0.
+		'_sort_nav_menu_items' => array(
+			'alt'     => 'wp_list_sort()',
+			'version' => '4.7.0',
+		),
+		'_usort_terms_by_ID' => array(
+			'alt'     => 'wp_list_sort()',
+			'version' => '4.7.0',
+		),
+		'_usort_terms_by_name' => array(
+			'alt'     => 'wp_list_sort()',
+			'version' => '4.7.0',
+		),
+		'get_paged_template' => array(
+			'alt'     => '',
+			'version' => '4.7.0',
+		),
+		'wp_get_network' => array(
+			'alt'     => 'get_network()',
+			'version' => '4.7.0',
+		),
+		'wp_kses_js_entities' => array(
+			'alt'     => '',
+			'version' => '4.7.0',
+		),
+
+		// WP 4.8.0.
+		'wp_dashboard_plugins_output' => array(
+			'alt'     => '',
+			'version' => '4.8.0',
+		),
+	);
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		// Make sure all array keys are lowercase.
+		$keys                       = array_keys( $this->deprecated_functions );
+		$keys                       = array_map( 'strtolower', $keys );
+		$this->deprecated_functions = array_combine( $keys, $this->deprecated_functions );
+
+		return array(
+			'deprecated_functions' => array(
+				'functions' => $keys,
+			),
+		);
+
+	} // End getGroups().
+
+	/**
+	 * Process a matched token.
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched. Will
+	 *                                always be 'deprecated_functions'.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 *
+	 * @return void
+	 */
+	public function process_matched_token( $stackPtr, $group_name, $matched_content ) {
+
+		$this->get_wp_version_from_cl();
+
+		$function_name = strtolower( $matched_content );
+
+		$message = '%s() has been deprecated since WordPress version %s.';
+		$data    = array(
+			$matched_content,
+			$this->deprecated_functions[ $function_name ]['version'],
+		);
+
+		if ( ! empty( $this->deprecated_functions[ $function_name ]['alt'] ) ) {
+			$message .= ' Use %s instead.';
+			$data[]   = $this->deprecated_functions[ $function_name ]['alt'];
+		}
+
+		$this->addMessage(
+			$message,
+			$stackPtr,
+			( version_compare( $this->deprecated_functions[ $function_name ]['version'], $this->minimum_supported_version, '<' ) ),
+			$this->string_to_errorcode( $matched_content . 'Found' ),
+			$data
+		);
+
+	} // End process_matched_token().
+
+}

--- a/ci/wpcs/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WP/DeprecatedParametersSniff.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WP;
+
+use WordPress\AbstractFunctionParameterSniff;
+
+/**
+ * Check for usage of deprecated parameters in WP functions and suggest alternative based on the parameter passed.
+ *
+ * This sniff will throw an error when usage of deprecated parameters is
+ * detected if the parameter was deprecated before the minimum supported
+ * WP version; a warning otherwise.
+ * By default, it is set to presume that a project will support the current
+ * WP version and up to three releases before.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ * @since   0.14.0 Now has the ability to handle minimum supported WP version
+ *                 being provided via the command-line or as as <config> value
+ *                 in a custom ruleset.
+ *
+ * @uses    \WordPress\Sniff::$minimum_supported_version
+ */
+class DeprecatedParametersSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * The group name for this group of functions.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var string
+	 */
+	protected $group_name = 'wp_deprecated_parameters';
+
+	/**
+	 * Array of function, argument, and default value for deprecated argument.
+	 *
+	 * The functions are ordered alphabetically.
+	 * Last updated for WordPress 4.8.0.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var array Multidimensional array with parameter details.
+	 *    $target_functions = array(
+	 *        (string) Function name. => array(
+	 *            (int) Target parameter position, 1-based. => array(
+	 *                'value'   => (mixed) Expected default value for the
+	 *                              deprecated parameter. Currently the default
+	 *                              values: true, false, null, empty arrays and
+	 *                              both empty and non-empty strings can be
+	 *                              handled correctly by the process_parameters()
+	 *                              method. When an additional default value is
+	 *                              added, the relevant code in the
+	 *                              process_parameters() method will need to be
+	 *                              adjusted.
+	 *                'version' => (int) The WordPress version when deprecated.
+	 *            )
+	 *         )
+	 *    );
+	 */
+	protected $target_functions = array(
+
+		'add_option' => array(
+			3 => array(
+				'value'   => '',
+				'version' => '2.3.0',
+			),
+		),
+		'comments_link' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '0.72',
+			),
+			2 => array(
+				'value'   => '',
+				'version' => '1.3.0',
+			),
+		),
+		'comments_number' => array(
+			4 => array(
+				'value'   => '',
+				'version' => '1.3.0',
+			),
+		),
+		'convert_chars' => array(
+			2 => array(
+				'value'   => '',
+				'version' => '0.71',
+			),
+		),
+		'discover_pingback_server_uri' => array(
+			2 => array(
+				'value'   => '',
+				'version' => '2.7.0',
+			),
+		),
+		'get_category_parents' => array(
+			5 => array(
+				'value'   => array(),
+				'version' => '4.8.0',
+			),
+		),
+		'get_delete_post_link' => array(
+			2 => array(
+				'value'   => '',
+				'version' => '3.0.0',
+			),
+		),
+		'get_last_updated' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '3.0.0', // Was previously part of MU.
+			),
+		),
+		'get_the_author' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '2.1.0',
+			),
+		),
+		'get_user_option' => array(
+			3 => array(
+				'value'   => '',
+				'version' => '2.3.0',
+			),
+		),
+		'get_wp_title_rss' => array(
+			1 => array(
+				'value'   => '&#8211;',
+				'version' => '4.4.0',
+			),
+		),
+		'is_email' => array(
+			2 => array(
+				'value'   => false,
+				'version' => '3.0.0',
+			),
+		),
+		'load_plugin_textdomain' => array(
+			2 => array(
+				'value'   => false,
+				'version' => '2.7.0',
+			),
+		),
+		'safecss_filter_attr' => array(
+			2 => array(
+				'value'   => '',
+				'version' => '2.8.1',
+			),
+		),
+		'the_attachment_link' => array(
+			3 => array(
+				'value'   => false,
+				'version' => '2.5.0',
+			),
+		),
+		'the_author' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '2.1.0',
+			),
+			2 => array(
+				'value'   => true,
+				'version' => '1.5.0',
+			),
+		),
+		'the_author_posts_link' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '2.1.0',
+			),
+		),
+		'trackback_rdf' => array(
+			1 => array(
+				'value'   => '',
+				'version' => '2.5.0',
+			),
+		),
+		'trackback_url' => array(
+			1 => array(
+				'value'   => true,
+				'version' => '2.5.0',
+			),
+		),
+		'update_blog_option' => array(
+			4 => array(
+				'value'   => null,
+				'version' => '3.1.0',
+			),
+		),
+		'update_blog_status' => array(
+			4 => array(
+				'value'   => null,
+				'version' => '3.1.0',
+			),
+		),
+		'update_user_status' => array(
+			4 => array(
+				'value'   => null,
+				'version' => '3.0.2',
+			),
+		),
+		'unregister_setting' => array(
+			4 => array(
+				'value'   => '',
+				'version' => '4.7.0',
+			),
+		),
+		'wp_get_http_headers' => array(
+			2 => array(
+				'value'   => false,
+				'version' => '2.7.0',
+			),
+		),
+		'wp_get_sidebars_widgets' => array(
+			1 => array(
+				'value'   => true,
+				'version' => '2.8.1',
+			),
+		),
+		'wp_install' => array(
+			5 => array(
+				'value'   => '',
+				'version' => '2.6.0',
+			),
+		),
+		'wp_new_user_notification' => array(
+			2 => array(
+				'value'   => null,
+				'version' => '4.3.1',
+			),
+		),
+		'wp_notify_postauthor' => array(
+			2 => array(
+				'value'   => null,
+				'version' => '3.8.0',
+			),
+		),
+		'wp_title_rss' => array(
+			1 => array(
+				'value'   => '&#8211;',
+				'version' => '4.4.0',
+			),
+		),
+		'wp_upload_bits' => array(
+			2 => array(
+				'value'   => '',
+				'version' => '2.0.0',
+			),
+		),
+		'xfn_check' => array(
+			3 => array(
+				'value'   => '',
+				'version' => '2.5.0',
+			),
+		),
+
+	); // End $target_functions.
+
+	/**
+	 * Process the parameters of a matched function.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+
+		$this->get_wp_version_from_cl();
+
+		$paramCount = count( $parameters );
+		foreach ( $this->target_functions[ $matched_content ] as $position => $parameter_args ) {
+
+			// Check that number of parameters defined is not less than the position to check.
+			if ( $position > $paramCount ) {
+				break;
+			}
+
+			// The list will need to updated if the default value is not supported.
+			switch ( $parameters[ $position ]['raw'] ) {
+				case 'true':
+					$matched_parameter = true;
+					break;
+				case 'false':
+					$matched_parameter = false;
+					break;
+				case 'null':
+					$matched_parameter = null;
+					break;
+				case 'array()':
+				case '[]':
+					$matched_parameter = array();
+					break;
+				default:
+					$matched_parameter = $this->strip_quotes( $parameters[ $position ]['raw'] );
+					break;
+			}
+
+			if ( $parameter_args['value'] === $matched_parameter ) {
+				continue;
+			}
+
+			$message  = 'The parameter "%s" at position #%s of %s() has been deprecated since WordPress version %s.';
+			$is_error = version_compare( $parameter_args['version'], $this->minimum_supported_version, '<' );
+			$code     = $this->string_to_errorcode( ucfirst( $matched_content ) . 'Param' . $position . 'Found' );
+
+			$data = array(
+				$parameters[ $position ]['raw'],
+				$position,
+				$matched_content,
+				$parameter_args['version'],
+			);
+
+			if ( isset( $parameter_args['value'] ) && $position < $paramCount ) {
+				$message .= ' Use "%s" instead.';
+				$data[]   = (string) $parameter_args['value'];
+			} else {
+				$message .= ' Instead do not pass the parameter.';
+			}
+
+			$this->addMessage( $message, $stackPtr, $is_error, $code, $data, 0 );
+		}
+	}
+
+}

--- a/ci/wpcs/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WP/DiscouragedConstantsSniff.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WP;
+
+use WordPress\AbstractFunctionParameterSniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Warns against usage of discouraged WP CONSTANTS and recommends alternatives.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class DiscouragedConstantsSniff extends AbstractFunctionParameterSniff {
+
+	/**
+	 * List of discouraged WP constants and their replacements.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var array
+	 */
+	protected $discouraged_constants = array(
+		'STYLESHEETPATH'      => 'get_stylesheet_directory()',
+		'TEMPLATEPATH'        => 'get_template_directory()',
+		'PLUGINDIR'           => 'WP_PLUGIN_DIR',
+		'MUPLUGINDIR'         => 'WPMU_PLUGIN_DIR',
+		'HEADER_IMAGE'        => 'add_theme_support( \'custom-header\' )',
+		'NO_HEADER_TEXT'      => 'add_theme_support( \'custom-header\' )',
+		'HEADER_TEXTCOLOR'    => 'add_theme_support( \'custom-header\' )',
+		'HEADER_IMAGE_WIDTH'  => 'add_theme_support( \'custom-header\' )',
+		'HEADER_IMAGE_HEIGHT' => 'add_theme_support( \'custom-header\' )',
+		'BACKGROUND_COLOR'    => 'add_theme_support( \'custom-background\' )',
+		'BACKGROUND_IMAGE'    => 'add_theme_support( \'custom-background\' )',
+	);
+
+	/**
+	 * Array of functions to check.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var array <string function name> => <int parameter position>
+	 */
+	protected $target_functions = array(
+		'define' => 1,
+	);
+
+	/**
+	 * Array of tokens which if found preceding the $stackPtr indicate that a T_STRING is not a constant.
+	 *
+	 * @var array
+	 */
+	private $preceding_tokens_to_ignore = array(
+		T_NAMESPACE       => true,
+		T_USE             => true,
+		T_CLASS           => true,
+		T_TRAIT           => true,
+		T_INTERFACE       => true,
+		T_EXTENDS         => true,
+		T_IMPLEMENTS      => true,
+		T_NEW             => true,
+		T_FUNCTION        => true,
+		T_DOUBLE_COLON    => true,
+		T_OBJECT_OPERATOR => true,
+		T_INSTANCEOF      => true,
+		T_GOTO            => true,
+
+	);
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+		if ( isset( $this->target_functions[ strtolower( $this->tokens[ $stackPtr ]['content'] ) ] ) ) {
+			// Disallow excluding function groups for this sniff.
+			$this->exclude = '';
+
+			return parent::process_token( $stackPtr );
+
+		} else {
+			return $this->process_arbitrary_tstring( $stackPtr );
+		}
+	}
+
+	/**
+	 * Process an arbitrary T_STRING token to determine whether it is one of the target constants.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_arbitrary_tstring( $stackPtr ) {
+		$content = $this->tokens[ $stackPtr ]['content'];
+
+		if ( ! isset( $this->discouraged_constants[ $content ] ) ) {
+			return;
+		}
+
+		$next = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+		if ( false !== $next && T_OPEN_PARENTHESIS === $this->tokens[ $next ]['code'] ) {
+			// Function call or declaration.
+			return;
+		}
+
+		$prev = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $stackPtr - 1 ), null, true );
+		if ( false !== $prev && isset( $this->preceding_tokens_to_ignore[ $this->tokens[ $prev ]['code'] ] ) ) {
+			// Not the use of a constant.
+			return;
+		}
+
+		if ( false !== $prev
+			&& T_NS_SEPARATOR === $this->tokens[ $prev ]['code']
+			&& T_STRING === $this->tokens[ ( $prev - 1 ) ]['code']
+		) {
+			// Namespaced constant of the same name.
+			return;
+		}
+
+		if ( false !== $prev
+			&& T_CONST === $this->tokens[ $prev ]['code']
+			&& true === $this->is_class_constant( $prev )
+		) {
+			// Class constant of the same name.
+			return;
+		}
+
+		/*
+		 * Deal with a number of variations of use statements.
+		 */
+		for ( $i = $stackPtr; $i > 0; $i-- ) {
+			if ( $this->tokens[ $i ]['line'] !== $this->tokens[ $stackPtr ]['line'] ) {
+				break;
+			}
+		}
+
+		$first_on_line = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $i + 1 ), null, true );
+		if ( false !== $first_on_line && T_USE === $this->tokens[ $first_on_line ]['code'] ) {
+			$next_on_line = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $first_on_line + 1 ), null, true );
+			if ( false !== $next_on_line ) {
+				if ( ( T_STRING === $this->tokens[ $next_on_line ]['code']
+						&& 'const' === $this->tokens[ $next_on_line ]['content'] )
+					|| T_CONST === $this->tokens[ $next_on_line ]['code'] // Happens in some PHPCS versions.
+				) {
+					$has_ns_sep = $this->phpcsFile->findNext( T_NS_SEPARATOR, ( $next_on_line + 1 ), $stackPtr );
+					if ( false !== $has_ns_sep ) {
+						// Namespaced const (group) use statement.
+						return;
+					}
+				} else {
+					// Not a const use statement.
+					return;
+				}
+			}
+		}
+
+		// Ok, this is really one of the discouraged constants.
+		$this->phpcsFile->addWarning(
+			'Found usage of constant "%s". Use %s instead.',
+			$stackPtr,
+			'UsageFound',
+			array(
+				$content,
+				$this->discouraged_constants[ $content ],
+			)
+		);
+	}
+
+	/**
+	 * Process the parameters of a matched `define` function call.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int    $stackPtr        The position of the current token in the stack.
+	 * @param array  $group_name      The name of the group which was matched.
+	 * @param string $matched_content The token content (function name) which was matched.
+	 * @param array  $parameters      Array with information about the parameters.
+	 *
+	 * @return void
+	 */
+	public function process_parameters( $stackPtr, $group_name, $matched_content, $parameters ) {
+		$function_name = strtolower( $matched_content );
+		$target_param  = $this->target_functions[ $function_name ];
+
+		// Was the target parameter passed ?
+		if ( ! isset( $parameters[ $target_param ] ) ) {
+			return;
+		}
+
+		$raw_content = $this->strip_quotes( $parameters[ $target_param ]['raw'] );
+
+		if ( isset( $this->discouraged_constants[ $raw_content ] ) ) {
+			$this->phpcsFile->addWarning(
+				'Found declaration of constant "%s". Use %s instead.',
+				$stackPtr,
+				'DeclarationFound',
+				array(
+					$raw_content,
+					$this->discouraged_constants[ $raw_content ],
+				)
+			);
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WP/DiscouragedFunctionsSniff.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WP;
+
+use WordPress\AbstractFunctionRestrictionsSniff;
+
+/**
+ * Discourages the use of various WordPress functions and suggests alternatives.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.11.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class DiscouragedFunctionsSniff extends AbstractFunctionRestrictionsSniff {
+
+	/**
+	 * Groups of functions to restrict.
+	 *
+	 * Example: groups => array(
+	 *  'lambda' => array(
+	 *      'type'      => 'error' | 'warning',
+	 *      'message'   => 'Use anonymous functions instead please!',
+	 *      'functions' => array( 'file_get_contents', 'create_function' ),
+	 *  )
+	 * )
+	 *
+	 * @return array
+	 */
+	public function getGroups() {
+		return array(
+			'query_posts' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is discouraged. Use WP_Query instead.',
+				'functions' => array(
+					'query_posts',
+				),
+			),
+
+			'wp_reset_query' => array(
+				'type'      => 'warning',
+				'message'   => '%s() is discouraged. Use the wp_reset_postdata() instead.',
+				'functions' => array(
+					'wp_reset_query',
+				),
+			),
+
+		);
+	} // end getGroups()
+
+} // end class

--- a/ci/wpcs/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WP/EnqueuedResourcesSniff.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WP;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Makes sure scripts and styles are enqueued and not explicitly echo'd.
+ *
+ * @link    https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/#inline-resources
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class EnqueuedResourcesSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return Tokens::$textStringTokens;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		$token = $this->tokens[ $stackPtr ];
+
+		if ( preg_match( '#rel=\\\\?[\'"]?stylesheet\\\\?[\'"]?#', $token['content'] ) > 0 ) {
+			$this->phpcsFile->addError(
+				'Stylesheets must be registered/enqueued via wp_enqueue_style',
+				$stackPtr,
+				'NonEnqueuedStylesheet'
+			);
+		}
+
+		if ( preg_match( '#<script[^>]*(?<=src=)#', $token['content'] ) > 0 ) {
+			$this->phpcsFile->addError(
+				'Scripts must be registered/enqueued via wp_enqueue_script',
+				$stackPtr,
+				'NonEnqueuedScript'
+			);
+		}
+
+	} // End process().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WP/I18nSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WP/I18nSniff.php
@@ -1,0 +1,705 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WP;
+
+use WordPress\Sniff;
+use WordPress\PHPCSHelper;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Makes sure WP internationalization functions are used properly.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/internationalization/
+ * @link    https://developer.wordpress.org/plugins/internationalization/
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.10.0
+ * @since   0.11.0 - Now also checks for translators comments.
+ *                 - Now has the ability to handle text-domain set via the command-line
+ *                   as a comma-delimited list.
+ *                   `phpcs --runtime-set text_domain my-slug,default`
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class I18nSniff extends Sniff {
+
+	/**
+	 * These Regexes copied from http://php.net/manual/en/function.sprintf.php#93552
+	 * and adjusted for better precision and updated specs.
+	 */
+	const SPRINTF_PLACEHOLDER_REGEX = '/(?:
+		(?<!%)                     # Don\'t match a literal % (%%).
+		(
+			%                          # Start of placeholder.
+			(?:[0-9]+\$)?              # Optional ordering of the placeholders.
+			[+-]?                      # Optional sign specifier.
+			(?:
+				(?:0|\'.)?                 # Optional padding specifier - excluding the space.
+				-?                         # Optional alignment specifier.
+				[0-9]*                     # Optional width specifier.
+				(?:\.(?:[ 0]|\'.)?[0-9]+)? # Optional precision specifier with optional padding character.
+				|                      # Only recognize the space as padding in combination with a width specifier.
+				(?:[ ])?                   # Optional space padding specifier.
+				-?                         # Optional alignment specifier.
+				[0-9]+                     # Width specifier.
+				(?:\.(?:[ 0]|\'.)?[0-9]+)? # Optional precision specifier with optional padding character.
+			)
+			[bcdeEfFgGosuxX]           # Type specifier.
+		)
+	)/x';
+
+	/**
+	 * "Unordered" means there's no position specifier: '%s', not '%2$s'.
+	 */
+	const UNORDERED_SPRINTF_PLACEHOLDER_REGEX = '/(?:
+		(?<!%)                     # Don\'t match a literal % (%%).
+		%                          # Start of placeholder.
+		[+-]?                      # Optional sign specifier.
+		(?:
+			(?:0|\'.)?                 # Optional padding specifier - excluding the space.
+			-?                         # Optional alignment specifier.
+			[0-9]*                     # Optional width specifier.
+			(?:\.(?:[ 0]|\'.)?[0-9]+)? # Optional precision specifier with optional padding character.
+			|                      # Only recognize the space as padding in combination with a width specifier.
+			(?:[ ])?                   # Optional space padding specifier.
+			-?                         # Optional alignment specifier.
+			[0-9]+                     # Width specifier.
+			(?:\.(?:[ 0]|\'.)?[0-9]+)? # Optional precision specifier with optional padding character.
+		)
+		[bcdeEfFgGosuxX]           # Type specifier.
+	)/x';
+
+	/**
+	 * Text domain.
+	 *
+	 * @todo Eventually this should be able to be auto-supplied via looking at $this->phpcsFile->getFilename()
+	 * @link https://youtrack.jetbrains.com/issue/WI-17740
+	 *
+	 * @var string[]|string
+	 */
+	public $text_domain;
+
+	/**
+	 * The I18N functions in use in WP.
+	 *
+	 * @since 0.10.0
+	 * @since 0.11.0 Changed visibility from public to protected.
+	 *
+	 * @var array <string function name> => <string function type>
+	 */
+	protected $i18n_functions = array(
+		'translate'                      => 'simple',
+		'__'                             => 'simple',
+		'esc_attr__'                     => 'simple',
+		'esc_html__'                     => 'simple',
+		'_e'                             => 'simple',
+		'esc_attr_e'                     => 'simple',
+		'esc_html_e'                     => 'simple',
+		'translate_with_gettext_context' => 'context',
+		'_x'                             => 'context',
+		'_ex'                            => 'context',
+		'esc_attr_x'                     => 'context',
+		'esc_html_x'                     => 'context',
+		'_n'                             => 'number',
+		'_nx'                            => 'number_context',
+		'_n_noop'                        => 'noopnumber',
+		'_nx_noop'                       => 'noopnumber_context',
+	);
+
+	/**
+	 * Toggle whether or not to check for translators comments for text string containing placeholders.
+	 *
+	 * Intended to make this part of the sniff unit testable, but can be used by end-users too,
+	 * though they can just as easily disable this via the sniff code.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var bool
+	 */
+	public $check_translator_comments = true;
+
+	/**
+	 * Whether or not the `default` text domain is one of the allowed text domains.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var bool
+	 */
+	private $text_domain_contains_default = false;
+
+	/**
+	 * Whether or not the `default` text domain is the only allowed text domain.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var bool
+	 */
+	private $text_domain_is_default = false;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_STRING,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stack_ptr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stack_ptr ) {
+		$token = $this->tokens[ $stack_ptr ];
+
+		// Reset defaults.
+		$this->text_domain_contains_default = false;
+		$this->text_domain_is_default       = false;
+
+		// Allow overruling the text_domain set in a ruleset via the command line.
+		$cl_text_domain = trim( PHPCSHelper::get_config_data( 'text_domain' ) );
+		if ( ! empty( $cl_text_domain ) ) {
+			$this->text_domain = $cl_text_domain;
+		}
+
+		$this->text_domain = $this->merge_custom_array( $this->text_domain, array(), false );
+
+		if ( ! empty( $this->text_domain ) ) {
+			if ( in_array( 'default', $this->text_domain, true ) ) {
+				$this->text_domain_contains_default = true;
+				if ( count( $this->text_domain ) === 1 ) {
+					$this->text_domain_is_default = true;
+				}
+			}
+		}
+
+		if ( '_' === $token['content'] ) {
+			$this->phpcsFile->addError( 'Found single-underscore "_()" function when double-underscore expected.', $stack_ptr, 'SingleUnderscoreGetTextFunction' );
+		}
+
+		if ( ! isset( $this->i18n_functions[ $token['content'] ] ) ) {
+			return;
+		}
+		$translation_function = $token['content'];
+
+		if ( in_array( $translation_function, array( 'translate', 'translate_with_gettext_context' ), true ) ) {
+			$this->phpcsFile->addWarning( 'Use of the "%s()" function is reserved for low-level API usage.', $stack_ptr, 'LowLevelTranslationFunction', array( $translation_function ) );
+		}
+
+		$func_open_paren_token = $this->phpcsFile->findNext( T_WHITESPACE, ( $stack_ptr + 1 ), null, true );
+		if ( false === $func_open_paren_token || T_OPEN_PARENTHESIS !== $this->tokens[ $func_open_paren_token ]['code'] ) {
+			return;
+		}
+
+		$arguments_tokens = array();
+		$argument_tokens  = array();
+		$tokens           = $this->tokens;
+
+		// Look at arguments.
+		for ( $i = ( $func_open_paren_token + 1 ); $i < $this->tokens[ $func_open_paren_token ]['parenthesis_closer']; $i++ ) {
+			$this_token                = $this->tokens[ $i ];
+			$this_token['token_index'] = $i;
+			if ( isset( Tokens::$emptyTokens[ $this_token['code'] ] ) ) {
+				continue;
+			}
+			if ( T_COMMA === $this_token['code'] ) {
+				$arguments_tokens[] = $argument_tokens;
+				$argument_tokens    = array();
+				continue;
+			}
+
+			// Merge consecutive single or double quoted strings (when they span multiple lines).
+			if ( isset( Tokens::$textStringTokens[ $this_token['code'] ] ) ) {
+				for ( $j = ( $i + 1 ); $j < $this->tokens[ $func_open_paren_token ]['parenthesis_closer']; $j++ ) {
+					if ( $this_token['code'] === $this->tokens[ $j ]['code'] ) {
+						$this_token['content'] .= $this->tokens[ $j ]['content'];
+						$i                      = $j;
+					} else {
+						break;
+					}
+				}
+			}
+			$argument_tokens[] = $this_token;
+
+			// Include everything up to and including the parenthesis_closer if this token has one.
+			if ( ! empty( $this_token['parenthesis_closer'] ) ) {
+				for ( $j = ( $i + 1 ); $j <= $this_token['parenthesis_closer']; $j++ ) {
+					$tokens[ $j ]['token_index'] = $j;
+					$argument_tokens[]           = $tokens[ $j ];
+				}
+				$i = $this_token['parenthesis_closer'];
+			}
+		}
+
+		if ( ! empty( $argument_tokens ) ) {
+			$arguments_tokens[] = $argument_tokens;
+		}
+		unset( $argument_tokens );
+
+		$argument_assertions = array();
+		if ( 'simple' === $this->i18n_functions[ $translation_function ] ) {
+			$argument_assertions[] = array(
+				'arg_name' => 'text',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+		} elseif ( 'context' === $this->i18n_functions[ $translation_function ] ) {
+			$argument_assertions[] = array(
+				'arg_name' => 'text',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'context',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+		} elseif ( 'number' === $this->i18n_functions[ $translation_function ] ) {
+			$argument_assertions[] = array(
+				'arg_name' => 'single',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'plural',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			array_shift( $arguments_tokens );
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+		} elseif ( 'number_context' === $this->i18n_functions[ $translation_function ] ) {
+			$argument_assertions[] = array(
+				'arg_name' => 'single',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'plural',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			array_shift( $arguments_tokens );
+			$argument_assertions[] = array(
+				'arg_name' => 'context',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+		} elseif ( 'noopnumber' === $this->i18n_functions[ $translation_function ] ) {
+			$argument_assertions[] = array(
+				'arg_name' => 'single',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'plural',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+		} elseif ( 'noopnumber_context' === $this->i18n_functions[ $translation_function ] ) {
+			$argument_assertions[] = array(
+				'arg_name' => 'single',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'plural',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'context',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+			$argument_assertions[] = array(
+				'arg_name' => 'domain',
+				'tokens'   => array_shift( $arguments_tokens ),
+			);
+		}
+
+		if ( ! empty( $arguments_tokens ) ) {
+			$this->phpcsFile->addError( 'Too many arguments for function "%s".', $func_open_paren_token, 'TooManyFunctionArgs', array( $translation_function ) );
+		}
+
+		foreach ( $argument_assertions as $argument_assertion_context ) {
+			if ( empty( $argument_assertion_context['tokens'][0] ) ) {
+				$argument_assertion_context['stack_ptr'] = $func_open_paren_token;
+			} else {
+				$argument_assertion_context['stack_ptr'] = $argument_assertion_context['tokens'][0]['token_index'];
+			}
+			$this->check_argument_tokens( $argument_assertion_context );
+		}
+
+		// For _n*() calls, compare the singular and plural strings.
+		if ( false !== strpos( $this->i18n_functions[ $translation_function ], 'number' ) ) {
+			$single_context = $argument_assertions[0];
+			$plural_context = $argument_assertions[1];
+
+			$this->compare_single_and_plural_arguments( $stack_ptr, $single_context, $plural_context );
+		}
+
+		if ( true === $this->check_translator_comments ) {
+			$this->check_for_translator_comment( $stack_ptr, $argument_assertions );
+		}
+	}
+
+	/**
+	 * Check if supplied tokens represent a translation text string literal.
+	 *
+	 * @param array $context Context (@todo needs better description).
+	 * @return bool
+	 */
+	protected function check_argument_tokens( $context ) {
+		$stack_ptr = $context['stack_ptr'];
+		$tokens    = $context['tokens'];
+		$arg_name  = $context['arg_name'];
+		$is_error  = empty( $context['warning'] );
+		$content   = isset( $tokens[0] ) ? $tokens[0]['content'] : '';
+
+		if ( empty( $tokens ) || 0 === count( $tokens ) ) {
+			$code = $this->string_to_errorcode( 'MissingArg' . ucfirst( $arg_name ) );
+			if ( 'domain' !== $arg_name ) {
+				$this->addMessage( 'Missing $%s arg.', $stack_ptr, $is_error, $code, array( $arg_name ) );
+				return false;
+			}
+
+			// Ok, we're examining a text domain, now deal correctly with the 'default' text domain.
+			if ( true === $this->text_domain_is_default ) {
+				return true;
+			}
+
+			if ( true === $this->text_domain_contains_default ) {
+				$this->phpcsFile->addWarning(
+					'Missing $%s arg. If this text string is supposed to use a WP Core translation, use the "default" text domain.',
+					$stack_ptr,
+					$code . 'Default',
+					array( $arg_name )
+				);
+			} elseif ( ! empty( $this->text_domain ) ) {
+				$this->addMessage( 'Missing $%s arg.', $stack_ptr, $is_error, $code, array( $arg_name ) );
+			}
+
+			return false;
+		}
+
+		if ( count( $tokens ) > 1 ) {
+			$contents = '';
+			foreach ( $tokens as $token ) {
+				$contents .= $token['content'];
+			}
+			$code = $this->string_to_errorcode( 'NonSingularStringLiteral' . ucfirst( $arg_name ) );
+			$this->addMessage( 'The $%s arg must be a single string literal, not "%s".', $stack_ptr, $is_error, $code, array( $arg_name, $contents ) );
+			return false;
+		}
+
+		if ( in_array( $arg_name, array( 'text', 'single', 'plural' ), true ) ) {
+			$this->check_text( $context );
+		}
+
+		if ( T_DOUBLE_QUOTED_STRING === $tokens[0]['code'] || T_HEREDOC === $tokens[0]['code'] ) {
+			$interpolated_variables = $this->get_interpolated_variables( $content );
+			foreach ( $interpolated_variables as $interpolated_variable ) {
+				$code = $this->string_to_errorcode( 'InterpolatedVariable' . ucfirst( $arg_name ) );
+				$this->addMessage( 'The $%s arg must not contain interpolated variables. Found "$%s".', $stack_ptr, $is_error, $code, array( $arg_name, $interpolated_variable ) );
+			}
+			if ( ! empty( $interpolated_variables ) ) {
+				return false;
+			}
+		}
+
+		if ( isset( Tokens::$textStringTokens[ $tokens[0]['code'] ] ) ) {
+			if ( 'domain' === $arg_name && ! empty( $this->text_domain ) ) {
+				$stripped_content = $this->strip_quotes( $content );
+
+				if ( ! in_array( $stripped_content, $this->text_domain, true ) ) {
+					$this->addMessage(
+						'Mismatched text domain. Expected \'%s\' but got %s.',
+						$stack_ptr,
+						$is_error,
+						'TextDomainMismatch',
+						array( implode( "' or '", $this->text_domain ), $content )
+					);
+					return false;
+				}
+
+				if ( true === $this->text_domain_is_default && 'default' === $stripped_content ) {
+					$fixable    = false;
+					$error      = 'No need to supply the text domain when the only accepted text-domain is "default".';
+					$error_code = 'SuperfluousDefaultTextDomain';
+
+					if ( $tokens[0]['token_index'] === $stack_ptr ) {
+						$prev = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $stack_ptr - 1 ), null, true );
+						if ( false !== $prev && T_COMMA === $this->tokens[ $prev ]['code'] ) {
+							$fixable = true;
+						}
+					}
+
+					if ( false === $fixable ) {
+						$this->phpcsFile->addWarning( $error, $stack_ptr, $error_code );
+						return false;
+					}
+
+					$fix = $this->phpcsFile->addFixableWarning( $error, $stack_ptr, $error_code );
+					if ( true === $fix ) {
+						// Remove preceeding comma, whitespace and the text domain token.
+						$this->phpcsFile->fixer->beginChangeset();
+						for ( $i = $prev; $i <= $stack_ptr; $i++ ) {
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+						}
+						$this->phpcsFile->fixer->endChangeset();
+					}
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		$code = $this->string_to_errorcode( 'NonSingularStringLiteral' . ucfirst( $arg_name ) );
+		$this->addMessage( 'The $%s arg must be a single string literal, not "%s".', $stack_ptr, $is_error, $code, array( $arg_name, $content ) );
+		return false;
+	}
+
+	/**
+	 * Check for inconsistencies between single and plural arguments.
+	 *
+	 * @param int   $stack_ptr      The position of the current token in the stack.
+	 * @param array $single_context Single context (@todo needs better description).
+	 * @param array $plural_context Plural context (@todo needs better description).
+	 * @return void
+	 */
+	protected function compare_single_and_plural_arguments( $stack_ptr, $single_context, $plural_context ) {
+		$single_content = $single_context['tokens'][0]['content'];
+		$plural_content = $plural_context['tokens'][0]['content'];
+
+		preg_match_all( self::SPRINTF_PLACEHOLDER_REGEX, $single_content, $single_placeholders );
+		$single_placeholders = $single_placeholders[0];
+
+		preg_match_all( self::SPRINTF_PLACEHOLDER_REGEX, $plural_content, $plural_placeholders );
+		$plural_placeholders = $plural_placeholders[0];
+
+		// English conflates "singular" with "only one", described in the codex:
+		// https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals .
+		if ( count( $single_placeholders ) < count( $plural_placeholders ) ) {
+			$error_string = 'Missing singular placeholder, needed for some languages. See https://codex.wordpress.org/I18n_for_WordPress_Developers#Plurals';
+			$single_index = $single_context['tokens'][0]['token_index'];
+
+			$this->phpcsFile->addError( $error_string, $single_index, 'MissingSingularPlaceholder' );
+		}
+
+		// Reordering is fine, but mismatched placeholders is probably wrong.
+		sort( $single_placeholders );
+		sort( $plural_placeholders );
+
+		if ( $single_placeholders !== $plural_placeholders ) {
+			$this->phpcsFile->addWarning( 'Mismatched placeholders is probably an error', $stack_ptr, 'MismatchedPlaceholders' );
+		}
+	}
+
+	/**
+	 * Check the string itself for problems.
+	 *
+	 * @param array $context Context (@todo needs better description).
+	 * @return void
+	 */
+	protected function check_text( $context ) {
+		$stack_ptr = $context['stack_ptr'];
+		$arg_name  = $context['arg_name'];
+		$content   = $context['tokens'][0]['content'];
+		$is_error  = empty( $context['warning'] );
+
+		// UnorderedPlaceholders: Check for multiple unordered placeholders.
+		$unordered_matches_count = preg_match_all( self::UNORDERED_SPRINTF_PLACEHOLDER_REGEX, $content, $unordered_matches );
+		$unordered_matches       = $unordered_matches[0];
+		$all_matches_count       = preg_match_all( self::SPRINTF_PLACEHOLDER_REGEX, $content, $all_matches );
+
+		if ( $unordered_matches_count > 0 && $unordered_matches_count !== $all_matches_count && $all_matches_count > 1 ) {
+			$code = $this->string_to_errorcode( 'MixedOrderedPlaceholders' . ucfirst( $arg_name ) );
+			$this->phpcsFile->addError(
+				'Multiple placeholders should be ordered. Mix of ordered and non-ordered placeholders found. Found: %s.',
+				$stack_ptr,
+				$code,
+				array( implode( ', ', $all_matches[0] ) )
+			);
+
+		} elseif ( $unordered_matches_count >= 2 ) {
+			$code = $this->string_to_errorcode( 'UnorderedPlaceholders' . ucfirst( $arg_name ) );
+
+			$suggestions     = array();
+			$replace_regexes = array();
+			$replacements    = array();
+			for ( $i = 0; $i < $unordered_matches_count; $i++ ) {
+				$to_insert         = ( $i + 1 );
+				$to_insert        .= ( '"' !== $content[0] ) ? '$' : '\$';
+				$suggestions[ $i ] = substr_replace( $unordered_matches[ $i ], $to_insert, 1, 0 );
+
+				// Prepare the strings for use a regex.
+				$replace_regexes[ $i ] = '`\Q' . $unordered_matches[ $i ] . '\E`';
+				// Note: the initial \\ is a literal \, the four \ in the replacement translate to also to a literal \.
+				$replacements[ $i ] = str_replace( '\\', '\\\\', $suggestions[ $i ] );
+				// Note: the $ needs escaping to prevent numeric sequences after the $ being interpreted as match replacements.
+				$replacements[ $i ] = str_replace( '$', '\\$', $replacements[ $i ] );
+			}
+
+			$fix = $this->addFixableMessage(
+				'Multiple placeholders should be ordered. Expected \'%s\', but got %s.',
+				$stack_ptr,
+				$is_error,
+				$code,
+				array( implode( ', ', $suggestions ), implode( ', ', $unordered_matches ) )
+			);
+
+			if ( true === $fix ) {
+				$fixed_str = preg_replace( $replace_regexes, $replacements, $content, 1 );
+
+				$this->phpcsFile->fixer->replaceToken( $stack_ptr, $fixed_str );
+			}
+		}
+
+		/*
+		 * NoEmptyStrings.
+		 *
+		 * Strip placeholders and surrounding quotes.
+		 */
+		$non_placeholder_content = $this->strip_quotes( $content );
+		$non_placeholder_content = preg_replace( self::SPRINTF_PLACEHOLDER_REGEX, '', $non_placeholder_content );
+
+		if ( empty( $non_placeholder_content ) ) {
+			$this->phpcsFile->addError( 'Strings should have translatable content', $stack_ptr, 'NoEmptyStrings' );
+		}
+	} // End check_text().
+
+	/**
+	 * Check for the presence of a translators comment if one of the text strings contains a placeholder.
+	 *
+	 * @param int   $stack_ptr  The position of the gettext call token in the stack.
+	 * @param array $args       The function arguments.
+	 * @return void
+	 */
+	protected function check_for_translator_comment( $stack_ptr, $args ) {
+		foreach ( $args as $arg ) {
+			if ( false === in_array( $arg['arg_name'], array( 'text', 'single', 'plural' ), true ) ) {
+				continue;
+			}
+
+			if ( empty( $arg['tokens'] ) ) {
+				continue;
+			}
+
+			foreach ( $arg['tokens'] as $token ) {
+				if ( empty( $token['content'] ) ) {
+					continue;
+				}
+
+				if ( preg_match( self::SPRINTF_PLACEHOLDER_REGEX, $token['content'], $placeholders ) < 1 ) {
+					// No placeholders found.
+					continue;
+				}
+
+				$previous_comment = $this->phpcsFile->findPrevious( Tokens::$commentTokens, ( $stack_ptr - 1 ) );
+
+				if ( false !== $previous_comment ) {
+					/*
+					 * Check that the comment is either on the line before the gettext call or
+					 * if it's not, that there is only whitespace between.
+					 */
+					$correctly_placed = false;
+
+					if ( ( $this->tokens[ $previous_comment ]['line'] + 1 ) === $this->tokens[ $stack_ptr ]['line'] ) {
+						$correctly_placed = true;
+					} else {
+						$next_non_whitespace = $this->phpcsFile->findNext( T_WHITESPACE, ( $previous_comment + 1 ), $stack_ptr, true );
+						if ( false === $next_non_whitespace || $this->tokens[ $next_non_whitespace ]['line'] === $this->tokens[ $stack_ptr ]['line'] ) {
+							// No non-whitespace found or next non-whitespace is on same line as gettext call.
+							$correctly_placed = true;
+						}
+						unset( $next_non_whitespace );
+					}
+
+					/*
+					 * Check that the comment starts with 'translators:'.
+					 */
+					if ( true === $correctly_placed ) {
+
+						if ( T_COMMENT === $this->tokens[ $previous_comment ]['code'] ) {
+							$comment_text = trim( $this->tokens[ $previous_comment ]['content'] );
+
+							// If it's multi-line /* */ comment, collect all the parts.
+							if ( '*/' === substr( $comment_text, -2 ) && '/*' !== substr( $comment_text, 0, 2 ) ) {
+								for ( $i = ( $previous_comment - 1 ); 0 <= $i; $i-- ) {
+									if ( T_COMMENT !== $this->tokens[ $i ]['code'] ) {
+										break;
+									}
+
+									$comment_text = trim( $this->tokens[ $i ]['content'] ) . $comment_text;
+								}
+							}
+
+							if ( true === $this->is_translators_comment( $comment_text ) ) {
+								// Comment is ok.
+								return;
+							}
+						} elseif ( T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ $previous_comment ]['code'] ) {
+							// If it's docblock comment (wrong style) make sure that it's a translators comment.
+							$db_start      = $this->phpcsFile->findPrevious( T_DOC_COMMENT_OPEN_TAG, ( $previous_comment - 1 ) );
+							$db_first_text = $this->phpcsFile->findNext( T_DOC_COMMENT_STRING, ( $db_start + 1 ), $previous_comment );
+
+							if ( true === $this->is_translators_comment( $this->tokens[ $db_first_text ]['content'] ) ) {
+								$this->phpcsFile->addWarning(
+									'A "translators:" comment must be a "/* */" style comment. Docblock comments will not be picked up by the tools to generate a ".pot" file.',
+									$stack_ptr,
+									'TranslatorsCommentWrongStyle'
+								);
+								return;
+							}
+						}
+					}
+				}
+
+				// Found placeholders but no translators comment.
+				$this->phpcsFile->addWarning(
+					'A gettext call containing placeholders was found, but was not accompanied by a "translators:" comment on the line above to clarify the meaning of the placeholders.',
+					$stack_ptr,
+					'MissingTranslatorsComment'
+				);
+				return;
+			}
+		}
+
+	} // End check_for_translator_comment().
+
+	/**
+	 * Check if a (collated) comment string starts with 'translators:'.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @param string $content Comment string content.
+	 * @return bool
+	 */
+	private function is_translators_comment( $content ) {
+		if ( preg_match( '`^(?:(?://|/\*{1,2}) )?translators:`i', $content, $matches ) === 1 ) {
+			return true;
+		}
+		return false;
+	}
+
+}

--- a/ci/wpcs/WordPress/Sniffs/WP/PreparedSQLSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WP/PreparedSQLSniff.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WP;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Sniff for prepared SQL.
+ *
+ * Makes sure that variables aren't directly interpolated into SQL statements.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#formatting-sql-statements
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.8.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class PreparedSQLSniff extends Sniff {
+
+	/**
+	 * The lists of $wpdb methods.
+	 *
+	 * @since 0.8.0
+	 * @since 0.11.0 Changed from static to non-static.
+	 *
+	 * @var array
+	 */
+	protected $methods = array(
+		'get_var'     => true,
+		'get_col'     => true,
+		'get_row'     => true,
+		'get_results' => true,
+		'prepare'     => true,
+		'query'       => true,
+	);
+
+	/**
+	 * Tokens that we don't flag when they are found in a $wpdb method call.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @var array
+	 */
+	protected $ignored_tokens = array(
+		T_OBJECT_OPERATOR          => true,
+		T_OPEN_PARENTHESIS         => true,
+		T_CLOSE_PARENTHESIS        => true,
+		T_STRING_CONCAT            => true,
+		T_CONSTANT_ENCAPSED_STRING => true,
+		T_OPEN_SQUARE_BRACKET      => true,
+		T_CLOSE_SQUARE_BRACKET     => true,
+		T_COMMA                    => true,
+		T_LNUMBER                  => true,
+		T_START_HEREDOC            => true,
+		T_END_HEREDOC              => true,
+		T_START_NOWDOC             => true,
+		T_NOWDOC                   => true,
+		T_END_NOWDOC               => true,
+		T_INT_CAST                 => true,
+		T_DOUBLE_CAST              => true,
+		T_BOOL_CAST                => true,
+	);
+
+	/**
+	 * A loop pointer.
+	 *
+	 * It is a property so that we can access it in all of our methods.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @var int
+	 */
+	protected $i;
+
+	/**
+	 * The loop end marker.
+	 *
+	 * It is a property so that we can access it in all of our methods.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @var int
+	 */
+	protected $end;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 0.8.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+
+		$this->ignored_tokens = $this->ignored_tokens + Tokens::$emptyTokens;
+
+		return array(
+			T_VARIABLE,
+			T_STRING,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.8.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+
+		if ( ! $this->is_wpdb_method_call( $stackPtr, $this->methods ) ) {
+			return;
+		}
+
+		if ( $this->has_whitelist_comment( 'unprepared SQL', $stackPtr ) ) {
+			return;
+		}
+
+		for ( $this->i; $this->i < $this->end; $this->i++ ) {
+
+			if ( isset( $this->ignored_tokens[ $this->tokens[ $this->i ]['code'] ] ) ) {
+				continue;
+			}
+
+			if ( T_DOUBLE_QUOTED_STRING === $this->tokens[ $this->i ]['code']
+				|| T_HEREDOC === $this->tokens[ $this->i ]['code']
+			) {
+
+				$bad_variables = array_filter(
+					$this->get_interpolated_variables( $this->tokens[ $this->i ]['content'] ),
+					function ( $symbol ) {
+						return ( 'wpdb' !== $symbol );
+					}
+				);
+
+				foreach ( $bad_variables as $bad_variable ) {
+					$this->phpcsFile->addError(
+						'Use placeholders and $wpdb->prepare(); found interpolated variable $%s at %s',
+						$this->i,
+						'NotPrepared',
+						array(
+							$bad_variable,
+							$this->tokens[ $this->i ]['content'],
+						)
+					);
+				}
+				continue;
+			}
+
+			if ( T_VARIABLE === $this->tokens[ $this->i ]['code'] ) {
+				if ( '$wpdb' === $this->tokens[ $this->i ]['content'] ) {
+					$this->is_wpdb_method_call( $this->i, $this->methods );
+					continue;
+				}
+
+				if ( $this->is_safe_casted( $this->i ) ) {
+					continue;
+				}
+			}
+
+			if ( T_STRING === $this->tokens[ $this->i ]['code'] ) {
+
+				if (
+					isset( $this->SQLEscapingFunctions[ $this->tokens[ $this->i ]['content'] ] )
+					|| isset( $this->SQLAutoEscapedFunctions[ $this->tokens[ $this->i ]['content'] ] )
+				) {
+
+					// Find the opening parenthesis.
+					$opening_paren = $this->phpcsFile->findNext( T_WHITESPACE, ( $this->i + 1 ), null, true, null, true );
+
+					if (
+						$opening_paren
+						&& T_OPEN_PARENTHESIS === $this->tokens[ $opening_paren ]['code']
+						&& isset( $this->tokens[ $opening_paren ]['parenthesis_closer'] )
+					) {
+						// Skip past the end of the function.
+						$this->i = $this->tokens[ $opening_paren ]['parenthesis_closer'];
+						continue;
+					}
+				} elseif ( isset( $this->formattingFunctions[ $this->tokens[ $this->i ]['content'] ] ) ) {
+					continue;
+				}
+			}
+
+			$this->phpcsFile->addError(
+				'Use placeholders and $wpdb->prepare(); found %s',
+				$this->i,
+				'NotPrepared',
+				array( $this->tokens[ $this->i ]['content'] )
+			);
+		}
+
+		return $this->end;
+
+	} // End process_token().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WhiteSpace/ArbitraryParenthesesSpacingSniff.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WhiteSpace;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Check & fix whitespace on the inside of arbitrary parentheses.
+ *
+ * Arbitrary parentheses are those which are not owned by a function (call), array or control structure.
+ * Spacing on the outside is not checked on purpose as this would too easily conflict with other spacing rules.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ *
+ * {@internal This sniff is a duplicate of the same sniff as pulled upstream.
+ * Once the upstream sniff has been merged and the minimum WPCS PHPCS requirement has gone up to
+ * the version in which the sniff was merged, this version can be safely removed.
+ * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1701} }}
+ */
+class ArbitraryParenthesesSpacingSniff extends Sniff {
+
+	/**
+	 * The number of spaces desired on the inside of the parentheses.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var integer
+	 */
+	public $spacingInside = 0;
+
+	/**
+	 * Allow newlines instead of spaces.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var boolean
+	 */
+	public $ignoreNewlines = false;
+
+	/**
+	 * Tokens which when they precede an open parenthesis indicate
+	 * that this is a type of structure this sniff should ignore.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @var array
+	 */
+	private $ignoreTokens = array();
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @return array
+	 */
+	public function register() {
+
+		$this->ignoreTokens                           = Tokens::$functionNameTokens;
+		$this->ignoreTokens[ T_VARIABLE ]             = T_VARIABLE;
+		$this->ignoreTokens[ T_CLOSE_PARENTHESIS ]    = T_CLOSE_PARENTHESIS;
+		$this->ignoreTokens[ T_CLOSE_CURLY_BRACKET ]  = T_CLOSE_CURLY_BRACKET;
+		$this->ignoreTokens[ T_CLOSE_SQUARE_BRACKET ] = T_CLOSE_SQUARE_BRACKET;
+		$this->ignoreTokens[ T_CLOSE_SHORT_ARRAY ]    = T_CLOSE_SHORT_ARRAY;
+		$this->ignoreTokens[ T_ANON_CLASS ]           = T_ANON_CLASS;
+		$this->ignoreTokens[ T_USE ]                  = T_USE;
+		$this->ignoreTokens[ T_LIST ]                 = T_LIST;
+		$this->ignoreTokens[ T_DECLARE ]              = T_DECLARE;
+
+		// The below two tokens have been added to the Tokens::$functionNameTokens array in PHPCS 3.1.0,
+		// so they can be removed once the minimum PHPCS requirement of WPCS has gone up.
+		$this->ignoreTokens[ T_SELF ]   = T_SELF;
+		$this->ignoreTokens[ T_STATIC ] = T_STATIC;
+
+		// Language constructs where the use of parentheses should be discouraged instead.
+		$this->ignoreTokens[ T_THROW ]      = T_THROW;
+		$this->ignoreTokens[ T_YIELD ]      = T_YIELD;
+		$this->ignoreTokens[ T_YIELD_FROM ] = T_YIELD_FROM;
+		$this->ignoreTokens[ T_CLONE ]      = T_CLONE;
+
+		return array(
+			T_OPEN_PARENTHESIS,
+			T_CLOSE_PARENTHESIS,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @since 0.14.0
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+
+		if ( isset( $this->tokens[ $stackPtr ]['parenthesis_owner'] ) ) {
+			// This parenthesis is owned by a function/control structure etc.
+			return;
+		}
+
+		// More checking for the type of parenthesis we *don't* want to handle.
+		$opener = $stackPtr;
+		if ( T_CLOSE_PARENTHESIS === $this->tokens[ $stackPtr ]['code'] ) {
+			if ( ! isset( $this->tokens[ $stackPtr ]['parenthesis_opener'] ) ) {
+				// Parse error.
+				return;
+			}
+
+			$opener = $this->tokens[ $stackPtr ]['parenthesis_opener'];
+		}
+
+		$preOpener = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $opener - 1 ), null, true );
+		if ( false !== $preOpener && isset( $this->ignoreTokens[ $this->tokens[ $preOpener ]['code'] ] ) ) {
+			// Function or language construct call.
+			return;
+		}
+
+		/*
+		 * Check for empty parentheses.
+		 */
+		if ( T_OPEN_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
+			&& isset( $this->tokens[ $stackPtr ]['parenthesis_closer'] )
+		) {
+			$nextNonEmpty = $this->phpcsFile->findNext( T_WHITESPACE, ( $stackPtr + 1 ), null, true );
+			if ( $nextNonEmpty === $this->tokens[ $stackPtr ]['parenthesis_closer'] ) {
+				$this->phpcsFile->addWarning( 'Empty set of arbitrary parentheses found.', $stackPtr, 'FoundEmpty' );
+
+				return ( $this->tokens[ $stackPtr ]['parenthesis_closer'] + 1 );
+			}
+		}
+
+		/*
+		 * Check the spacing on the inside of the parentheses.
+		 */
+		$this->spacingInside = (int) $this->spacingInside;
+
+		if ( T_OPEN_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
+			&& isset( $this->tokens[ ( $stackPtr + 1 ) ], $this->tokens[ ( $stackPtr + 2 ) ] )
+		) {
+			$nextToken = $this->tokens[ ( $stackPtr + 1 ) ];
+
+			if ( T_WHITESPACE !== $nextToken['code'] ) {
+				$inside = 0;
+			} else {
+				if ( $this->tokens[ ( $stackPtr + 2 ) ]['line'] !== $this->tokens[ $stackPtr ]['line'] ) {
+					$inside = 'newline';
+				} else {
+					$inside = $nextToken['length'];
+				}
+			}
+
+			if ( $this->spacingInside !== $inside
+				&& ( 'newline' !== $inside || false === $this->ignoreNewlines )
+			) {
+				$error = 'Expected %s space after open parenthesis; %s found';
+				$data  = array(
+					$this->spacingInside,
+					$inside,
+				);
+				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpaceAfterOpen', $data );
+
+				if ( true === $fix ) {
+					$expected = '';
+					if ( $this->spacingInside > 0 ) {
+						$expected = str_repeat( ' ', $this->spacingInside );
+					}
+
+					if ( 0 === $inside ) {
+						if ( '' !== $expected ) {
+							$this->phpcsFile->fixer->addContent( $stackPtr, $expected );
+						}
+					} elseif ( 'newline' === $inside ) {
+						$this->phpcsFile->fixer->beginChangeset();
+						for ( $i = ( $stackPtr + 2 ); $i < $this->phpcsFile->numTokens; $i++ ) {
+							if ( T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+								break;
+							}
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+						}
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), $expected );
+						$this->phpcsFile->fixer->endChangeset();
+					} else {
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), $expected );
+					}
+				}
+			}
+		}
+
+		if ( T_CLOSE_PARENTHESIS === $this->tokens[ $stackPtr ]['code']
+			&& isset( $this->tokens[ ( $stackPtr - 1 ) ], $this->tokens[ ( $stackPtr - 2 ) ] )
+		) {
+			$prevToken = $this->tokens[ ( $stackPtr - 1 ) ];
+
+			if ( T_WHITESPACE !== $prevToken['code'] ) {
+				$inside = 0;
+			} else {
+				if ( $this->tokens[ ( $stackPtr - 2 ) ]['line'] !== $this->tokens[ $stackPtr ]['line'] ) {
+					$inside = 'newline';
+				} else {
+					$inside = $prevToken['length'];
+				}
+			}
+
+			if ( $this->spacingInside !== $inside
+				&& ( 'newline' !== $inside || false === $this->ignoreNewlines )
+			) {
+				$error = 'Expected %s space before close parenthesis; %s found';
+				$data  = array(
+					$this->spacingInside,
+					$inside,
+				);
+				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpaceBeforeClose', $data );
+
+				if ( true === $fix ) {
+					$expected = '';
+					if ( $this->spacingInside > 0 ) {
+						$expected = str_repeat( ' ', $this->spacingInside );
+					}
+
+					if ( 0 === $inside ) {
+						if ( '' !== $expected ) {
+							$this->phpcsFile->fixer->addContentBefore( $stackPtr, $expected );
+						}
+					} elseif ( 'newline' === $inside ) {
+						$this->phpcsFile->fixer->beginChangeset();
+						for ( $i = ( $stackPtr - 2 ); $i > 0; $i-- ) {
+							if ( T_WHITESPACE !== $this->tokens[ $i ]['code'] ) {
+								break;
+							}
+							$this->phpcsFile->fixer->replaceToken( $i, '' );
+						}
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr - 1 ), $expected );
+						$this->phpcsFile->fixer->endChangeset();
+					} else {
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr - 1 ), $expected );
+					}
+				}
+			}
+		}
+
+	} // End process_token().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WhiteSpace/CastStructureSpacingSniff.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WhiteSpace;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Ensure cast statements don't contain whitespace, but *are* surrounded by whitespace, based upon Squiz code.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#space-usage
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.3.0
+ * @since   0.11.0 This sniff now has the ability to fix the issues it flags.
+ * @since   0.11.0 The error level for all errors thrown by this sniff has been raised from warning to error.
+ * @since   0.12.0 This class now extends WordPress_Sniff.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class CastStructureSpacingSniff extends Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return Tokens::$castTokens;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+
+		if ( T_WHITESPACE !== $this->tokens[ ( $stackPtr - 1 ) ]['code'] ) {
+			$error = 'No space before opening casting parenthesis is prohibited';
+			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
+			if ( true === $fix ) {
+				$this->phpcsFile->fixer->addContentBefore( $stackPtr, ' ' );
+			}
+		}
+
+		if ( T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code'] ) {
+			$error = 'No space after closing casting parenthesis is prohibited';
+			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterCloseParenthesis' );
+			if ( true === $fix ) {
+				$this->phpcsFile->fixer->addContent( $stackPtr, ' ' );
+			}
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
@@ -1,0 +1,555 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WhiteSpace;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Enforces spacing around logical operators and assignments, based upon Squiz code.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.1.0
+ * @since   2013-06-11 This sniff no longer supports JS.
+ * @since   0.3.0      This sniff now has the ability to fix most errors it flags.
+ * @since   0.7.0      This class now extends WordPress_Sniff.
+ * @since   0.13.0     Class name changed: this class is now namespaced.
+ *
+ * Last synced with base class 2017-01-15 at commit b024ad84656c37ef5733c6998ebc1e60957b2277.
+ * Note: This class has diverged quite far from the original. All the same, checking occasionally
+ * to see if there are upstream fixes made from which this sniff can benefit, is warranted.
+ * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/ControlStructureSpacingSniff.php
+ */
+class ControlStructureSpacingSniff extends Sniff {
+
+	/**
+	 * Check for blank lines on start/end of control structures.
+	 *
+	 * @var boolean
+	 */
+	public $blank_line_check = false;
+
+	/**
+	 * Check for blank lines after control structures.
+	 *
+	 * @var boolean
+	 */
+	public $blank_line_after_check = true;
+
+	/**
+	 * Require for space before T_COLON when using the alternative syntax for control structures.
+	 *
+	 * @var string one of 'required', 'forbidden', 'optional'
+	 */
+	public $space_before_colon = 'required';
+
+	/**
+	 * How many spaces should be between a T_CLOSURE and T_OPEN_PARENTHESIS.
+	 *
+	 * `function[*]() {...}`
+	 *
+	 * @since 0.7.0
+	 *
+	 * @var int
+	 */
+	public $spaces_before_closure_open_paren = -1;
+
+	/**
+	 * Tokens for which to ignore extra space on the inside of parenthesis.
+	 *
+	 * For functions, this is already checked by the Squiz.Functions.FunctionDeclarationArgumentSpacing sniff.
+	 * For do / else / try, there are no parenthesis, so skip it.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var array
+	 */
+	private $ignore_extra_space_after_open_paren = array(
+		T_FUNCTION => true,
+		T_CLOSURE  => true,
+		T_DO       => true,
+		T_ELSE     => true,
+		T_TRY      => true,
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_IF,
+			T_WHILE,
+			T_FOREACH,
+			T_FOR,
+			T_SWITCH,
+			T_DO,
+			T_ELSE,
+			T_ELSEIF,
+			T_FUNCTION,
+			T_CLOSURE,
+			T_USE,
+			T_TRY,
+			T_CATCH,
+		);
+
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public function process_token( $stackPtr ) {
+		$this->spaces_before_closure_open_paren = (int) $this->spaces_before_closure_open_paren;
+
+		if ( isset( $this->tokens[ ( $stackPtr + 1 ) ] ) && T_WHITESPACE !== $this->tokens[ ( $stackPtr + 1 ) ]['code']
+			&& ! ( T_ELSE === $this->tokens[ $stackPtr ]['code'] && T_COLON === $this->tokens[ ( $stackPtr + 1 ) ]['code'] )
+			&& ! ( T_CLOSURE === $this->tokens[ $stackPtr ]['code']
+				&& 0 >= $this->spaces_before_closure_open_paren )
+		) {
+			$error = 'Space after opening control structure is required';
+			$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterStructureOpen' );
+
+			if ( true === $fix ) {
+				$this->phpcsFile->fixer->addContent( $stackPtr, ' ' );
+			}
+		}
+
+		if ( ! isset( $this->tokens[ $stackPtr ]['scope_closer'] ) ) {
+
+			if ( T_USE === $this->tokens[ $stackPtr ]['code'] && 'closure' === $this->get_use_type( $stackPtr ) ) {
+				$scopeOpener = $this->phpcsFile->findNext( T_OPEN_CURLY_BRACKET, ( $stackPtr + 1 ) );
+				$scopeCloser = $this->tokens[ $scopeOpener ]['scope_closer'];
+			} elseif ( T_WHILE !== $this->tokens[ $stackPtr ]['code'] ) {
+				return;
+			}
+		} else {
+			$scopeOpener = $this->tokens[ $stackPtr ]['scope_opener'];
+			$scopeCloser = $this->tokens[ $stackPtr ]['scope_closer'];
+		}
+
+		// Alternative syntax.
+		if ( isset( $scopeOpener ) && T_COLON === $this->tokens[ $scopeOpener ]['code'] ) {
+
+			if ( 'required' === $this->space_before_colon ) {
+
+				if ( T_WHITESPACE !== $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
+					$error = 'Space between opening control structure and T_COLON is required';
+					$fix   = $this->phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceBetweenStructureColon' );
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
+					}
+				}
+			} elseif ( 'forbidden' === $this->space_before_colon ) {
+
+				if ( T_WHITESPACE === $this->tokens[ ( $scopeOpener - 1 ) ]['code'] ) {
+					$error = 'Extra space between opening control structure and T_COLON found';
+					$fix   = $this->phpcsFile->addFixableError( $error, ( $scopeOpener - 1 ), 'SpaceBetweenStructureColon' );
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->replaceToken( ( $scopeOpener - 1 ), '' );
+					}
+				}
+			}
+		}
+
+		$parenthesisOpener = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+		// If this is a function declaration.
+		if ( T_FUNCTION === $this->tokens[ $stackPtr ]['code'] ) {
+
+			if ( T_STRING === $this->tokens[ $parenthesisOpener ]['code'] ) {
+
+				$function_name_ptr = $parenthesisOpener;
+
+			} elseif ( T_BITWISE_AND === $this->tokens[ $parenthesisOpener ]['code'] ) {
+
+				// This function returns by reference (function &function_name() {}).
+				$parenthesisOpener = $this->phpcsFile->findNext(
+					Tokens::$emptyTokens,
+					( $parenthesisOpener + 1 ),
+					null,
+					true
+				);
+				$function_name_ptr = $parenthesisOpener;
+			}
+
+			if ( isset( $function_name_ptr ) ) {
+				$parenthesisOpener = $this->phpcsFile->findNext(
+					Tokens::$emptyTokens,
+					( $parenthesisOpener + 1 ),
+					null,
+					true
+				);
+
+				// Checking this: function my_function[*](...) {}.
+				if ( ( $function_name_ptr + 1 ) !== $parenthesisOpener ) {
+
+					$error = 'Space between function name and opening parenthesis is prohibited.';
+					$fix   = $this->phpcsFile->addFixableError(
+						$error,
+						$stackPtr,
+						'SpaceBeforeFunctionOpenParenthesis',
+						$this->tokens[ ( $function_name_ptr + 1 ) ]['content']
+					);
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->replaceToken( ( $function_name_ptr + 1 ), '' );
+					}
+				}
+			}
+		} elseif ( T_CLOSURE === $this->tokens[ $stackPtr ]['code'] ) {
+
+			// Check if there is a use () statement.
+			if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
+
+				$usePtr = $this->phpcsFile->findNext(
+					Tokens::$emptyTokens,
+					( $this->tokens[ $parenthesisOpener ]['parenthesis_closer'] + 1 ),
+					null,
+					true,
+					null,
+					true
+				);
+
+				// If it is, we set that as the "scope opener".
+				if ( T_USE === $this->tokens[ $usePtr ]['code'] ) {
+					$scopeOpener = $usePtr;
+				}
+			}
+		}
+
+		if (
+			T_COLON !== $this->tokens[ $parenthesisOpener ]['code']
+			&& T_FUNCTION !== $this->tokens[ $stackPtr ]['code']
+		) {
+
+			if (
+				T_CLOSURE === $this->tokens[ $stackPtr ]['code']
+				&& 0 === $this->spaces_before_closure_open_paren
+			) {
+
+				if ( ( $stackPtr + 1 ) !== $parenthesisOpener ) {
+					// Checking this: function[*](...) {}.
+					$error = 'Space before closure opening parenthesis is prohibited';
+					$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'SpaceBeforeClosureOpenParenthesis' );
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), '' );
+					}
+				}
+			} elseif (
+				(
+					T_CLOSURE !== $this->tokens[ $stackPtr ]['code']
+					|| 1 === $this->spaces_before_closure_open_paren
+				)
+				&& ( $stackPtr + 1 ) === $parenthesisOpener
+			) {
+
+				// Checking this: if[*](...) {}.
+				$error = 'No space before opening parenthesis is prohibited';
+				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceBeforeOpenParenthesis' );
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->addContent( $stackPtr, ' ' );
+				}
+			}
+		}
+
+		if (
+			T_WHITESPACE === $this->tokens[ ( $stackPtr + 1 ) ]['code']
+			&& ' ' !== $this->tokens[ ( $stackPtr + 1 ) ]['content']
+		) {
+			// Checking this: if [*](...) {}.
+			$error = 'Expected exactly one space before opening parenthesis; "%s" found.';
+			$fix   = $this->phpcsFile->addFixableError(
+				$error,
+				$stackPtr,
+				'ExtraSpaceBeforeOpenParenthesis',
+				$this->tokens[ ( $stackPtr + 1 ) ]['content']
+			);
+
+			if ( true === $fix ) {
+				$this->phpcsFile->fixer->replaceToken( ( $stackPtr + 1 ), ' ' );
+			}
+		}
+
+		if ( T_CLOSE_PARENTHESIS !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
+			if ( T_WHITESPACE !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
+				// Checking this: $value = my_function([*]...).
+				$error = 'No space after opening parenthesis is prohibited';
+				$fix   = $this->phpcsFile->addFixableError( $error, $stackPtr, 'NoSpaceAfterOpenParenthesis' );
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->addContent( $parenthesisOpener, ' ' );
+				}
+			} elseif ( ( ' ' !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['content']
+				&& "\n" !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['content']
+				&& "\r\n" !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['content'] )
+				&& ! isset( $this->ignore_extra_space_after_open_paren[ $this->tokens[ $stackPtr ]['code'] ] )
+			) {
+				// Checking this: if ([*]...) {}.
+				$error = 'Expected exactly one space after opening parenthesis; "%s" found.';
+				$fix   = $this->phpcsFile->addFixableError(
+					$error,
+					$stackPtr,
+					'ExtraSpaceAfterOpenParenthesis',
+					$this->tokens[ ( $parenthesisOpener + 1 ) ]['content']
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->replaceToken( ( $parenthesisOpener + 1 ), ' ' );
+				}
+			}
+		}
+
+		if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_closer'] ) ) {
+
+			$parenthesisCloser = $this->tokens[ $parenthesisOpener ]['parenthesis_closer'];
+
+			if ( T_CLOSE_PARENTHESIS !== $this->tokens[ ( $parenthesisOpener + 1 ) ]['code'] ) {
+
+				// Checking this: if (...[*]) {}.
+				if ( T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser - 1 ) ]['code'] ) {
+					$error = 'No space before closing parenthesis is prohibited';
+					$fix   = $this->phpcsFile->addFixableError( $error, $parenthesisCloser, 'NoSpaceBeforeCloseParenthesis' );
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->addContentBefore( $parenthesisCloser, ' ' );
+					}
+				} elseif ( ' ' !== $this->tokens[ ( $parenthesisCloser - 1 ) ]['content'] ) {
+					$prevNonEmpty = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $parenthesisCloser - 1 ), null, true );
+					if ( $this->tokens[ ( $parenthesisCloser ) ]['line'] === $this->tokens[ ( $prevNonEmpty + 1 ) ]['line'] ) {
+						$error = 'Expected exactly one space before closing parenthesis; "%s" found.';
+						$fix   = $this->phpcsFile->addFixableError(
+							$error,
+							$stackPtr,
+							'ExtraSpaceBeforeCloseParenthesis',
+							$this->tokens[ ( $parenthesisCloser - 1 ) ]['content']
+						);
+
+						if ( true === $fix ) {
+							$this->phpcsFile->fixer->replaceToken( ( $parenthesisCloser - 1 ), ' ' );
+						}
+					}
+				}
+
+				if (
+					T_WHITESPACE !== $this->tokens[ ( $parenthesisCloser + 1 ) ]['code']
+					&& ( isset( $scopeOpener ) && T_COLON !== $this->tokens[ $scopeOpener ]['code'] )
+				) {
+					$error = 'Space between opening control structure and closing parenthesis is required';
+					$fix   = $this->phpcsFile->addFixableError( $error, $scopeOpener, 'NoSpaceAfterCloseParenthesis' );
+
+					if ( true === $fix ) {
+						$this->phpcsFile->fixer->addContentBefore( $scopeOpener, ' ' );
+					}
+				}
+			}
+
+			if ( isset( $this->tokens[ $parenthesisOpener ]['parenthesis_owner'] )
+				&& ( isset( $scopeOpener )
+				&& $this->tokens[ $parenthesisCloser ]['line'] !== $this->tokens[ $scopeOpener ]['line'] )
+			) {
+				$error = 'Opening brace should be on the same line as the declaration';
+				$fix   = $this->phpcsFile->addFixableError( $error, $parenthesisOpener, 'OpenBraceNotSameLine' );
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->beginChangeset();
+
+					for ( $i = ( $parenthesisCloser + 1 ); $i < $scopeOpener; $i++ ) {
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+					}
+
+					$this->phpcsFile->fixer->addContent( $parenthesisCloser, ' ' );
+					$this->phpcsFile->fixer->endChangeset();
+				}
+				return;
+
+			} elseif (
+				T_WHITESPACE === $this->tokens[ ( $parenthesisCloser + 1 ) ]['code']
+				&& ' ' !== $this->tokens[ ( $parenthesisCloser + 1 ) ]['content']
+			) {
+
+				// Checking this: if (...) [*]{}.
+				$error = 'Expected exactly one space between closing parenthesis and opening control structure; "%s" found.';
+				$fix   = $this->phpcsFile->addFixableError(
+					$error,
+					$stackPtr,
+					'ExtraSpaceAfterCloseParenthesis',
+					$this->tokens[ ( $parenthesisCloser + 1 ) ]['content']
+				);
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->replaceToken( ( $parenthesisCloser + 1 ), ' ' );
+				}
+			}
+		}
+
+		if ( false !== $this->blank_line_check && isset( $scopeOpener ) ) {
+			$firstContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $scopeOpener + 1 ), null, true );
+
+			// We ignore spacing for some structures that tend to have their own rules.
+			$ignore = array(
+				T_FUNCTION             => true,
+				T_CLOSURE              => true,
+				T_CLASS                => true,
+				T_ANON_CLASS           => true,
+				T_INTERFACE            => true,
+				T_TRAIT                => true,
+				T_DOC_COMMENT_OPEN_TAG => true,
+				T_CLOSE_TAG            => true,
+				T_COMMENT              => true,
+			);
+
+			if ( ! isset( $ignore[ $this->tokens[ $firstContent ]['code'] ] )
+				&& $this->tokens[ $firstContent ]['line'] > ( $this->tokens[ $scopeOpener ]['line'] + 1 )
+			) {
+				$error = 'Blank line found at start of control structure';
+				$fix   = $this->phpcsFile->addFixableError( $error, $scopeOpener, 'BlankLineAfterStart' );
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->beginChangeset();
+
+					for ( $i = ( $scopeOpener + 1 ); $i < $firstContent; $i++ ) {
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+					}
+
+					$this->phpcsFile->fixer->addNewline( $scopeOpener );
+					$this->phpcsFile->fixer->endChangeset();
+				}
+			}
+
+			if ( $firstContent !== $scopeCloser ) {
+				$lastContent = $this->phpcsFile->findPrevious( T_WHITESPACE, ( $scopeCloser - 1 ), null, true );
+
+				$lastNonEmptyContent = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $scopeCloser - 1 ), null, true );
+
+				$checkToken = $lastContent;
+				if ( isset( $this->tokens[ $lastNonEmptyContent ]['scope_condition'] ) ) {
+					$checkToken = $this->tokens[ $lastNonEmptyContent ]['scope_condition'];
+				}
+
+				if ( ! isset( $ignore[ $this->tokens[ $checkToken ]['code'] ] )
+					&& $this->tokens[ $lastContent ]['line'] <= ( $this->tokens[ $scopeCloser ]['line'] - 2 )
+				) {
+					for ( $i = ( $scopeCloser - 1 ); $i > $lastContent; $i-- ) {
+						if ( $this->tokens[ $i ]['line'] < $this->tokens[ $scopeCloser ]['line']
+							&& T_OPEN_TAG !== $this->tokens[ $firstContent ]['code']
+						) {
+							// TODO: Reporting error at empty line won't highlight it in IDE.
+							$error = 'Blank line found at end of control structure';
+							$fix   = $this->phpcsFile->addFixableError( $error, $i, 'BlankLineBeforeEnd' );
+
+							if ( true === $fix ) {
+								$this->phpcsFile->fixer->beginChangeset();
+
+								for ( $j = ( $lastContent + 1 ); $j < $scopeCloser; $j++ ) {
+									$this->phpcsFile->fixer->replaceToken( $j, '' );
+								}
+
+								$this->phpcsFile->fixer->addNewlineBefore( $scopeCloser );
+								$this->phpcsFile->fixer->endChangeset();
+							}
+							break;
+						}
+					}
+				}
+			}
+			unset( $ignore );
+		}
+
+		if ( ! isset( $scopeCloser ) || true !== $this->blank_line_after_check ) {
+			return;
+		}
+
+		// {@internal This is just for the blank line check. Only whitespace should be considered,
+		// not "other" empty tokens.}}
+		$trailingContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $scopeCloser + 1 ), null, true );
+		if ( false === $trailingContent ) {
+			return;
+		}
+
+		if ( T_COMMENT === $this->tokens[ $trailingContent ]['code'] ) {
+			// Special exception for code where the comment about
+			// an ELSE or ELSEIF is written between the control structures.
+			$nextCode = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $scopeCloser + 1 ), null, true );
+
+			if ( T_ELSE === $this->tokens[ $nextCode ]['code'] || T_ELSEIF === $this->tokens[ $nextCode ]['code'] ) {
+				$trailingContent = $nextCode;
+			}
+
+			// Move past end comments.
+			if ( $this->tokens[ $trailingContent ]['line'] === $this->tokens[ $scopeCloser ]['line'] ) {
+				if ( preg_match( '`^//[ ]?end`i', $this->tokens[ $trailingContent ]['content'], $matches ) > 0 ) {
+					$scopeCloser     = $trailingContent;
+					$trailingContent = $this->phpcsFile->findNext( T_WHITESPACE, ( $trailingContent + 1 ), null, true );
+				}
+			}
+		}
+
+		if ( T_ELSE === $this->tokens[ $trailingContent ]['code'] && T_IF === $this->tokens[ $stackPtr ]['code'] ) {
+			// IF with ELSE.
+			return;
+		}
+
+		if ( T_WHILE === $this->tokens[ $trailingContent ]['code'] && T_DO === $this->tokens[ $stackPtr ]['code'] ) {
+			// DO with WHILE.
+			return;
+		}
+
+		if ( T_CLOSE_TAG === $this->tokens[ $trailingContent ]['code'] ) {
+			// At the end of the script or embedded code.
+			return;
+		}
+
+		if ( isset( $this->tokens[ $trailingContent ]['scope_condition'] )
+			&& T_CLOSE_CURLY_BRACKET === $this->tokens[ $trailingContent ]['code']
+		) {
+			// Another control structure's closing brace.
+			$owner = $this->tokens[ $trailingContent ]['scope_condition'];
+			if ( in_array( $this->tokens[ $owner ]['code'], array( T_FUNCTION, T_CLOSURE, T_CLASS, T_ANON_CLASS, T_INTERFACE, T_TRAIT ), true ) ) {
+				// The next content is the closing brace of a function, class, interface or trait
+				// so normal function/class rules apply and we can ignore it.
+				return;
+			}
+
+			if ( ( $this->tokens[ $scopeCloser ]['line'] + 1 ) !== $this->tokens[ $trailingContent ]['line'] ) {
+				// TODO: Won't cover following case: "} echo 'OK';".
+				$error = 'Blank line found after control structure';
+				$fix   = $this->phpcsFile->addFixableError( $error, $scopeCloser, 'BlankLineAfterEnd' );
+
+				if ( true === $fix ) {
+					$this->phpcsFile->fixer->beginChangeset();
+
+					$i = ( $scopeCloser + 1 );
+					while ( $this->tokens[ $i ]['line'] !== $this->tokens[ $trailingContent ]['line'] ) {
+						$this->phpcsFile->fixer->replaceToken( $i, '' );
+						$i++;
+					}
+
+					// TODO: Instead a separate error should be triggered when content comes right after closing brace.
+					if ( T_COMMENT !== $this->tokens[ $scopeCloser ]['code'] ) {
+						$this->phpcsFile->fixer->addNewlineBefore( $trailingContent );
+					}
+					$this->phpcsFile->fixer->endChangeset();
+				}
+			}
+		}
+
+	} // End process_token().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WhiteSpace/DisallowInlineTabsSniff.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WhiteSpace;
+
+use WordPress\Sniff;
+use WordPress\PHPCSHelper;
+
+/**
+ * Enforces using spaces for mid-line alignment.
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.12.0
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class DisallowInlineTabsSniff extends Sniff {
+
+	/**
+	 * The --tab-width CLI value that is being used.
+	 *
+	 * @var int
+	 */
+	private $tab_width;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_OPEN_TAG,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int Integer stack pointer to skip the rest of the file.
+	 */
+	public function process_token( $stackPtr ) {
+		if ( ! isset( $this->tab_width ) ) {
+			$this->tab_width = PHPCSHelper::get_tab_width( $this->phpcsFile );
+		}
+
+		$check_tokens = array(
+			T_WHITESPACE             => true,
+			T_DOC_COMMENT_WHITESPACE => true,
+			T_DOC_COMMENT_STRING     => true,
+		);
+
+		for ( $i = ( $stackPtr + 1 ); $i < $this->phpcsFile->numTokens; $i++ ) {
+			// Skip all non-whitespace tokens and skip whitespace at the start of a new line.
+			if ( ! isset( $check_tokens[ $this->tokens[ $i ]['code'] ] ) || 1 === $this->tokens[ $i ]['column'] ) {
+				continue;
+			}
+
+			// If tabs are being converted to spaces by the tokenizer, the
+			// original content should be checked instead of the converted content.
+			if ( isset( $this->tokens[ $i ]['orig_content'] ) ) {
+				$content = $this->tokens[ $i ]['orig_content'];
+			} else {
+				$content = $this->tokens[ $i ]['content'];
+			}
+
+			if ( '' === $content || strpos( $content, "\t" ) === false ) {
+				continue;
+			}
+
+			$fix = $this->phpcsFile->addFixableError(
+				'Spaces must be used for mid-line alignment; tabs are not allowed',
+				$i,
+				'NonIndentTabsUsed'
+			);
+			if ( true === $fix ) {
+				if ( isset( $this->tokens[ $i ]['orig_content'] ) ) {
+					// Use the replacement that PHPCS has already done.
+					$this->phpcsFile->fixer->replaceToken( $i, $this->tokens[ $i ]['content'] );
+				} else {
+					// Replace tabs with spaces, using an indent of $tab_width.
+					// Other sniffs can then correct the indent if they need to.
+					$spaces     = str_repeat( ' ', $this->tab_width );
+					$newContent = str_replace( "\t", $spaces, $this->tokens[ $i ]['content'] );
+					$this->phpcsFile->fixer->replaceToken( $i, $newContent );
+				}
+			}
+		}
+
+		// Ignore the rest of the file.
+		return ( $this->phpcsFile->numTokens + 1 );
+
+	} // End process().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WhiteSpace/OperatorSpacingSniff.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WhiteSpace;
+
+use Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff as PHPCS_Squiz_OperatorSpacingSniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Verify operator spacing, uses the Squiz sniff, but additionally also sniffs for the `!` (boolean not) operator.
+ *
+ * "Always put spaces after commas, and on both sides of logical, comparison, string and assignment operators."
+ *
+ * @link    https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#space-usage
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.1.0
+ * @since   0.3.0  This sniff now has the ability to fix the issues it flags.
+ * @since   0.12.0 This sniff used to be a copy of a very old and outdated version of the
+ *                 upstream sniff.
+ *                 Now, the sniff defers completely to the upstream sniff, adding just the
+ *                 T_BOOLEAN_NOT and the logical operators (`&&` and the like) - via the
+ *                 registration method and changing the value of the customizable
+ *                 $ignoreNewlines property.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ *
+ * Last synced with base class June 2017 at commit 41127aa4764536f38f504fb3f7b8831f05919c89.
+ * @link    https://github.com/squizlabs/PHP_CodeSniffer/blob/master/CodeSniffer/Standards/Squiz/Sniffs/WhiteSpace/OperatorSpacingSniff.php
+ */
+class OperatorSpacingSniff extends PHPCS_Squiz_OperatorSpacingSniff {
+
+	/**
+	 * Allow newlines instead of spaces.
+	 *
+	 * N.B.: The upstream sniff defaults to `false`.
+	 *
+	 * @var boolean
+	 */
+	public $ignoreNewlines = true;
+
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		$tokens                  = parent::register();
+		$tokens[ T_BOOLEAN_NOT ] = T_BOOLEAN_NOT;
+		$logical_operators       = Tokens::$booleanOperators;
+
+		// Using array union to auto-dedup.
+		return $tokens + $logical_operators;
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WhiteSpace/PrecisionAlignmentSniff.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WhiteSpace;
+
+use WordPress\Sniff;
+use WordPress\PHPCSHelper;
+
+/**
+ * Warn on line indentation ending with spaces for precision alignment.
+ *
+ * WP demands tabs for indentation. In rare cases, spaces for precision alignment can be
+ * intentional and acceptable, but more often than not, this is a typo.
+ *
+ * The `Generic.WhiteSpace.DisallowSpaceIndent` sniff already checks for space indentation
+ * and auto-fixes to tabs.
+ *
+ * This sniff only checks for precision alignments which can not be corrected by the
+ * `Generic.WhiteSpace.DisallowSpaceIndent` sniff.
+ *
+ * As this may be intentional, this sniff explicitly does *NOT* contain a fixer.
+ *
+ * @link    https://make.wordpress.org/core/handbook/coding-standards/php/#indentation
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class PrecisionAlignmentSniff extends Sniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+		'JS',
+		'CSS',
+	);
+
+	/**
+	 * Allow for providing a list of tokens for which (preceding) precision alignment should be ignored.
+	 *
+	 * <rule ref="WordPress.WhiteSpace.PrecisionAlignment">
+	 *    <properties>
+	 *        <property name="ignoreAlignmentTokens" type="array"
+	 *             value="T_COMMENT,T_INLINE_HTML"/>
+	 *    </properties>
+	 * </rule>
+	 *
+	 * @var array
+	 */
+	public $ignoreAlignmentTokens = array();
+
+	/**
+	 * The --tab-width CLI value that is being used.
+	 *
+	 * @var int
+	 */
+	private $tab_width;
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return array(
+			T_OPEN_TAG,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int Integer stack pointer to skip the rest of the file.
+	 */
+	public function process_token( $stackPtr ) {
+		if ( ! isset( $this->tab_width ) ) {
+			$this->tab_width = PHPCSHelper::get_tab_width( $this->phpcsFile );
+		}
+
+		// Handle any custom ignore tokens received from a ruleset.
+		$this->ignoreAlignmentTokens = $this->merge_custom_array( $this->ignoreAlignmentTokens );
+
+		$check_tokens = array(
+			T_WHITESPACE             => true,
+			T_INLINE_HTML            => true,
+			T_DOC_COMMENT_WHITESPACE => true,
+			T_COMMENT                => true,
+		);
+
+		for ( $i = ( $stackPtr + 1 ); $i < $this->phpcsFile->numTokens; $i++ ) {
+			if ( ! isset( $this->tokens[ ( $i + 1 ) ] ) ) {
+				break;
+			}
+
+			if ( 1 !== $this->tokens[ $i ]['column'] ) {
+				continue;
+			} elseif ( isset( $check_tokens[ $this->tokens[ $i ]['code'] ] ) === false
+				|| T_WHITESPACE === $this->tokens[ ( $i + 1 ) ]['code']
+				|| $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar
+				|| isset( $this->ignoreAlignmentTokens[ $this->tokens[ $i ]['type'] ] )
+				|| isset( $this->ignoreAlignmentTokens[ $this->tokens[ ( $i + 1 ) ]['type'] ] )
+			) {
+				continue;
+			}
+
+			$spaces = 0;
+			switch ( $this->tokens[ $i ]['type'] ) {
+				case 'T_WHITESPACE':
+					$spaces = ( $this->tokens[ $i ]['length'] % $this->tab_width );
+					break;
+
+				case 'T_DOC_COMMENT_WHITESPACE':
+					$length = $this->tokens[ $i ]['length'];
+					$spaces = ( $length % $this->tab_width );
+
+					if ( ( T_DOC_COMMENT_STAR === $this->tokens[ ( $i + 1 ) ]['code']
+						|| T_DOC_COMMENT_CLOSE_TAG === $this->tokens[ ( $i + 1 ) ]['code'] )
+						&& 0 !== $spaces
+					) {
+						// One alignment space expected before the *.
+						--$spaces;
+					}
+					break;
+
+				case 'T_COMMENT':
+					/*
+					 * Indentation whitespace for subsequent lines of multi-line comments
+					 * are tokenized as part of the comment.
+					 */
+					$comment    = ltrim( $this->tokens[ $i ]['content'] );
+					$whitespace = str_replace( $comment, '', $this->tokens[ $i ]['content'] );
+					$length     = strlen( $whitespace );
+					$spaces     = ( $length % $this->tab_width );
+
+					if ( isset( $comment[0] ) && '*' === $comment[0] && 0 !== $spaces ) {
+						--$spaces;
+					}
+					break;
+
+				case 'T_INLINE_HTML':
+					if ( $this->tokens[ $i ]['content'] === $this->phpcsFile->eolChar ) {
+						$spaces = 0;
+					} else {
+						/*
+						 * Indentation whitespace for inline HTML is part of the T_INLINE_HTML token.
+						 */
+						$content    = ltrim( $this->tokens[ $i ]['content'] );
+						$whitespace = str_replace( $content, '', $this->tokens[ $i ]['content'] );
+						$spaces     = ( strlen( $whitespace ) % $this->tab_width );
+					}
+					break;
+			}
+
+			if ( $spaces > 0 && ! $this->has_whitelist_comment( 'precision alignment', $i ) ) {
+				$this->phpcsFile->addWarning(
+					'Found precision alignment of %s spaces.',
+					$i,
+					'Found',
+					array( $spaces )
+				);
+			}
+		}
+
+		// Ignore the rest of the file.
+		return ( $this->phpcsFile->numTokens + 1 );
+
+	} // End process().
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/WhiteSpace/SemicolonSpacingSniff.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\WhiteSpace;
+
+use Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff as PHPCS_Squiz_SemicolonSpacingSniff;
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Ensure there is no whitespace before a semicolon, while allowing for empty conditions in a `for`.
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   0.14.0
+ */
+class SemicolonSpacingSniff extends PHPCS_Squiz_SemicolonSpacingSniff {
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return void|int
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Don't examine semi-colons for empty conditions in `for()` control structures.
+		if ( isset( $tokens[ $stackPtr ]['nested_parenthesis'] ) ) {
+			$close_parenthesis = end( $tokens[ $stackPtr ]['nested_parenthesis'] );
+
+			if ( isset( $tokens[ $close_parenthesis ]['parenthesis_owner'] ) ) {
+				$owner = $tokens[ $close_parenthesis ]['parenthesis_owner'];
+
+				if ( T_FOR === $tokens[ $owner ]['code'] ) {
+					$previous = $phpcsFile->findPrevious(
+						Tokens::$emptyTokens,
+						( $stackPtr - 1 ),
+						$tokens[ $owner ]['parenthesis_opener'],
+						true
+					);
+
+					if ( false !== $previous
+						&& ( $previous === $tokens[ $owner ]['parenthesis_opener']
+							|| T_SEMICOLON === $tokens[ $previous ]['code'] )
+					) {
+						return;
+					}
+				}
+			}
+		}
+
+		return parent::process( $phpcsFile, $stackPtr );
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/Sniffs/XSS/EscapeOutputSniff.php
+++ b/ci/wpcs/WordPress/Sniffs/XSS/EscapeOutputSniff.php
@@ -1,0 +1,510 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace WordPress\Sniffs\XSS;
+
+use WordPress\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * Verifies that all outputted strings are escaped.
+ *
+ * @link    http://codex.wordpress.org/Data_Validation Data Validation on WordPress Codex
+ *
+ * @package WPCS\WordPressCodingStandards
+ *
+ * @since   2013-06-11
+ * @since   0.4.0  This class now extends WordPress_Sniff.
+ * @since   0.5.0  The various function list properties which used to be contained in this class
+ *                 have been moved to the WordPress_Sniff parent class.
+ * @since   0.12.0 This sniff will now also check for output escaping when using shorthand
+ *                 echo tags `<?=`.
+ * @since   0.13.0 Class name changed: this class is now namespaced.
+ */
+class EscapeOutputSniff extends Sniff {
+
+	/**
+	 * Custom list of functions which escape values for output.
+	 *
+	 * @since 0.5.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customEscapingFunctions = array();
+
+	/**
+	 * Custom list of functions whose return values are pre-escaped for output.
+	 *
+	 * @since 0.3.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customAutoEscapedFunctions = array();
+
+	/**
+	 * Custom list of functions which escape values for output.
+	 *
+	 * @since      0.3.0
+	 * @deprecated 0.5.0 Use $customEscapingFunctions instead.
+	 * @see        \WordPress\Sniffs\XSS\EscapeOutputSniff::$customEscapingFunctions
+	 *
+	 * @var string|string[]
+	 */
+	public $customSanitizingFunctions = array();
+
+	/**
+	 * Custom list of functions which print output incorporating the passed values.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @var string|string[]
+	 */
+	public $customPrintingFunctions = array();
+
+	/**
+	 * Printing functions that incorporate unsafe values.
+	 *
+	 * @since 0.4.0
+	 * @since 0.11.0 Changed from public static to protected non-static.
+	 *
+	 * @var array
+	 */
+	protected $unsafePrintingFunctions = array(
+		'_e'  => 'esc_html_e() or esc_attr_e()',
+		'_ex' => 'echo esc_html_x() or echo esc_attr_x()',
+	);
+
+	/**
+	 * Cache of previously added custom functions.
+	 *
+	 * Prevents having to do the same merges over and over again.
+	 *
+	 * @since 0.4.0
+	 * @since 0.11.0 - Changed from public static to protected non-static.
+	 *               - Changed the format from simple bool to array.
+	 *
+	 * @var array
+	 */
+	protected $addedCustomFunctions = array(
+		'escape'     => null,
+		'autoescape' => null,
+		'sanitize'   => null,
+		'print'      => null,
+	);
+
+	/**
+	 * List of names of the tokens representing PHP magic constants.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @var array
+	 */
+	private $magic_constant_tokens = array(
+		'T_CLASS_C'  => true, // __CLASS__
+		'T_DIR'      => true, // __DIR__
+		'T_FILE'     => true, // __FILE__
+		'T_FUNC_C'   => true, // __FUNCTION__
+		'T_LINE'     => true, // __LINE__
+		'T_METHOD_C' => true, // __METHOD__
+		'T_NS_C'     => true, // __NAMESPACE__
+		'T_TRAIT_C'  => true, // __TRAIT__
+	);
+
+	/**
+	 * List of names of the cast tokens which can be considered as a safe escaping method.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var array
+	 */
+	private $safe_cast_tokens = array(
+		'T_INT_CAST'    => true, // (int)
+		'T_DOUBLE_CAST' => true, // (float)
+		'T_BOOL_CAST'   => true, // (bool)
+		'T_UNSET_CAST'  => true, // (unset)
+	);
+
+	/**
+	 * List of tokens which can be considered as a safe when directly part of the output.
+	 *
+	 * @since 0.12.0
+	 *
+	 * @var array
+	 */
+	private $safe_components = array(
+		'T_CONSTANT_ENCAPSED_STRING' => true,
+		'T_LNUMBER'                  => true,
+		'T_MINUS'                    => true,
+		'T_PLUS'                     => true,
+		'T_MULTIPLY'                 => true,
+		'T_DIVIDE'                   => true,
+		'T_MODULUS'                  => true,
+		'T_TRUE'                     => true,
+		'T_FALSE'                    => true,
+		'T_NULL'                     => true,
+		'T_DNUMBER'                  => true,
+		'T_START_NOWDOC'             => true,
+		'T_NOWDOC'                   => true,
+		'T_END_NOWDOC'               => true,
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+
+		$tokens = array(
+			T_ECHO,
+			T_PRINT,
+			T_EXIT,
+			T_STRING,
+			T_OPEN_TAG_WITH_ECHO,
+		);
+
+		/*
+		 * Check whether short open echo tags are disabled and if so, register the
+		 * T_INLINE_HTML token which is how short open tags are being handled in that case.
+		 *
+		 * In PHP < 5.4, support for short open echo tags depended on whether the
+		 * `short_open_tag` ini directive was set to `true`.
+		 * For PHP >= 5.4, the `short_open_tag` no longer affects the short open
+		 * echo tags and these are now always enabled.
+		 */
+		if ( PHP_VERSION_ID < 50400 && false === (bool) ini_get( 'short_open_tag' ) ) {
+			$tokens[] = T_INLINE_HTML;
+		}
+		return $tokens;
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param int $stackPtr The position of the current token in the stack.
+	 *
+	 * @return int|void Integer stack pointer to skip forward or void to continue
+	 *                  normal file processing.
+	 */
+	public function process_token( $stackPtr ) {
+
+		$this->mergeFunctionLists();
+
+		$function = $this->tokens[ $stackPtr ]['content'];
+
+		// Find the opening parenthesis (if present; T_ECHO might not have it).
+		$open_paren = $this->phpcsFile->findNext( Tokens::$emptyTokens, ( $stackPtr + 1 ), null, true );
+
+		// If function, not T_ECHO nor T_PRINT.
+		if ( T_STRING === $this->tokens[ $stackPtr ]['code'] ) {
+			// Skip if it is a function but is not of the printing functions.
+			if ( ! isset( $this->printingFunctions[ $this->tokens[ $stackPtr ]['content'] ] ) ) {
+				return;
+			}
+
+			if ( isset( $this->tokens[ $open_paren ]['parenthesis_closer'] ) ) {
+				$end_of_statement = $this->tokens[ $open_paren ]['parenthesis_closer'];
+			}
+
+			// These functions only need to have the first argument escaped.
+			if ( in_array( $function, array( 'trigger_error', 'user_error' ), true ) ) {
+				$end_of_statement = $this->phpcsFile->findEndOfStatement( $open_paren + 1 );
+			}
+		} elseif ( T_INLINE_HTML === $this->tokens[ $stackPtr ]['code'] ) {
+			// Skip if no PHP short_open_tag is found in the string.
+			if ( false === strpos( $this->tokens[ $stackPtr ]['content'], '<?=' ) ) {
+				return;
+			}
+
+			// Report on what is very likely a PHP short open echo tag outputting a variable.
+			if ( preg_match( '`\<\?\=[\s]*(\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(?:(?:->\S+|\[[^\]]+\]))*)[\s]*;?[\s]*\?\>`', $this->tokens[ $stackPtr ]['content'], $matches ) > 0 ) {
+				$this->phpcsFile->addError(
+					"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '%s'.",
+					$stackPtr,
+					'OutputNotEscapedShortEcho',
+					array( $matches[1] )
+				);
+				return;
+			}
+
+			return;
+		}
+
+		// Checking for the ignore comment, ex: //xss ok.
+		if ( $this->has_whitelist_comment( 'xss', $stackPtr ) ) {
+			return;
+		}
+
+		if ( isset( $end_of_statement, $this->unsafePrintingFunctions[ $function ] ) ) {
+			$error = $this->phpcsFile->addError(
+				"All output should be run through an escaping function (like %s), found '%s'.",
+				$stackPtr,
+				'UnsafePrintingFunction',
+				array( $this->unsafePrintingFunctions[ $function ], $function )
+			);
+
+			// If the error was reported, don't bother checking the function's arguments.
+			if ( $error ) {
+				return $end_of_statement;
+			}
+		}
+
+		$ternary = false;
+
+		// This is already determined if this is a function and not T_ECHO.
+		if ( ! isset( $end_of_statement ) ) {
+
+			$end_of_statement = $this->phpcsFile->findNext( array( T_SEMICOLON, T_CLOSE_TAG ), $stackPtr );
+			$last_token       = $this->phpcsFile->findPrevious( Tokens::$emptyTokens, ( $end_of_statement - 1 ), null, true );
+
+			// Check for the ternary operator. We only need to do this here if this
+			// echo is lacking parenthesis. Otherwise it will be handled below.
+			if ( T_OPEN_PARENTHESIS !== $this->tokens[ $open_paren ]['code'] || T_CLOSE_PARENTHESIS !== $this->tokens[ $last_token ]['code'] ) {
+
+				$ternary = $this->phpcsFile->findNext( T_INLINE_THEN, $stackPtr, $end_of_statement );
+
+				// If there is a ternary skip over the part before the ?. However, if
+				// the ternary is within parentheses, it will be handled in the loop.
+				if ( false !== $ternary && empty( $this->tokens[ $ternary ]['nested_parenthesis'] ) ) {
+					$stackPtr = $ternary;
+				}
+			}
+		}
+
+		// Ignore the function itself.
+		$stackPtr++;
+
+		$in_cast = false;
+
+		// Looping through echo'd components.
+		$watch = true;
+		for ( $i = $stackPtr; $i < $end_of_statement; $i++ ) {
+
+			// Ignore whitespaces and comments.
+			if ( isset( Tokens::$emptyTokens[ $this->tokens[ $i ]['code'] ] ) ) {
+				continue;
+			}
+
+			// Ignore namespace separators.
+			if ( T_NS_SEPARATOR === $this->tokens[ $i ]['code'] ) {
+				continue;
+			}
+
+			if ( T_OPEN_PARENTHESIS === $this->tokens[ $i ]['code'] ) {
+
+				if ( ! isset( $this->tokens[ $i ]['parenthesis_closer'] ) ) {
+					// Live coding or parse error.
+					break;
+				}
+
+				if ( $in_cast ) {
+
+					// Skip to the end of a function call if it has been casted to a safe value.
+					$i       = $this->tokens[ $i ]['parenthesis_closer'];
+					$in_cast = false;
+
+				} else {
+
+					// Skip over the condition part of a ternary (i.e., to after the ?).
+					$ternary = $this->phpcsFile->findNext( T_INLINE_THEN, $i, $this->tokens[ $i ]['parenthesis_closer'] );
+
+					if ( false !== $ternary ) {
+
+						$next_paren = $this->phpcsFile->findNext( T_OPEN_PARENTHESIS, ( $i + 1 ), $this->tokens[ $i ]['parenthesis_closer'] );
+
+						// We only do it if the ternary isn't within a subset of parentheses.
+						if ( false === $next_paren || ( isset( $this->tokens[ $next_paren ]['parenthesis_closer'] ) && $ternary > $this->tokens[ $next_paren ]['parenthesis_closer'] ) ) {
+							$i = $ternary;
+						}
+					}
+				}
+
+				continue;
+			}
+
+			// Handle arrays for those functions that accept them.
+			if ( T_ARRAY === $this->tokens[ $i ]['code'] ) {
+				$i++; // Skip the opening parenthesis.
+				continue;
+			}
+
+			if ( in_array( $this->tokens[ $i ]['code'], array( T_DOUBLE_ARROW, T_CLOSE_PARENTHESIS ), true ) ) {
+				continue;
+			}
+
+			// Handle magic constants for debug functions.
+			if ( isset( $this->magic_constant_tokens[ $this->tokens[ $i ]['type'] ] ) ) {
+				continue;
+			}
+
+			// Wake up on concatenation characters, another part to check.
+			if ( T_STRING_CONCAT === $this->tokens[ $i ]['code'] ) {
+				$watch = true;
+				continue;
+			}
+
+			// Wake up after a ternary else (:).
+			if ( $ternary && T_INLINE_ELSE === $this->tokens[ $i ]['code'] ) {
+				$watch = true;
+				continue;
+			}
+
+			// Wake up for commas.
+			if ( T_COMMA === $this->tokens[ $i ]['code'] ) {
+				$in_cast = false;
+				$watch   = true;
+				continue;
+			}
+
+			if ( false === $watch ) {
+				continue;
+			}
+
+			// Allow T_CONSTANT_ENCAPSED_STRING eg: echo 'Some String';
+			// Also T_LNUMBER, e.g.: echo 45; exit -1; and booleans.
+			if ( isset( $this->safe_components[ $this->tokens[ $i ]['type'] ] ) ) {
+				continue;
+			}
+
+			$watch = false;
+
+			// Allow int/double/bool casted variables.
+			if ( isset( $this->safe_cast_tokens[ $this->tokens[ $i ]['type'] ] ) ) {
+				$in_cast = true;
+				continue;
+			}
+
+			// Now check that next token is a function call.
+			if ( T_STRING === $this->tokens[ $i ]['code'] ) {
+
+				$ptr                    = $i;
+				$functionName           = $this->tokens[ $i ]['content'];
+				$function_opener        = $this->phpcsFile->findNext( T_OPEN_PARENTHESIS, ( $i + 1 ), null, false, null, true );
+				$is_formatting_function = isset( $this->formattingFunctions[ $functionName ] );
+
+				if ( false !== $function_opener ) {
+
+					if ( 'array_map' === $functionName ) {
+
+						// Get the first parameter (name of function being used on the array).
+						$mapped_function = $this->phpcsFile->findNext(
+							Tokens::$emptyTokens,
+							( $function_opener + 1 ),
+							$this->tokens[ $function_opener ]['parenthesis_closer'],
+							true
+						);
+
+						// If we're able to resolve the function name, do so.
+						if ( $mapped_function && T_CONSTANT_ENCAPSED_STRING === $this->tokens[ $mapped_function ]['code'] ) {
+							$functionName = $this->strip_quotes( $this->tokens[ $mapped_function ]['content'] );
+							$ptr          = $mapped_function;
+						}
+					}
+
+					// Skip pointer to after the function.
+					// If this is a formatting function we just skip over the opening
+					// parenthesis. Otherwise we skip all the way to the closing.
+					if ( $is_formatting_function ) {
+						$i     = ( $function_opener + 1 );
+						$watch = true;
+					} else {
+						if ( isset( $this->tokens[ $function_opener ]['parenthesis_closer'] ) ) {
+							$i = $this->tokens[ $function_opener ]['parenthesis_closer'];
+						} else {
+							// Live coding or parse error.
+							break;
+						}
+					}
+				}
+
+				// If this is a safe function, we don't flag it.
+				if (
+					$is_formatting_function
+					|| isset( $this->autoEscapedFunctions[ $functionName ] )
+					|| isset( $this->escapingFunctions[ $functionName ] )
+				) {
+					continue;
+				}
+
+				$content = $functionName;
+
+			} else {
+				$content = $this->tokens[ $i ]['content'];
+				$ptr     = $i;
+			}
+
+			$this->phpcsFile->addError(
+				"All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '%s'.",
+				$ptr,
+				'OutputNotEscaped',
+				$content
+			);
+		}
+
+		return $end_of_statement;
+
+	} // End process_token().
+
+	/**
+	 * Merge custom functions provided via a custom ruleset with the defaults, if we haven't already.
+	 *
+	 * @since 0.11.0 Split out from the `process()` method.
+	 *
+	 * @return void
+	 */
+	protected function mergeFunctionLists() {
+		if ( $this->customEscapingFunctions !== $this->addedCustomFunctions['escape']
+			|| $this->customSanitizingFunctions !== $this->addedCustomFunctions['sanitize']
+		) {
+			$customEscapeFunctions = $this->merge_custom_array( $this->customEscapingFunctions, array(), false );
+
+			if ( ! empty( $this->customSanitizingFunctions ) ) {
+				$customEscapeFunctions = $this->merge_custom_array(
+					$this->customSanitizingFunctions,
+					$customEscapeFunctions,
+					false
+				);
+
+				$this->phpcsFile->addWarning(
+					'The customSanitizingFunctions property is deprecated in favor of customEscapingFunctions.',
+					0,
+					'DeprecatedCustomSanitizingFunctions'
+				);
+			}
+
+			$this->escapingFunctions = $this->merge_custom_array(
+				$customEscapeFunctions,
+				$this->escapingFunctions
+			);
+
+			$this->addedCustomFunctions['escape']   = $this->customEscapingFunctions;
+			$this->addedCustomFunctions['sanitize'] = $this->customSanitizingFunctions;
+		}
+
+		if ( $this->customAutoEscapedFunctions !== $this->addedCustomFunctions['autoescape'] ) {
+			$this->autoEscapedFunctions = $this->merge_custom_array(
+				$this->customAutoEscapedFunctions,
+				$this->autoEscapedFunctions
+			);
+
+			$this->addedCustomFunctions['autoescape'] = $this->customAutoEscapedFunctions;
+		}
+
+		if ( $this->customPrintingFunctions !== $this->addedCustomFunctions['print'] ) {
+
+			$this->printingFunctions = $this->merge_custom_array(
+				$this->customPrintingFunctions,
+				$this->printingFunctions
+			);
+
+			$this->addedCustomFunctions['print'] = $this->customPrintingFunctions;
+		}
+	}
+
+} // End class.

--- a/ci/wpcs/WordPress/ruleset.xml
+++ b/ci/wpcs/WordPress/ruleset.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress" namespace="WordPress">
+	<description>WordPress Coding Standards</description>
+
+	<autoload>./PHPCSAliases.php</autoload>
+
+	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress-Docs"/>
+	<rule ref="WordPress-Extra"/>
+	<rule ref="WordPress-VIP"/>
+
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+		<!-- From "VIP": The obfuscation group is excluded as there are plenty of legitimate uses for the base64 functions. -->
+		<properties>
+			<property name="exclude" value="obfuscation"/>
+		</properties>
+	</rule>
+</ruleset>

--- a/ci/wpcs/composer.json
+++ b/ci/wpcs/composer.json
@@ -1,0 +1,31 @@
+{
+	"name"       : "wp-coding-standards/wpcs",
+	"description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+	"keywords"   : ["phpcs", "standards", "WordPress"],
+	"license"    : "MIT",
+	"authors"    : [
+		{
+			"name"    : "Contributors",
+			"homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+
+		}
+	],
+	"require"    : {
+		"php" : ">=5.3",
+		"squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
+	},
+	"suggest" : {
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+	},
+	"minimum-stability" : "RC",
+	"support"    : {
+		"issues": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues",
+		"wiki"  : "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki",
+		"source": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards"
+	},
+	"type"       : "phpcodesniffer-standard",
+	"scripts"    : {
+		"post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths ../../..",
+		"post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
+	}
+}

--- a/ci/wpcs/phpcs.xml.dist.sample
+++ b/ci/wpcs/phpcs.xml.dist.sample
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<ruleset name="Example Project">
+	<description>A custom set of rules to check for a WPized WordPress project</description>
+
+	<!-- Exclude WP Core folders and files from being checked. -->
+	<exclude-pattern>/docroot/wp-admin/*</exclude-pattern>
+	<exclude-pattern>/docroot/wp-includes/*</exclude-pattern>
+	<exclude-pattern>/docroot/wp-*.php</exclude-pattern>
+	<exclude-pattern>/docroot/index.php</exclude-pattern>
+	<exclude-pattern>/docroot/xmlrpc.php</exclude-pattern>
+	<exclude-pattern>/docroot/wp-content/plugins/*</exclude-pattern>
+
+	<!-- Exclude the Composer Vendor directory. -->
+	<exclude-pattern>/vendor/*</exclude-pattern>
+
+	<!-- Exclude the Node Modules directory. -->
+	<exclude-pattern>/node_modules/*</exclude-pattern>
+
+	<!-- Exclude minified Javascript files. -->
+	<exclude-pattern>*.min.js</exclude-pattern>
+
+	<!-- Include the WordPress-Extra standard. -->
+	<rule ref="WordPress-Extra">
+		<!--
+		We may want a middle ground though. The best way to do this is add the
+		entire ruleset, then rule by rule, remove ones that don't suit a project.
+		We can do this by running `phpcs` with the '-s' flag, which allows us to
+		see the names of the sniffs reporting errors.
+		Once we know the sniff names, we can opt to exclude sniffs which don't
+		suit our project like so.
+
+		The below two examples just show how you can exclude rules.
+		They are not intended as advice about which sniffs to exclude.
+		-->
+
+		<!--
+		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
+		<exclude name="WordPress.XSS.EscapeOutput"/>
+		-->
+	</rule>
+
+	<!-- Let's also check that everything is properly documented. -->
+	<rule ref="WordPress-Docs"/>
+
+	<!-- Add in some extra rules from other standards. -->
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+	<rule ref="Generic.Commenting.Todo"/>
+
+	<!-- Check for PHP cross-version compatibility. -->
+	<!--
+	To enable this, the PHPCompatibility standard needs
+	to be installed.
+	See the readme for installation instructions:
+	https://github.com/wimg/PHPCompatibility
+	-->
+	<!--
+	<config name="testVersion" value="5.2-99.0"/>
+	<rule ref="PHPCompatibility"/>
+	-->
+
+	<!--
+	To get the optimal benefits of using WPCS, we should add a couple of
+	custom properties.
+	Adjust the values of these properties to fit our needs.
+
+	For information on additional custom properties available, check out
+	the wiki:
+	https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
+	-->
+	<config name="minimum_supported_wp_version" value="4.5"/>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="my-textdomain,library-textdomain"/>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="my_prefix"/>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/documentation/commands.php
+++ b/documentation/commands.php
@@ -580,6 +580,23 @@ $ fab environment:vagrant <strong>import_backup</strong>
 $ fab environment:vagrant <strong>import_backup:<span class="args">backup2017</span></strong>
                             </pre>
                        </div>
+                       <div class="col-lg-12 anchor" id="configure_circle_ci" name="configure_circle_ci">
+                            <h2>configure_circle_ci</h2>
+                            <p>
+                                Write continuous integration configuration by circleci.
+                            </p>
+                            <pre>
+$ fab <strong>configure_circle_ci</strong>
+                            </pre>
+
+                            <h4>Arguments</h4>
+                            <p>None</p>
+                            
+                            <h4>Examples</h4>
+                            <pre>
+$ fab <strong>configure_circle_ci</strong>
+                            </pre>
+                       </div>
                        <div class="col-lg-12 anchor" id="version" name="version">
                             <h2>version</h2>
                             <p>

--- a/documentation/menu.php
+++ b/documentation/menu.php
@@ -227,9 +227,16 @@
                     </a>
                 </li>
                 <li class="list-group-item">
+                    <a href="commands.php#configure_circle_ci">
+                        configure_circle_ci
+                    </a>
+                </li>
+                <li class="list-group-item">
                     <a href="commands.php#version">
                         version
                     </a>
+                </li>
+                <li class="list-group-item">
                 </li>
             </ul>
         </div>

--- a/fabfile.py
+++ b/fabfile.py
@@ -980,9 +980,20 @@ def verify_checksums():
             """.format(**env))
 
 @task
+def configure_circle_ci():
+    """
+    Write continuous integration configuration by circleci.
+    """
+    print "Creanting configuration..."
+    local("cp wordpress-workflow/ci/circle.yml circle.yml")
+    local("ln -s wordpress-workflow/ci/Dangerfile Dangerfile")
+    local("ln -s wordpress-workflow/ci/Gemfile Gemfile")
+
+
+@task
 def version():
     """
     Print Wordpress Workflow version.
     """
-    print blue("Wordpress Workflow version 0.3.6")
+    print blue("Wordpress Workflow version 0.3.7")
 


### PR DESCRIPTION
### Task related 
[Arreglar que al sincronizar los templates en el Vagrantfile no los coloca en el directorio completo en unas computadoras en mac oss](http://manoderecha.net/md/index.php/task/139668)

# Problem 
In mac osx not shared correctly the temples folder in vagrant.

# Solution 
Changed the way to specify the path to share the templates folder

# Test
Tests in local environment.