### PR TITLE
Update ubuntu/trusty32 box version to v20180222.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-
+# Version 0.4.1 (2018-02-27)
+    * Update ubuntu/trusty32 version to 20180222.1.0
 # Version 0.4.0 (2018-01-10)
     * Fix text valiator of pull-request in danger #55
     * Update to php 7.0

--- a/README.md
+++ b/README.md
@@ -210,10 +210,7 @@ project documentation.
 ## Migrate to wordpress workflow version 0.3.3 or later
 In file environment.json:
 
-+ Change vagrant user to ```ubuntu```.
 + Change vagrant group to ```www-data```.
-+ Change vagrant public_dir to ```/home/ubuntu/public_www/```.
-+ Change vagrant wordpress_dir to ```/home/ubuntu/wordpress-workflow/```.
 + Change vagrant dbuser to ```wordpress```.
 + Change vagrant dbpassword to ```password```.
 + Add new value : ```"dbprefix": "wp_"``` to all enviroments

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,11 +7,12 @@ Vagrant.configure("2") do |config|
   vagrant_config = (JSON.parse(File.read(environments_json_path)))['vagrant']
 
   config.vm.box = "ubuntu/xenial32"
-  config.vm.box_version = "20170803.0.0"
+  config.vm.box_url = "https://app.vagrantup.com/ubuntu/boxes/xenial32"
+  config.vm.box_version = "20180224.0.0"
 
   #provisioning
   config.vm.provision "shell", path: "wordpress-workflow/provision/preprovision.sh"
-  config.vm.provision "file", source:"wordpress-workflow/provision/templates/", destination: "/home/ubuntu/templates/"
+  config.vm.provision "file", source:"wordpress-workflow/provision/templates/", destination: "/home/vagrant/"
   config.vm.provision "shell", path: "wordpress-workflow/provision/provision.sh"
 
   # Private IP
@@ -22,11 +23,11 @@ Vagrant.configure("2") do |config|
   config.hostsupdater.aliases = ["wordpress-workflow.local", vagrant_config['url']]
 
   # Shared folders.
-  config.vm.synced_folder "src", "/home/ubuntu/wordpress-workflow",
-    owner: "ubuntu",
+  config.vm.synced_folder "src", "/home/vagrant/wordpress-workflow",
+    owner: "vagrant",
     group: "www-data",
     mount_options: ["dmode=775,fmode=764"]
-  config.vm.synced_folder "wordpress-workflow/documentation", "/home/ubuntu/workflow-documentation"
+  config.vm.synced_folder "wordpress-workflow/documentation", "/home/vagrant/workflow-documentation"
 
   # Provider
   config.vm.provider "virtualbox" do |v|

--- a/defaults/environments.json
+++ b/defaults/environments.json
@@ -1,11 +1,11 @@
 {
     "vagrant": {
         "url": "wordpress.local",
-        "user": "ubuntu",
+        "user": "vagrant",
         "group": "www-data",
         "hosts": ["127.0.0.1:2222"],
-        "public_dir": "/home/ubuntu/public_www/",
-        "wpworkflow_dir": "/home/ubuntu/wordpress-workflow/",
+        "public_dir": "/home/vagrant/public_www/",
+        "wpworkflow_dir": "/home/vagrant/wordpress-workflow/",
         "command_prefixes": [],
         "title": "wordpress workflow",
         "admin_user": "admin",

--- a/fabfile.py
+++ b/fabfile.py
@@ -995,5 +995,5 @@ def version():
     """
     Print Wordpress Workflow version.
     """
-    print blue("Wordpress Workflow version 0.4.0")
+    print blue("Wordpress Workflow version 0.4.1")
 

--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -12,9 +12,9 @@ PACKAGES="$PACKAGES nginx-full php7.0-fpm php7.0-cgi spawn-fcgi php-pear php7.0-
 PACKAGES="$PACKAGES php7.0-mbstring php7.0-curl php7.0-cli php7.0-gd php7.0-intl"
 PACKAGES="$PACKAGES php7.0-xsl php7.0-zip fcgiwrap phpmyadmin"
 
-APP_TOKEN="/home/ubuntu/workflow-documentation/scripts/app_token"
-PUBLIC_DIRECTORY="/home/ubuntu/public_www"
-PHPMYADMIN_DIRECTORY="/home/ubuntu/public_www/phpmyadmin"
+APP_TOKEN="/home/vagrant/workflow-documentation/scripts/app_token"
+PUBLIC_DIRECTORY="/home/vagrant/public_www"
+PHPMYADMIN_DIRECTORY="/home/vagrant/public_www/phpmyadmin"
 
 # Sets mysql pasword
 debconf-set-selections <<< 'mariadb-server mysql-server/root_password password rootpass'
@@ -40,8 +40,8 @@ if [ ! -d "$PUBLIC_DIRECTORY" ]; then
     mkdir $PUBLIC_DIRECTORY
 fi
 
-chown -R ubuntu $PUBLIC_DIRECTORY
-chgrp -R ubuntu $PUBLIC_DIRECTORY
+chown -R vagrant $PUBLIC_DIRECTORY
+chgrp -R vagrant $PUBLIC_DIRECTORY
 
 echo "Installing wp-cli"
 curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
@@ -55,8 +55,8 @@ mv composer.phar /usr/local/bin/composer
 
 # Installing squizlabs/php_codesniffer & WordPress-Coding-Standards
 composer create-project wp-coding-standards/wpcs:dev-master --no-dev
-ln -s /home/ubuntu/wpcs/vendor/bin/phpcs /usr/local/bin/phpcs
-ln -s /home/ubuntu/wpcs/vendor/bin/phpcbf /usr/local/bin/phpcbf
+ln -s /home/vagrant/wpcs/vendor/bin/phpcs /usr/local/bin/phpcs
+ln -s /home/vagrant/wpcs/vendor/bin/phpcbf /usr/local/bin/phpcbf
 
 # Generates unique token for application
 if [ ! -f "$APP_TOKEN" ]; then
@@ -72,16 +72,16 @@ fi
 # Activates site
 
 # Apache
-cp /home/ubuntu/templates/wordpress.apache /etc/apache2/sites-available/wordpress.conf
+cp /home/vagrant/templates/wordpress.apache /etc/apache2/sites-available/wordpress.conf
 a2enmod actions
 a2ensite wordpress
 service apache2 stop
 
 # Nginx
-cp /home/ubuntu/templates/www.conf /etc/php/7.0/fpm/pool.d/www.conf
-cp /home/ubuntu/templates/wordpress.nginx /etc/nginx/sites-available/wordpress
-cp /home/ubuntu/templates/nginx.conf /etc/nginx/nginx.conf
-cp /home/ubuntu/templates/nginx.conf /home/ubuntu/nginx.conf
+cp /home/vagrant/templates/www.conf /etc/php/7.0/fpm/pool.d/www.conf
+cp /home/vagrant/templates/wordpress.nginx /etc/nginx/sites-available/wordpress
+cp /home/vagrant/templates/nginx.conf /etc/nginx/nginx.conf
+cp /home/vagrant/templates/nginx.conf /home/vagrant/nginx.conf
 rm  /etc/nginx/sites-enabled/*
 ln -s /etc/nginx/sites-available/wordpress /etc/nginx/sites-enabled/
 service php7.0-fpm restart


### PR DESCRIPTION
# Related tasks 
+ [Actualizar la version del box ubuntu/trusty32  a la versión v20180222.1.0](http://manoderecha.net/md/index.php/task/143071)

# Main description 
Update version of ubuntu/trusty32 box to v20180222.1.0

# Solution description 
- Set new version in Vagrant file.
- Change user ubuntu of box to vagrant (new user of new version box)